### PR TITLE
Terminal Text Padding + Side Scroll Bar Rework + Minor Close Issue Fix

### DIFF
--- a/DynamicIsland/ContentView.swift
+++ b/DynamicIsland/ContentView.swift
@@ -621,6 +621,11 @@ struct ContentView: View {
                 }
                 if newState == .closed {
                     removeStickyTerminalClickMonitor()
+                } else {
+                    // Install the outside-click monitor for terminal opens that don't
+                    // change `currentView` (e.g. shortcut re-opening with the terminal
+                    // tab already selected, where the cursor never enters the notch).
+                    syncStickyTerminalOutsideClickMonitor()
                 }
                 #if os(macOS)
                 if newState == .open {
@@ -1973,10 +1978,19 @@ struct ContentView: View {
         }
     }
 
-    /// Installs the global outside-click monitor when Terminal + sticky mode are active (e.g. keyboard-opened terminal).
-    /// Removes the monitor when the tab, sticky setting, or open state no longer applies.
+    /// Installs the global outside-click monitor whenever the Terminal tab is open
+    /// (e.g. keyboard-opened terminal), regardless of sticky mode.
+    ///
+    /// Sticky mode only controls whether the terminal closes when the cursor leaves
+    /// the notch (see `shouldPreventAutoClose`).  An outside click should always close
+    /// the terminal — this covers the case where the terminal is opened via the
+    /// shortcut and the cursor never enters the notch, so there's no hover-out event
+    /// to trigger the normal auto-close.
+    ///
+    /// While the cursor is hovering inside the notch, hover handling owns close
+    /// behavior, so the monitor is not installed; it is re-synced on hover-out.
     private func syncStickyTerminalOutsideClickMonitor() {
-        guard vm.notchState == .open, terminalStickyMode, coordinator.currentView == .terminal else {
+        guard vm.notchState == .open, coordinator.currentView == .terminal, !isHovering else {
             removeStickyTerminalClickMonitor()
             return
         }

--- a/DynamicIsland/managers/TerminalManager.swift
+++ b/DynamicIsland/managers/TerminalManager.swift
@@ -41,15 +41,45 @@ import Defaults
 /// (recorded during the transient removal) but the child kept its previous
 /// large frame.
 final class StableTerminalContainerView: NSView {
+    /// Identifies the gutter tint view so `resizeSubviews` can keep its ring mask in sync.
+    static let gutterTintIdentifier = NSUserInterfaceItemIdentifier("terminalGutterTint")
+
     override func resizeSubviews(withOldSize oldSize: NSSize) {
         let size = bounds.size
         // Block degenerate sizes — the terminal would collapse to 2×1
         guard size.width >= 10, size.height >= 10 else { return }
         // Manually fill children to bounds — bypasses autoresizing math
         // that breaks when oldSize was zero but child kept its old frame.
+        // The terminal view gets an inner inset so glyphs don't hug the edge;
+        // the frosted blur underlay and the gutter tint stay full-bleed to the
+        // rounded clip (the tint is masked to the ring so it only fills the inset
+        // gutter, matching the terminal background without doubling over it).
+        let inset = notchTerminalInnerTextInset
+        let terminalFrame = bounds.insetBy(dx: inset, dy: inset)
         for child in subviews {
-            child.frame = bounds
+            if child is LocalProcessTerminalView {
+                child.frame = terminalFrame
+            } else {
+                child.frame = bounds
+                if child.identifier == Self.gutterTintIdentifier {
+                    Self.applyGutterMask(to: child, bounds: bounds, hole: terminalFrame)
+                }
+            }
         }
+    }
+
+    /// Masks `view` to the gutter ring: the full bounds minus the inset `hole`
+    /// where the terminal sits, using the even-odd fill rule.
+    static func applyGutterMask(to view: NSView, bounds: CGRect, hole: CGRect) {
+        let localBounds = CGRect(origin: .zero, size: bounds.size)
+        let mask = (view.layer?.mask as? CAShapeLayer) ?? CAShapeLayer()
+        mask.fillRule = .evenOdd
+        let path = CGMutablePath()
+        path.addRect(localBounds)
+        path.addRect(CGRect(x: hole.minX, y: hole.minY, width: hole.width, height: hole.height))
+        mask.path = path
+        mask.frame = localBounds
+        view.layer?.mask = mask
     }
 
     override func viewDidMoveToWindow() {
@@ -111,6 +141,19 @@ class TerminalManager: ObservableObject {
         return v
     }()
 
+    /// Tinted ring that fills the inset gutter with the terminal's background color
+    /// so the inset text isn't surrounded by a bare-blur "ring".  Sits above the
+    /// blur and below `terminalView`; masked to the gutter so it never doubles the
+    /// translucent background over the terminal's own cells.
+    private lazy var terminalGutterTintView: NSView = {
+        let v = NSView()
+        v.identifier = StableTerminalContainerView.gutterTintIdentifier
+        v.wantsLayer = true
+        v.layer?.backgroundColor = NSColor.clear.cgColor
+        v.autoresizingMask = [.width, .height]
+        return v
+    }()
+
     private init() {}
 
     // MARK: - Lifecycle
@@ -148,14 +191,35 @@ class TerminalManager: ObservableObject {
         if terminalBackgroundEffectView.superview == nil {
             containerView.addSubview(terminalBackgroundEffectView)
         }
+        if terminalGutterTintView.superview == nil {
+            containerView.addSubview(
+                terminalGutterTintView,
+                positioned: .above,
+                relativeTo: terminalBackgroundEffectView
+            )
+        }
+        updateGutterTintColor()
         containerView.addSubview(view)
         terminalView = view
 
-        // If the container already has a valid size, snap the child to it.
+        // If the container already has a valid size, snap the children to it.
+        // Blur + gutter tint fill the full bounds; the terminal is inset so its
+        // glyphs don't hug the edge, and the gutter tint is masked to the ring.
         let containerSize = containerView.bounds.size
         if containerSize.width >= 10, containerSize.height >= 10 {
-            terminalBackgroundEffectView.frame = containerView.bounds
-            view.frame = containerView.bounds
+            let bounds = containerView.bounds
+            let terminalFrame = bounds.insetBy(
+                dx: notchTerminalInnerTextInset,
+                dy: notchTerminalInnerTextInset
+            )
+            terminalBackgroundEffectView.frame = bounds
+            terminalGutterTintView.frame = bounds
+            StableTerminalContainerView.applyGutterMask(
+                to: terminalGutterTintView,
+                bounds: bounds,
+                hole: terminalFrame
+            )
+            view.frame = terminalFrame
         }
 
         // Apply translucency immediately and again on the next run loop tick.
@@ -263,6 +327,13 @@ class TerminalManager: ObservableObject {
     private func refreshTerminalOpacityAndTranslucency(for view: LocalProcessTerminalView) {
         applyTerminalBackgroundAppearance(to: view)
         synchronizeTerminalTranslucencyPresentation(to: view)
+        updateGutterTintColor()
+    }
+
+    /// Keeps the gutter tint ring matching the terminal's resolved (translucent)
+    /// background color so the inset gutter blends seamlessly with the cells.
+    private func updateGutterTintColor() {
+        terminalGutterTintView.layer?.backgroundColor = resolvedTerminalBackgroundNSColor().cgColor
     }
 
     // MARK: - Settings Application

--- a/DynamicIsland/managers/TerminalManager.swift
+++ b/DynamicIsland/managers/TerminalManager.swift
@@ -43,6 +43,9 @@ import Defaults
 final class StableTerminalContainerView: NSView {
     /// Identifies the gutter tint view so `resizeSubviews` can keep its ring mask in sync.
     static let gutterTintIdentifier = NSUserInterfaceItemIdentifier("terminalGutterTint")
+    /// Identifies the custom scroll knob overlay so `resizeSubviews` leaves its frame
+    /// alone (it's positioned from the scroll state, not stretched to fill the bounds).
+    static let scrollKnobIdentifier = NSUserInterfaceItemIdentifier("terminalScrollKnob")
 
     override func resizeSubviews(withOldSize oldSize: NSSize) {
         let size = bounds.size
@@ -59,12 +62,18 @@ final class StableTerminalContainerView: NSView {
         for child in subviews {
             if child is LocalProcessTerminalView {
                 child.frame = terminalFrame
+            } else if child.identifier == Self.scrollKnobIdentifier {
+                // Positioned from scroll state in `updateScrollKnob`; don't stretch it.
+                continue
             } else {
                 child.frame = bounds
                 if child.identifier == Self.gutterTintIdentifier {
                     Self.applyGutterMask(to: child, bounds: bounds, hole: terminalFrame)
                 }
             }
+        }
+        MainActor.assumeIsolated {
+            TerminalManager.shared.refreshScrollKnobLayout()
         }
     }
 
@@ -94,6 +103,21 @@ final class StableTerminalContainerView: NSView {
             TerminalManager.shared.refreshTerminalAppearanceIfNeeded()
         }
     }
+}
+
+// MARK: - Scroll Knob Overlay
+
+/// Layer-backed rounded knob drawn on top of the terminal as a custom scrollbar.
+///
+/// SwiftTerm's built-in `NSScroller` is layer-backed and renders its knob via CoreUI,
+/// which ignores `drawKnob`/`drawKnobSlot` overrides — so we can't restyle it directly.
+/// Instead we hide that scroller and render this view ourselves, driven by the
+/// scroller's live values (`doubleValue`, `knobProportion`, `isEnabled`) via KVO.
+///
+/// `hitTest` returns nil so clicks and scroll-wheel events pass straight through to
+/// the terminal underneath.
+final class TerminalScrollKnobView: NSView {
+    override func hitTest(_ point: NSPoint) -> NSView? { nil }
 }
 
 // MARK: - Terminal Manager
@@ -129,6 +153,27 @@ class TerminalManager: ObservableObject {
 
     /// The actual terminal view (child of `containerView`).
     private(set) var terminalView: LocalProcessTerminalView?
+
+    /// SwiftTerm's built-in scroller (kept as the data source for our custom knob).
+    private weak var terminalScroller: NSScroller?
+
+    /// KVO of the scroller's value/proportion/enabled state that drives the knob.
+    private var scrollerObservations: [NSKeyValueObservation] = []
+
+    /// Custom rounded scrollbar knob rendered on top of the terminal.
+    private lazy var scrollKnobView: TerminalScrollKnobView = {
+        let v = TerminalScrollKnobView()
+        v.identifier = StableTerminalContainerView.scrollKnobIdentifier
+        v.wantsLayer = true
+        v.layer?.backgroundColor = NSColor.white.withAlphaComponent(0.45).cgColor
+        v.alphaValue = 0
+        return v
+    }()
+
+    /// Thickness of the custom scroll knob, and its margins inside the terminal.
+    private let scrollKnobThickness: CGFloat = 6
+    private let scrollKnobEndInset: CGFloat = 3
+    private let scrollKnobRightMargin: CGFloat = 2
 
     /// Frosted blur of desktop/content behind the terminal; always below `terminalView`.
     private lazy var terminalBackgroundEffectView: NSVisualEffectView = {
@@ -201,6 +246,13 @@ class TerminalManager: ObservableObject {
         updateGutterTintColor()
         containerView.addSubview(view)
         terminalView = view
+
+        // Keep the custom scroll knob above the terminal (re-add to bring to front).
+        scrollKnobView.removeFromSuperview()
+        containerView.addSubview(scrollKnobView)
+        if let scroller = terminalScroller {
+            updateScrollKnob(from: scroller)
+        }
 
         // If the container already has a valid size, snap the children to it.
         // Blur + gutter tint fill the full bounds; the terminal is inset so its
@@ -372,6 +424,75 @@ class TerminalManager: ObservableObject {
         view.useBrightColors = Defaults[.terminalBoldAsBright]
 
         refreshTerminalOpacityAndTranslucency(for: view)
+        styleTerminalScroller(for: view)
+    }
+
+    /// Hides SwiftTerm's built-in scroller and wires KVO so its live scroll state
+    /// drives our custom `scrollKnobView` (see `TerminalScrollKnobView`).
+    private func styleTerminalScroller(for view: LocalProcessTerminalView) {
+        guard let scroller = view.subviews.compactMap({ $0 as? NSScroller }).first else { return }
+        terminalScroller = scroller
+        // Hide SwiftTerm's own scroller drawing; it stays alive as our data source.
+        scroller.alphaValue = 0
+
+        scrollerObservations.forEach { $0.invalidate() }
+        scrollerObservations = []
+        let onChange: (NSScroller) -> Void = { scroller in
+            MainActor.assumeIsolated {
+                TerminalManager.shared.updateScrollKnob(from: scroller)
+            }
+        }
+        scrollerObservations = [
+            scroller.observe(\.doubleValue, options: [.new]) { s, _ in onChange(s) },
+            scroller.observe(\.knobProportion, options: [.new]) { s, _ in onChange(s) },
+            scroller.observe(\.isEnabled, options: [.new]) { s, _ in onChange(s) }
+        ]
+        updateScrollKnob(from: scroller)
+    }
+
+    /// Re-runs the knob layout using the current scroller state (e.g. after a resize).
+    func refreshScrollKnobLayout() {
+        guard let scroller = terminalScroller else { return }
+        updateScrollKnob(from: scroller)
+    }
+
+    /// Positions and shows/hides the custom scroll knob from the scroller's state.
+    private func updateScrollKnob(from scroller: NSScroller) {
+        guard scrollKnobView.superview === containerView else { return }
+
+        guard scroller.isEnabled else {
+            scrollKnobView.animator().alphaValue = 0
+            return
+        }
+
+        let bounds = containerView.bounds
+        guard bounds.width >= 10, bounds.height >= 10 else { return }
+
+        // Track lives inside the inset terminal area, along its right edge.
+        let terminalFrame = bounds.insetBy(
+            dx: notchTerminalInnerTextInset,
+            dy: notchTerminalInnerTextInset
+        )
+        let thickness = scrollKnobThickness
+        let trackTopY = terminalFrame.maxY - scrollKnobEndInset      // visual top (non-flipped)
+        let trackBottomY = terminalFrame.minY + scrollKnobEndInset
+        let trackHeight = max(0, trackTopY - trackBottomY)
+        guard trackHeight > thickness else {
+            scrollKnobView.animator().alphaValue = 0
+            return
+        }
+
+        let proportion = max(0.04, min(1.0, CGFloat(scroller.knobProportion)))
+        let knobHeight = max(thickness * 2, proportion * trackHeight)
+        let travel = max(0, trackHeight - knobHeight)
+        // doubleValue: 0 = top of scrollback, 1 = bottom (current); y grows upward.
+        let value = max(0, min(1, CGFloat(scroller.doubleValue)))
+        let knobMinY = trackBottomY + (1 - value) * travel
+        let x = terminalFrame.maxX - thickness - scrollKnobRightMargin
+
+        scrollKnobView.frame = NSRect(x: x, y: knobMinY, width: thickness, height: knobHeight)
+        scrollKnobView.layer?.cornerRadius = thickness / 2
+        scrollKnobView.animator().alphaValue = 1
     }
 
     /// Updates font size on the live terminal view.

--- a/DynamicIsland/sizing/matters.swift
+++ b/DynamicIsland/sizing/matters.swift
@@ -159,6 +159,10 @@ let minimalisticCornerRadiusInsets: (opened: (top: CGFloat, bottom: CGFloat), cl
 /// Padding on the terminal block inside the notch. Inner corner radius = outer shell radius on that edge, minus the matching edge padding.
 let notchTerminalContentEdgePadding: (top: CGFloat, horizontal: CGFloat, bottom: CGFloat) = (4, 8, 8)
 
+/// Inner margin (all edges) between the SwiftTerm view's glyphs and the terminal block edge.
+/// Applied to the LocalProcessTerminalView frame only; the frosted blur underlay stays full-bleed.
+let notchTerminalInnerTextInset: CGFloat = 6
+
 /// Bottom radii for the shell (outer) and the terminal ``clipShape`` (inner), per design: inner = outer shell bottom radius − `notchTerminalContentEdgePadding.bottom`.
 func notchTerminalBottomCornerRadii(
     isDynamicIslandMode: Bool,


### PR DESCRIPTION
## Terminal inner inset added (all sides)

- Introduced `notchTerminalInnerTextInset` in `DynamicIsland/sizing/matters.swift`.
- `StableTerminalContainerView.resizeSubviews` now frames `LocalProcessTerminalView` to `bounds.insetBy(...)` instead of full bounds.
- Initial mount path in `TerminalManager.ensureTerminalView` uses the same inset frame, keeping behavior consistent between first layout and subsequent resizes.

## Inset gutter background harmonized

- Added `terminalGutterTintView` below the terminal view and above the frosted effect view.
- Applied an even-odd mask (`StableTerminalContainerView.applyGutterMask`) so tint only fills the ring area outside the inset terminal frame.
- `updateGutterTintColor()` keeps gutter tint synchronized with `resolvedTerminalBackgroundNSColor()` (including opacity/background changes), eliminating blur-vs-terminal color mismatch artifacts.

## Outside-click close logic corrected for shortcut-open path

- In `ContentView.syncStickyTerminalOutsideClickMonitor`, monitor installation now depends on:
  - notch open
  - current tab is terminal
  - not currently hovering notch
- It is no longer gated by `terminalStickyMode`, so outside-click close works even when sticky mode is disabled and terminal is opened via shortcut without hover transitions.
- Added monitor re-sync on notch open state transitions so monitor is installed even when currentView did not change during reopen.

## Custom terminal scrollbar rendering

- SwiftTerm’s built-in scroller is retained as a state source but visually hidden.
- Added `TerminalScrollKnobView` (non-intercepting overlay) rendered in `TerminalManager` as a custom rounded knob.
- KVO observers on scroller `doubleValue`, `knobProportion`, and `isEnabled` drive:
  - knob position
  - knob height
  - visibility (hidden when non-scrollable)
- Knob layout is refreshed on container resize via `refreshScrollKnobLayout()`.

<img width="1227" height="765" alt="image" src="https://github.com/user-attachments/assets/413c2548-c2b3-4257-b7f8-e1c966a42412" />
