### PR TITLE
Fix brightness HUD reverting to native macOS OSD on Tahoe

### DIFF
--- a/DynamicIsland/managers/MediaKeyInterceptor.swift
+++ b/DynamicIsland/managers/MediaKeyInterceptor.swift
@@ -176,6 +176,15 @@ final class MediaKeyInterceptor {
     }
 
     private func handleEvent(cgEvent: CGEvent, type: CGEventType) -> Unmanaged<CGEvent>? {
+        if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput {
+            if let tap = eventTap {
+                CGEvent.tapEnable(tap: tap, enable: true)
+                NSLog("⚠️ Media key event tap was disabled by the system (reason: %@); re-enabled",
+                      type == .tapDisabledByTimeout ? "timeout" : "user input")
+            }
+            return Unmanaged.passUnretained(cgEvent)
+        }
+
         guard let systemDefinedType = systemDefinedEventType,
               type == systemDefinedType,
               let nsEvent = NSEvent(cgEvent: cgEvent),

--- a/DynamicIsland/managers/SystemChangesObserver.swift
+++ b/DynamicIsland/managers/SystemChangesObserver.swift
@@ -184,6 +184,9 @@ final class SystemChangesObserver: MediaKeyInterceptorDelegate {
         isRepeat: Bool,
         modifiers: NSEvent.ModifierFlags
     ) {
+        let isBacklight = modifiers.contains(.command) && keyboardBacklightEnabled
+        guard isBacklight || brightnessEnabled else { return }
+
         // Elastic Limit Detection (Vertical HUD)
         if Defaults[.enableVerticalHUD] {
             let brightness = brightnessController.currentBrightness
@@ -193,12 +196,12 @@ final class SystemChangesObserver: MediaKeyInterceptorDelegate {
                 Task { @MainActor in VerticalHUDWindowManager.shared.triggerBump(direction: -1) }
             }
         }
-        
+
         let baseStep = brightnessStep(for: step)
         let delta = direction == .up ? baseStep : -baseStep
-        if modifiers.contains(.command) && keyboardBacklightEnabled {
+        if isBacklight {
             keyboardBacklightController.adjust(by: delta)
-        } else if brightnessEnabled {
+        } else {
             brightnessController.adjust(by: delta)
         }
     }

--- a/DynamicIsland/managers/SystemMediaControllers.swift
+++ b/DynamicIsland/managers/SystemMediaControllers.swift
@@ -476,6 +476,7 @@ final class SystemBrightnessController {
     private let maximumBrightnessAnimationDuration: TimeInterval = 0.3
     private let brightnessAnimationDurationScale: TimeInterval = 1.6
     private var lastEmittedBrightness: Float = 0.5
+    private var pendingAdjustTarget: Float?
     private let coreBrightnessClient = CoreBrightnessDisplayClient.shared
     private var pollTimer: Timer?
     private let pollInterval: TimeInterval = 0.15
@@ -526,12 +527,14 @@ final class SystemBrightnessController {
     }
 
     func adjust(by delta: Float) {
-        // Refresh baseline to avoid jumping if auto-brightness changed the level.
-        syncWithSystemBrightnessIfNeeded()
         markUserInitiated()
-        let target = max(0, min(1, lastEmittedBrightness + delta))
+        let base = pendingAdjustTarget ?? lastEmittedBrightness
+        let target = max(0, min(1, base + delta))
+        pendingAdjustTarget = target
         DispatchQueue.main.async { [weak self] in
-            self?.beginBrightnessAnimation(to: target)
+            guard let self else { return }
+            self.pendingAdjustTarget = nil
+            self.beginBrightnessAnimation(to: target)
         }
     }
 


### PR DESCRIPTION
## Summary

- **Re-enable CGEvent tap after system timeout** — macOS auto-disables event taps when the callback takes too long; the brightness path's synchronous `CoreBrightness`/`DisplayServices` calls were slow enough on Tahoe to trigger this. The tap was never re-enabled, permanently killing all media key interception.
- **Remove slow sync from tap callback path** — moved `syncWithSystemBrightnessIfNeeded()` out of `adjust(by:)` to prevent future timeouts. Added `pendingAdjustTarget` to fix rapid key presses collapsing into a single brightness step.
- **Add missing early guard to brightness handler** — matches the volume handler's `guard volumeEnabled` pattern.

Fixes #478

## Test plan

- [ ] On macOS Tahoe, press brightness keys — Dynamic Island HUD should appear instead of native OSD
- [ ] Hold brightness key for rapid repeat — brightness should change by one step per repeat (not collapse)
- [ ] Disable brightness HUD in settings — brightness keys should pass through to native macOS handling
- [ ] Cmd+brightness (keyboard backlight) should still work when backlight control is enabled
- [ ] Volume HUD should continue working as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)