### PR TITLE
Atoll: Center notch after leaving minimalist mode and enlarge idle animation

### DIFF
--- a/DynamicIsland/ContentView.swift
+++ b/DynamicIsland/ContentView.swift
@@ -546,7 +546,7 @@ struct ContentView: View {
             maxHeight: dynamicNotchSize.height + currentShadowPadding + (isDynamicIslandMode ? dynamicIslandTopOffset : 0),
             alignment: .top
         )
-        .frame(maxHeight: .infinity, alignment: .top)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
         .environmentObject(privacyManager)
         .background(dragDetector)
         .environmentObject(vm)
@@ -970,15 +970,17 @@ struct ContentView: View {
 
     @ViewBuilder
     func DynamicIslandFaceAnimation() -> some View {
+        let sideSize = max(0, vm.effectiveClosedNotchHeight - 12)
         HStack {
             HStack {
                 Rectangle()
                     .fill(.clear)
-                    .frame(width: max(0, vm.effectiveClosedNotchHeight - 12), height: max(0, vm.effectiveClosedNotchHeight - 12))
+                    .frame(width: sideSize, height: sideSize)
                 Rectangle()
                     .fill(.black)
                     .frame(width: vm.closedNotchSize.width - 20)
                 IdleAnimationView()
+                    .frame(width: sideSize, height: sideSize)
             }
         }.frame(height: vm.effectiveClosedNotchHeight + (isHovering ? 8 : 0), alignment: .center)
     }

--- a/DynamicIsland/components/IdleAnimationView.swift
+++ b/DynamicIsland/components/IdleAnimationView.swift
@@ -65,7 +65,6 @@ private struct AnimationContentView: View {
             .rotationEffect(.degrees(config.rotation))
             .opacity(config.opacity)
             .padding(.bottom, config.paddingBottom)
-            .frame(width: config.expandWithAnimation ? nil : 30, height: 20)
             .clipped()
             
         case .lottieURL(let url):
@@ -83,7 +82,6 @@ private struct AnimationContentView: View {
             .rotationEffect(.degrees(config.rotation))
             .opacity(config.opacity)
             .padding(.bottom, config.paddingBottom)
-            .frame(width: config.expandWithAnimation ? nil : 30, height: 20)
             .clipped()
         }
     }


### PR DESCRIPTION
- Also remove fixed viewports for inactive animations