### PR TITLE
Compatibility with new macOS 27 Siri AI overlays

### DIFF
--- a/DynamicIsland/managers/Extensions/ExtensionLockScreenWidgetPresentationController.swift
+++ b/DynamicIsland/managers/Extensions/ExtensionLockScreenWidgetPresentationController.swift
@@ -195,7 +195,7 @@ private final class ExtensionLockScreenWidgetWindowPool {
         window.isOpaque = false
         window.backgroundColor = .clear
         window.hasShadow = false
-        window.level = NSWindow.Level(rawValue: Int(CGShieldingWindowLevel()))
+        window.level = .screenSaver
         window.collectionBehavior = [.canJoinAllSpaces, .stationary, .fullScreenAuxiliary]
         window.ignoresMouseEvents = true
         window.isMovable = false

--- a/DynamicIsland/managers/LockScreenLiveActivityWindowManager.swift
+++ b/DynamicIsland/managers/LockScreenLiveActivityWindowManager.swift
@@ -92,7 +92,7 @@ class LockScreenLiveActivityWindowManager {
         window.isReleasedWhenClosed = false
         window.ignoresMouseEvents = false
         window.hasShadow = false
-        window.level = NSWindow.Level(rawValue: Int(CGShieldingWindowLevel()))
+        window.level = .screenSaver
         window.collectionBehavior = [.canJoinAllSpaces, .stationary, .fullScreenAuxiliary]
         window.alphaValue = 0
         window.animationBehavior = .none

--- a/DynamicIsland/managers/LockScreenPanelManager.swift
+++ b/DynamicIsland/managers/LockScreenPanelManager.swift
@@ -134,7 +134,7 @@ class LockScreenPanelManager {
             newWindow.isReleasedWhenClosed = false
             newWindow.isOpaque = false
             newWindow.backgroundColor = .clear
-            newWindow.level = NSWindow.Level(rawValue: Int(CGShieldingWindowLevel()))
+            newWindow.level = .screenSaver
             newWindow.collectionBehavior = [.canJoinAllSpaces, .stationary, .fullScreenAuxiliary]
             newWindow.isMovable = false
             newWindow.hasShadow = false

--- a/DynamicIsland/managers/LockScreenReminderWidgetPanelManager.swift
+++ b/DynamicIsland/managers/LockScreenReminderWidgetPanelManager.swift
@@ -105,7 +105,7 @@ final class LockScreenReminderWidgetPanelManager {
         newWindow.backgroundColor = .clear
         newWindow.hasShadow = false
         newWindow.ignoresMouseEvents = true
-        newWindow.level = NSWindow.Level(rawValue: Int(CGShieldingWindowLevel()))
+        newWindow.level = .screenSaver
         newWindow.collectionBehavior = [.canJoinAllSpaces, .stationary, .fullScreenAuxiliary]
 
         ScreenCaptureVisibilityManager.shared.register(newWindow, scope: .entireInterface)

--- a/DynamicIsland/managers/LockScreenTimerWidgetManager.swift
+++ b/DynamicIsland/managers/LockScreenTimerWidgetManager.swift
@@ -230,7 +230,7 @@ final class LockScreenTimerWidgetPanelManager {
         newWindow.isOpaque = false
         newWindow.backgroundColor = .clear
         newWindow.hasShadow = false
-        newWindow.level = NSWindow.Level(rawValue: Int(CGShieldingWindowLevel()))
+        newWindow.level = .screenSaver
         newWindow.collectionBehavior = [.canJoinAllSpaces, .stationary, .fullScreenAuxiliary]
         newWindow.ignoresMouseEvents = false
         newWindow.isMovable = false

--- a/DynamicIsland/managers/LockScreenWeatherPanelManager.swift
+++ b/DynamicIsland/managers/LockScreenWeatherPanelManager.swift
@@ -103,7 +103,7 @@ final class LockScreenWeatherPanelManager {
         newWindow.backgroundColor = .clear
         newWindow.hasShadow = false
         newWindow.ignoresMouseEvents = true
-        newWindow.level = NSWindow.Level(rawValue: Int(CGShieldingWindowLevel()))
+        newWindow.level = .screenSaver
         newWindow.collectionBehavior = [.canJoinAllSpaces, .stationary, .fullScreenAuxiliary]
 
         ScreenCaptureVisibilityManager.shared.register(newWindow, scope: .entireInterface)

--- a/DynamicIsland/managers/TimerControlWindowManager.swift
+++ b/DynamicIsland/managers/TimerControlWindowManager.swift
@@ -182,7 +182,7 @@ final class TimerControlWindowManager {
         window.isOpaque = false
         window.backgroundColor = .clear
         window.hasShadow = false
-        window.level = NSWindow.Level(rawValue: Int(CGShieldingWindowLevel()))
+        window.level = .screenSaver
         window.collectionBehavior = [.canJoinAllSpaces, .stationary, .fullScreenAuxiliary]
         window.ignoresMouseEvents = false
         window.isMovable = false


### PR DESCRIPTION
Update window level to `.screenSaver` for compatibility with new macOS 27 Siri AI overlays.

Currently, widgets on the lock screen appear on top of the Siri AI overlay when triggering a conversation on the macOS 27 dev beta. This adjustment lowers the window priority to ensure the overlay correctly covers the widgets.