### PR TITLE
BugFix: AnimatedArtworkManager and layout recursion

### DIFF
--- a/DynamicIsland/managers/AnimatedArtworkManager.swift
+++ b/DynamicIsland/managers/AnimatedArtworkManager.swift
@@ -28,21 +28,27 @@ actor AnimatedArtworkManager {
 
     func fetchAnimatedArtworkURL(title: String, artist: String) async -> URL? {
         let key = "\(title)|\(artist)"
-        if key == cachedKey, let url = cachedVideoURL {
-            return url
+        if key == cachedKey {
+            return cachedVideoURL
         }
 
-        guard await requestMusicAuthorization() else { return nil }
+        cachedKey = key
+
+        guard await requestMusicAuthorization() else {
+            cachedVideoURL = nil
+            return nil
+        }
 
         guard let songID = await searchSongID(title: title, artist: artist) else {
+            cachedVideoURL = nil
             return nil
         }
 
         guard let videoURL = await fetchEditorialVideoURL(songID: songID) else {
+            cachedVideoURL = nil
             return nil
         }
 
-        cachedKey = key
         cachedSongID = songID
         cachedVideoURL = videoURL
         return videoURL

--- a/DynamicIsland/managers/MusicControlWindowManager.swift
+++ b/DynamicIsland/managers/MusicControlWindowManager.swift
@@ -34,7 +34,7 @@ struct MusicControlWindowMetrics: Equatable {
 final class MusicControlWindowManager {
     static let shared = MusicControlWindowManager()
 
-    private var window: NSWindow?
+    private var window: NSPanel?
     private var hostingView: NSHostingView<MusicControlOverlay>?
     private var hasDelegated = false
     private var lastMetrics: MusicControlWindowMetrics?
@@ -142,7 +142,7 @@ final class MusicControlWindowManager {
         }
     }
 
-    private func tearDownWindowResources(using window: NSWindow? = nil) {
+    private func tearDownWindowResources(using window: NSPanel? = nil) {
         let targetWindow = window ?? self.window
         targetWindow?.contentView = nil
         targetWindow?.orderOut(nil)
@@ -162,12 +162,12 @@ final class MusicControlWindowManager {
         return view
     }
 
-    private func ensureWindow(on screen: NSScreen) -> NSWindow {
+    private func ensureWindow(on screen: NSScreen) -> NSPanel {
         if let window {
             return window
         }
 
-        let window = NSWindow(
+        let window = NSPanel(
             contentRect: NSRect(x: screen.frame.midX, y: screen.frame.midY, width: 240, height: 68),
             styleMask: [.borderless, .nonactivatingPanel],
             backing: .buffered,
@@ -192,7 +192,6 @@ final class MusicControlWindowManager {
     }
 
     private func measuredSize(for hosting: NSHostingView<MusicControlOverlay>) -> CGSize {
-        hosting.layoutSubtreeIfNeeded()
         let size = hosting.fittingSize
         return CGSize(width: ceil(size.width), height: ceil(size.height))
     }

--- a/DynamicIsland/managers/TimerControlWindowManager.swift
+++ b/DynamicIsland/managers/TimerControlWindowManager.swift
@@ -34,7 +34,7 @@ struct TimerControlWindowMetrics: Equatable {
 final class TimerControlWindowManager {
     static let shared = TimerControlWindowManager()
 
-    private var window: NSWindow?
+    private var window: NSPanel?
     private var hostingView: NSHostingView<TimerControlOverlay>?
     private var hasDelegated = false
     private var lastMetrics: TimerControlWindowMetrics?
@@ -146,7 +146,7 @@ final class TimerControlWindowManager {
         }
     }
 
-    private func tearDownWindowResources(using window: NSWindow? = nil) {
+    private func tearDownWindowResources(using window: NSPanel? = nil) {
         let targetWindow = window ?? self.window
         targetWindow?.contentView = nil
         targetWindow?.orderOut(nil)
@@ -166,12 +166,12 @@ final class TimerControlWindowManager {
         return view
     }
 
-    private func ensureWindow(on screen: NSScreen) -> NSWindow {
+    private func ensureWindow(on screen: NSScreen) -> NSPanel {
         if let window {
             return window
         }
 
-        let window = NSWindow(
+        let window = NSPanel(
             contentRect: NSRect(x: screen.frame.midX, y: screen.frame.midY, width: 220, height: 64),
             styleMask: [.borderless, .nonactivatingPanel],
             backing: .buffered,
@@ -196,7 +196,6 @@ final class TimerControlWindowManager {
     }
 
     private func measuredSize(for hosting: NSHostingView<TimerControlOverlay>) -> CGSize {
-        hosting.layoutSubtreeIfNeeded()
         let size = hosting.fittingSize
         return CGSize(width: ceil(size.width), height: ceil(size.height))
     }


### PR DESCRIPTION
Things done:

- Removed force update with `layoutSubtreeIfNeeded()`
- Fixed logic of Animated Artwork caching for `nil` states
- Changed a couple places from `NSWindow` to `NSPanel` (just a nitpick in warning, been bugging me out since a while)