### PR TITLE
Atoll: Fix Pickers showing text with minimized dropdowns

### DIFF
--- a/DynamicIsland/components/Settings/SettingsView.swift
+++ b/DynamicIsland/components/Settings/SettingsView.swift
@@ -6485,7 +6485,7 @@ struct ClipboardSettings: View {
                             }
                         }
                         .pickerStyle(.menu)
-                        .frame(width: 100)
+                        .frame(minWidth: 100)
                     }
                     .settingsHighlight(id: highlightID("Display Mode"))
                     
@@ -6499,7 +6499,7 @@ struct ClipboardSettings: View {
                             Text("10 items").tag(10)
                         }
                         .pickerStyle(.menu)
-                        .frame(width: 100)
+                        .frame(minWidth: 100)
                     }
                     .settingsHighlight(id: highlightID("History Size"))
                     
@@ -6696,10 +6696,10 @@ struct ScreenAssistantSettings: View {
                             }
                         }
                         .pickerStyle(.menu)
-                        .frame(width: 100)
+                        .frame(minWidth: 100)
                     }
                     .settingsHighlight(id: highlightID("Display Mode"))
-                    
+
                     HStack {
                         Text("Attached Files")
                         Spacer()
@@ -6823,10 +6823,10 @@ struct ColorPickerSettings: View {
                             }
                         }
                         .pickerStyle(.menu)
-                        .frame(width: 100)
+                        .frame(minWidth: 100)
                     }
                     .settingsHighlight(id: highlightID("Display Mode"))
-                    
+
                     HStack {
                         Text("History Size")
                         Spacer()
@@ -6837,7 +6837,7 @@ struct ColorPickerSettings: View {
                             Text("20 colors").tag(20)
                         }
                         .pickerStyle(.menu)
-                        .frame(width: 100)
+                        .frame(minWidth: 100)
                     }
                     .settingsHighlight(id: highlightID("History Size"))
                     

--- a/DynamicIsland/components/Settings/SettingsView.swift
+++ b/DynamicIsland/components/Settings/SettingsView.swift
@@ -6479,7 +6479,7 @@ struct ClipboardSettings: View {
                     HStack {
                         Text("Display Mode")
                         Spacer()
-                        Picker("Display Mode", selection: $clipboardDisplayMode) {
+                        Picker("", selection: $clipboardDisplayMode) {
                             ForEach(ClipboardDisplayMode.allCases, id: \.self) { mode in
                                 Text(mode.displayName).tag(mode)
                             }
@@ -6492,7 +6492,7 @@ struct ClipboardSettings: View {
                     HStack {
                         Text("History Size")
                         Spacer()
-                        Picker("History Size", selection: $clipboardHistorySize) {
+                        Picker("", selection: $clipboardHistorySize) {
                             Text("3 items").tag(3)
                             Text("5 items").tag(5)
                             Text("7 items").tag(7)
@@ -6690,7 +6690,7 @@ struct ScreenAssistantSettings: View {
                     HStack {
                         Text("Display Mode")
                         Spacer()
-                        Picker("Display Mode", selection: $screenAssistantDisplayMode) {
+                        Picker("", selection: $screenAssistantDisplayMode) {
                             ForEach(ScreenAssistantDisplayMode.allCases, id: \.self) { mode in
                                 Text(mode.displayName).tag(mode)
                             }
@@ -6817,7 +6817,7 @@ struct ColorPickerSettings: View {
                     HStack {
                         Text("Display Mode")
                         Spacer()
-                        Picker("Display Mode", selection: $colorPickerDisplayMode) {
+                        Picker("", selection: $colorPickerDisplayMode) {
                             ForEach(ColorPickerDisplayMode.allCases, id: \.self) { mode in
                                 Text(mode.displayName).tag(mode)
                             }
@@ -6830,7 +6830,7 @@ struct ColorPickerSettings: View {
                     HStack {
                         Text("History Size")
                         Spacer()
-                        Picker("History Size", selection: $colorHistorySize) {
+                        Picker("", selection: $colorHistorySize) {
                             Text("5 colors").tag(5)
                             Text("10 colors").tag(10)
                             Text("15 colors").tag(15)


### PR DESCRIPTION
Before: 
<img width="439" height="100" alt="image" src="https://github.com/user-attachments/assets/78ab24d9-fd9e-433d-a5bf-58d99596483f" />

After: 
<img width="448" height="81" alt="image" src="https://github.com/user-attachments/assets/fdf1a618-7b9c-4aeb-8f33-8edbbf8e619a" />
