### PR TITLE
fix(localization): correct Russian translation "Пауза" → "Яркость"

### DIFF
--- a/DynamicIsland/Localizable.xcstrings
+++ b/DynamicIsland/Localizable.xcstrings
@@ -8983,7 +8983,7 @@
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Пауза"
+            "value" : "Яркость"
           }
         },
         "tr" : {


### PR DESCRIPTION
The string responsible for brightness title was wrongly translated as "Пауза" (Pause). This change fixes it