### PR TITLE
Finally fixed: added explicit cancellation checks, need to verify by independent testers

### DIFF
--- a/DynamicIsland/DynamicIslandApp.swift
+++ b/DynamicIsland/DynamicIslandApp.swift
@@ -398,6 +398,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             self?.debouncedUpdateWindowSize()
         }.store(in: &cancellables)
 
+        MemoryUsageMonitor.shared.startMonitoring()
+
         ReminderLiveActivityManager.shared.$activeWindowReminders
             .receive(on: RunLoop.main)
             .sink { [weak self] _ in

--- a/DynamicIsland/managers/LockScreenReminderWidgetManager.swift
+++ b/DynamicIsland/managers/LockScreenReminderWidgetManager.swift
@@ -1,8 +1,6 @@
 import Foundation
 import Combine
 import Defaults
-import SwiftUI
-import AppKit
 
 @MainActor
 final class LockScreenReminderWidgetManager: ObservableObject {
@@ -13,56 +11,48 @@ final class LockScreenReminderWidgetManager: ObservableObject {
     private let reminderManager = ReminderLiveActivityManager.shared
     private var cancellables = Set<AnyCancellable>()
 
-    private let timeFormatter: DateFormatter = {
-        let formatter = DateFormatter()
-        formatter.dateStyle = .none
-        formatter.timeStyle = .short
-        return formatter
-    }()
-
     private init() {
-        observeReminderUpdates()
         observeDefaults()
+        observeLockState()
+        observeReminderSnapshots()
     }
 
-    func showReminderWidget() {
+    private func observeLockState() {
+        LockScreenManager.shared.$isLocked
+            .removeDuplicates()
+            .receive(on: RunLoop.main)
+            .sink { [weak self] locked in
+                self?.handleLockStateChange(isLocked: locked)
+            }
+            .store(in: &cancellables)
+    }
+
+    private func observeReminderSnapshots() {
+        reminderManager.$lockScreenSnapshot
+            .receive(on: RunLoop.main)
+            .sink { [weak self] snapshot in
+                self?.handleSnapshotUpdate(snapshot)
+            }
+            .store(in: &cancellables)
+    }
+
+    private func handleLockStateChange(isLocked: Bool) {
+        Logger.log("LockScreenReminderWidgetManager: handleLockStateChange(isLocked: \(isLocked))", category: .lifecycle)
         guard Defaults[.enableLockScreenReminderWidget] else {
             LockScreenReminderWidgetPanelManager.shared.hide()
             return
         }
 
-        if let snapshot {
-            LockScreenReminderWidgetPanelManager.shared.show(with: snapshot)
-        } else {
-            recomputeSnapshot(now: reminderManager.currentDate)
-            if let snapshot {
-                LockScreenReminderWidgetPanelManager.shared.show(with: snapshot)
+        if isLocked {
+            if let latest = reminderManager.lockScreenSnapshot ?? snapshot {
+                snapshot = latest
+                LockScreenReminderWidgetPanelManager.shared.show(with: latest)
             } else {
                 LockScreenReminderWidgetPanelManager.shared.hide()
             }
+        } else {
+            LockScreenReminderWidgetPanelManager.shared.hide()
         }
-    }
-
-    func hideReminderWidget() {
-        LockScreenReminderWidgetPanelManager.shared.hide()
-    }
-
-    private func observeReminderUpdates() {
-        reminderManager.$activeReminder
-            .receive(on: RunLoop.main)
-            .sink { [weak self] _ in
-                guard let self else { return }
-                self.recomputeSnapshot(now: self.reminderManager.currentDate)
-            }
-            .store(in: &cancellables)
-
-        reminderManager.$currentDate
-            .receive(on: RunLoop.main)
-            .sink { [weak self] now in
-                guard let self else { return }
-                self.recomputeSnapshot(now: now)
-            }
-            .store(in: &cancellables)
     }
 
     private func observeDefaults() {
@@ -70,8 +60,9 @@ final class LockScreenReminderWidgetManager: ObservableObject {
             .sink { [weak self] change in
                 guard let self else { return }
                 if change.newValue {
-                    self.recomputeSnapshot(now: self.reminderManager.currentDate)
-                    self.showReminderWidgetIfPossible()
+                    if LockScreenManager.shared.currentLockStatus {
+                        self.handleSnapshotUpdate(self.reminderManager.lockScreenSnapshot)
+                    }
                 } else {
                     self.snapshot = nil
                     LockScreenReminderWidgetPanelManager.shared.hide()
@@ -82,128 +73,29 @@ final class LockScreenReminderWidgetManager: ObservableObject {
         Defaults.publisher(.lockScreenReminderChipStyle, options: [])
             .sink { [weak self] _ in
                 guard let self else { return }
-                self.recomputeSnapshot(now: self.reminderManager.currentDate)
+                self.handleSnapshotUpdate(self.reminderManager.lockScreenSnapshot)
             }
             .store(in: &cancellables)
     }
 
-    private func showReminderWidgetIfPossible() {
-        guard LockScreenManager.shared.currentLockStatus else { return }
-        guard Defaults[.enableLockScreenReminderWidget] else { return }
-        if let snapshot {
-            LockScreenReminderWidgetPanelManager.shared.show(with: snapshot)
-        } else {
-            LockScreenReminderWidgetPanelManager.shared.hide()
-        }
-    }
-
-    private func recomputeSnapshot(now: Date) {
+    private func handleSnapshotUpdate(_ newSnapshot: LockScreenReminderWidgetSnapshot?) {
         guard Defaults[.enableLockScreenReminderWidget] else {
             snapshot = nil
             LockScreenReminderWidgetPanelManager.shared.hide()
             return
         }
 
-        guard let entry = reminderManager.activeReminder else {
-            snapshot = nil
-            LockScreenReminderWidgetPanelManager.shared.hide()
-            return
-        }
+        snapshot = newSnapshot
 
-        let snapshot = makeSnapshot(from: entry, now: now)
-        if self.snapshot != snapshot {
-            self.snapshot = snapshot
-        }
-        deliver(snapshot)
-    }
-
-    private func deliver(_ snapshot: LockScreenReminderWidgetSnapshot) {
         guard LockScreenManager.shared.currentLockStatus else { return }
-        if LockScreenReminderWidgetPanelManager.shared.isVisible {
-            LockScreenReminderWidgetPanelManager.shared.update(with: snapshot)
+
+        if let newSnapshot {
+            Logger.log("LockScreenReminderWidgetManager: Updating snapshot on lock screen", category: .ui)
+            LockScreenReminderWidgetPanelManager.shared.show(with: newSnapshot)
         } else {
-            LockScreenReminderWidgetPanelManager.shared.show(with: snapshot)
+            LockScreenReminderWidgetPanelManager.shared.hide()
         }
     }
 
-    private func makeSnapshot(from entry: ReminderLiveActivityManager.ReminderEntry, now: Date) -> LockScreenReminderWidgetSnapshot {
-        let title = entry.event.title.isEmpty ? "Upcoming Reminder" : entry.event.title
-        let timeText = timeFormatter.string(from: entry.event.start)
-        let isCritical = criticalWindowContains(entry: entry, now: now)
-        let relative = relativeDescription(for: entry, now: now)
-        let accent = accentColor(for: entry, isCritical: isCritical)
-        let iconName = isCritical ? ReminderLiveActivityManager.criticalIconName : ReminderLiveActivityManager.standardIconName
-
-        return LockScreenReminderWidgetSnapshot(
-            title: title,
-            eventTimeText: timeText,
-            relativeDescription: relative,
-            accent: accent,
-            chipStyle: Defaults[.lockScreenReminderChipStyle],
-            isCritical: isCritical,
-            iconName: iconName
-        )
-    }
-
-    private func accentColor(for entry: ReminderLiveActivityManager.ReminderEntry, isCritical: Bool) -> LockScreenReminderWidgetSnapshot.RGBAColor {
-        if isCritical {
-            return LockScreenReminderWidgetSnapshot.RGBAColor(nsColor: .systemRed)
-        }
-
-        let boosted = Color(nsColor: entry.event.calendar.color).ensureMinimumBrightness(factor: 0.7)
-        return LockScreenReminderWidgetSnapshot.RGBAColor(nsColor: NSColor(boosted))
-    }
-
-    private func relativeDescription(for entry: ReminderLiveActivityManager.ReminderEntry, now: Date) -> String? {
-        let remaining = entry.event.start.timeIntervalSince(now)
-        if remaining <= 0 {
-            return "now"
-        }
-
-        let minutes = Int(ceil(remaining / 60))
-        if minutes <= 0 {
-            return "now"
-        }
-        if minutes == 1 {
-            return "in 1 min"
-        }
-        return "in \(minutes) min"
-    }
-
-    private func criticalWindowContains(entry: ReminderLiveActivityManager.ReminderEntry, now: Date) -> Bool {
-        let window = TimeInterval(Defaults[.reminderSneakPeekDuration])
-        guard window > 0 else { return false }
-        let remaining = entry.event.start.timeIntervalSince(now)
-        return remaining > 0 && remaining <= window
-    }
-}
-
-struct LockScreenReminderWidgetSnapshot: Equatable {
-    struct RGBAColor: Equatable {
-        let red: Double
-        let green: Double
-        let blue: Double
-        let alpha: Double
-
-        init(nsColor: NSColor) {
-            let color = nsColor.usingColorSpace(.sRGB) ?? nsColor
-            self.red = Double(color.redComponent)
-            self.green = Double(color.greenComponent)
-            self.blue = Double(color.blueComponent)
-            self.alpha = Double(color.alphaComponent)
-        }
-
-        var color: Color {
-            Color(red: red, green: green, blue: blue, opacity: alpha)
-        }
-    }
-
-    let title: String
-    let eventTimeText: String
-    let relativeDescription: String?
-    let accent: RGBAColor
-    let chipStyle: LockScreenReminderChipStyle
-    let isCritical: Bool
-    let iconName: String
 }
 

--- a/DynamicIsland/managers/MemoryUsageMonitor.swift
+++ b/DynamicIsland/managers/MemoryUsageMonitor.swift
@@ -1,0 +1,110 @@
+import AppKit
+import Foundation
+import Darwin
+
+@MainActor
+final class MemoryUsageMonitor {
+    static let shared = MemoryUsageMonitor()
+
+    private let thresholdBytes: UInt64 = 300 * 1_024 * 1_024
+    private let pollInterval: TimeInterval = 8 // Clamp within 5-10 seconds to limit battery impact
+    private let restartCooldown: TimeInterval = 300
+    private let logSampleInterval: TimeInterval = 300
+    private var monitorTask: Task<Void, Never>?
+    private var lastRestartAttempt: Date = .distantPast
+    private var lastLogSample: Date = .distantPast
+
+    func startMonitoring() {
+        guard monitorTask == nil else { return }
+        monitorTask = Task { [weak self] in
+            guard let self else { return }
+            while !Task.isCancelled {
+                await self.evaluateMemoryFootprint()
+                do {
+                    try await Task.sleep(for: .seconds(self.pollInterval))
+                } catch {
+                    break
+                }
+            }
+        }
+    }
+
+    func stopMonitoring() {
+        monitorTask?.cancel()
+        monitorTask = nil
+    }
+
+    private func evaluateMemoryFootprint() async {
+        guard let usage = currentResidentSize() else { return }
+        if usage >= thresholdBytes {
+            restartIfNeeded(currentUsage: usage)
+        } else if Date().timeIntervalSince(lastLogSample) >= logSampleInterval {
+            lastLogSample = Date()
+            Logger.log("[MemoryMonitor] Resident usage: \(formatMegabytes(usage)) MB", category: .memory)
+        }
+    }
+
+    private func restartIfNeeded(currentUsage: UInt64) {
+        let now = Date()
+        guard now.timeIntervalSince(lastRestartAttempt) >= restartCooldown else {
+            Logger.log("[MemoryMonitor] Usage \(formatMegabytes(currentUsage)) MB exceeds threshold but cooldown active", category: .warning)
+            return
+        }
+        lastRestartAttempt = now
+        Logger.log("[MemoryMonitor] Usage \(formatMegabytes(currentUsage)) MB >= \(formatMegabytes(thresholdBytes)) MB. Prompting for restart.", category: .warning)
+        presentRestartAlert(currentUsage: currentUsage)
+    }
+
+    private func presentRestartAlert(currentUsage: UInt64) {
+        let alert = NSAlert()
+        alert.alertStyle = .warning
+        alert.messageText = "DynamicIsland memory usage is high"
+        alert.informativeText = "The app is currently using \(formatMegabytes(currentUsage)) MB, which exceeds the safe limit of \(formatMegabytes(thresholdBytes)) MB. Restart now to free memory?"
+        alert.addButton(withTitle: "Restart Now")
+        alert.addButton(withTitle: "Later")
+
+        let response = alert.runModal()
+        if response == .alertFirstButtonReturn {
+            relaunchApplication()
+        } else {
+            Logger.log("[MemoryMonitor] Restart postponed by user", category: .warning)
+        }
+    }
+
+    private func relaunchApplication() {
+        let workspace = NSWorkspace.shared
+        let configuration = NSWorkspace.OpenConfiguration()
+        configuration.createsNewApplicationInstance = true
+
+        let appURL = workspace.urlForApplication(withBundleIdentifier: Bundle.main.bundleIdentifier ?? "") ?? Bundle.main.bundleURL
+
+        workspace.openApplication(at: appURL, configuration: configuration) { _, error in
+            if let error {
+                Logger.log("[MemoryMonitor] Failed to launch replacement app: \(error.localizedDescription)", category: .error)
+            }
+            Task { @MainActor in
+                NSApplication.shared.terminate(nil)
+            }
+        }
+    }
+
+    private func currentResidentSize() -> UInt64? {
+        var info = mach_task_basic_info()
+        var count = mach_msg_type_number_t(MemoryLayout<mach_task_basic_info>.size) / 4
+        let result = withUnsafeMutablePointer(to: &info) {
+            $0.withMemoryRebound(to: integer_t.self, capacity: Int(count)) {
+                task_info(mach_task_self_, task_flavor_t(MACH_TASK_BASIC_INFO), $0, &count)
+            }
+        }
+        guard result == KERN_SUCCESS else {
+            Logger.log("[MemoryMonitor] task_info failed with code \(result)", category: .error)
+            return nil
+        }
+        return UInt64(info.resident_size)
+    }
+
+    private func formatMegabytes(_ bytes: UInt64) -> String {
+        let mb = Double(bytes) / 1_048_576.0
+        return String(format: "%.1f", mb)
+    }
+}

--- a/DynamicIsland/models/LockScreenReminderWidgetSnapshot.swift
+++ b/DynamicIsland/models/LockScreenReminderWidgetSnapshot.swift
@@ -1,0 +1,31 @@
+import SwiftUI
+import AppKit
+
+struct LockScreenReminderWidgetSnapshot: Equatable {
+    struct RGBAColor: Equatable {
+        let red: Double
+        let green: Double
+        let blue: Double
+        let alpha: Double
+
+        init(nsColor: NSColor) {
+            let color = nsColor.usingColorSpace(.sRGB) ?? nsColor
+            self.red = Double(color.redComponent)
+            self.green = Double(color.greenComponent)
+            self.blue = Double(color.blueComponent)
+            self.alpha = Double(color.alphaComponent)
+        }
+
+        var color: Color {
+            Color(red: red, green: green, blue: blue, opacity: alpha)
+        }
+    }
+
+    let title: String
+    let eventTimeText: String
+    let relativeDescription: String?
+    let accent: RGBAColor
+    let chipStyle: LockScreenReminderChipStyle
+    let isCritical: Bool
+    let iconName: String
+}


### PR DESCRIPTION
Task scheduling conflicts caused an infinite loop to run after the lock screen is unlocked when reminders/events were scheduled on the day making it difficult for the stuff to work as the memory leaked to ~500MB in 10 minutes

I added guards and explicit task cancellation checks
Added a memory monitor that polls every 8 seconds to verify if the memory ever goes more than 300MB then the app restarts to partially resolve it