### PR TITLE
Fix focus modes always showing Do Not Disturb on non-English macOS

### DIFF
--- a/DynamicIsland/managers/DoNotDisturbManager.swift
+++ b/DynamicIsland/managers/DoNotDisturbManager.swift
@@ -190,11 +190,23 @@ final class DoNotDisturbManager: ObservableObject {
             // Compute display name
             let finalName: String
             if resolvedMode == .custom, !FullDiskAccessAuthorization.hasPermission() {
-                finalName = "Focus"
+                // Use the provided name if it looks like a real display name (not an
+                // icon slug like "graduationcap.fill"). Slugs always contain a dot.
+                if let tn = trimmedName, !tn.isEmpty, !tn.contains(".") {
+                    finalName = tn
+                } else {
+                    finalName = "Focus"
+                }
             } else if resolvedMode == .custom, FullDiskAccessAuthorization.hasPermission() {
                 // With FDA, prefer the real name from ModeConfigurations.json (fixes slug names like graduationcap.fill).
                 let lookedUp = FocusMetadataReader.shared.getDisplayName(for: trimmedName ?? "", identifier: finalIdentifier)
-                finalName = lookedUp.isEmpty ? "Focus" : lookedUp
+                if !lookedUp.isEmpty {
+                    finalName = lookedUp
+                } else if let tn = trimmedName, !tn.isEmpty, !tn.contains(".") {
+                    finalName = tn
+                } else {
+                    finalName = "Focus"
+                }
             } else if let name = trimmedName, !name.isEmpty {
                 let lower = name.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
                 switch lower {
@@ -851,6 +863,14 @@ extension FocusModeType {
 
         if let identifier, !identifier.isEmpty {
             return FocusModeType(identifier: identifier)
+        }
+
+        // If a name was provided but didn't match any known English mode names, the
+        // system is likely reporting a localized (non-English) name such as "Travail"
+        // for Work on a French macOS. Treat it as a custom/unidentified focus mode
+        // instead of incorrectly falling back to Do Not Disturb.
+        if let name, !name.isEmpty {
+            return .custom
         }
 
         return .doNotDisturb


### PR DESCRIPTION
When macOS reports a focus mode with a localized name (e.g. "Travail" for Work in French) but without a specific bundle identifier, resolve() failed to match the foreign name against its English-only lookup table and fell back to returning .doNotDisturb. This caused the wrong identifier ("com.apple.donotdisturb.mode") to be stored, making every focus mode render as Do Not Disturb regardless of which mode was actually active.

Fix by treating an unrecognized name with no identifier as .custom instead of .doNotDisturb, and preserving the provided display name when it is not an icon slug (slugs contain a dot, display names do not).