### PR TITLE
Add QQ Music support via system Now Playing

### DIFF
--- a/DynamicIsland/MediaControllers/QQMusicController.swift
+++ b/DynamicIsland/MediaControllers/QQMusicController.swift
@@ -1,0 +1,293 @@
+/*
+ * Atoll (DynamicIsland)
+ * Copyright (C) 2024-2026 Atoll Contributors
+ *
+ * Originally from boring.notch project
+ * Modified and adapted for Atoll (DynamicIsland)
+ * See NOTICE for details.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import AppKit
+import Combine
+import Foundation
+
+/// Media Remote stream filtered to `com.tencent.QQMusicMac` only. When another app owns
+/// Now Playing, state idles so stale QQ Music metadata is not shown.
+///
+/// QQ Music for Mac does not expose an AppleScript dictionary, so unlike Apple Music or
+/// Spotify it cannot be controlled directly. It does weak-link `MediaPlayer.framework`
+/// and publishes to the system Now Playing center, so we drive it the same way as
+/// `AmazonMusicController`: consume the system-wide MediaRemote stream and only surface
+/// state when QQ Music is the active Now Playing source.
+final class QQMusicController: ObservableObject, MediaControllerProtocol {
+    static let bundleIdentifier = "com.tencent.QQMusicMac"
+
+    func updatePlaybackInfo() async {}
+
+    @Published private(set) var playbackState: PlaybackState = QQMusicController.makeIdlePlaybackState()
+
+    var playbackStatePublisher: AnyPublisher<PlaybackState, Never> {
+        $playbackState.eraseToAnyPublisher()
+    }
+
+    var isWorking: Bool {
+        process != nil && process?.isRunning == true
+    }
+
+    private let mediaRemoteBundle: CFBundle
+    private let MRMediaRemoteSendCommandFunction: @convention(c) (Int, AnyObject?) -> Void
+    private let MRMediaRemoteSetElapsedTimeFunction: @convention(c) (Double) -> Void
+    private let MRMediaRemoteSetShuffleModeFunction: @convention(c) (Int) -> Void
+    private let MRMediaRemoteSetRepeatModeFunction: @convention(c) (Int) -> Void
+
+    private var process: Process?
+    private var pipeHandler: JSONLinesPipeHandler?
+    private var streamTask: Task<Void, Never>?
+
+    /// True only after a stream line explicitly identified QQ Music as the now playing source.
+    private var qqMusicSessionActive = false
+
+    init?() {
+        guard
+            let bundle = CFBundleCreate(
+                kCFAllocatorDefault,
+                NSURL(fileURLWithPath: "/System/Library/PrivateFrameworks/MediaRemote.framework")),
+            let MRMediaRemoteSendCommandPointer = CFBundleGetFunctionPointerForName(
+                bundle, "MRMediaRemoteSendCommand" as CFString),
+            let MRMediaRemoteSetElapsedTimePointer = CFBundleGetFunctionPointerForName(
+                bundle, "MRMediaRemoteSetElapsedTime" as CFString),
+            let MRMediaRemoteSetShuffleModePointer = CFBundleGetFunctionPointerForName(
+                bundle, "MRMediaRemoteSetShuffleMode" as CFString),
+            let MRMediaRemoteSetRepeatModePointer = CFBundleGetFunctionPointerForName(
+                bundle, "MRMediaRemoteSetRepeatMode" as CFString)
+        else { return nil }
+
+        self.mediaRemoteBundle = bundle
+        MRMediaRemoteSendCommandFunction = unsafeBitCast(
+            MRMediaRemoteSendCommandPointer, to: (@convention(c) (Int, AnyObject?) -> Void).self)
+        MRMediaRemoteSetElapsedTimeFunction = unsafeBitCast(
+            MRMediaRemoteSetElapsedTimePointer, to: (@convention(c) (Double) -> Void).self)
+        MRMediaRemoteSetShuffleModeFunction = unsafeBitCast(
+            MRMediaRemoteSetShuffleModePointer, to: (@convention(c) (Int) -> Void).self)
+        MRMediaRemoteSetRepeatModeFunction = unsafeBitCast(
+            MRMediaRemoteSetRepeatModePointer, to: (@convention(c) (Int) -> Void).self)
+
+        Task { await setupNowPlayingObserver() }
+    }
+
+    deinit {
+        streamTask?.cancel()
+
+        if let pipeHandler = self.pipeHandler {
+            Task { await pipeHandler.close() }
+        }
+
+        if let process = self.process {
+            if process.isRunning {
+                process.terminate()
+                process.waitUntilExit()
+            }
+        }
+
+        self.process = nil
+        self.pipeHandler = nil
+    }
+
+    func play() async {
+        MRMediaRemoteSendCommandFunction(0, nil)
+    }
+
+    func pause() async {
+        MRMediaRemoteSendCommandFunction(1, nil)
+    }
+
+    func togglePlay() async {
+        MRMediaRemoteSendCommandFunction(2, nil)
+    }
+
+    func nextTrack() async {
+        MRMediaRemoteSendCommandFunction(4, nil)
+    }
+
+    func previousTrack() async {
+        MRMediaRemoteSendCommandFunction(5, nil)
+    }
+
+    func seek(to time: Double) async {
+        await MainActor.run {
+            MRMediaRemoteSetElapsedTimeFunction(time)
+        }
+    }
+
+    func isActive() -> Bool {
+        NSWorkspace.shared.runningApplications.contains { $0.bundleIdentifier == Self.bundleIdentifier }
+    }
+
+    func toggleShuffle() async {
+        MRMediaRemoteSetShuffleModeFunction(playbackState.isShuffled ? 1 : 3)
+        playbackState.isShuffled.toggle()
+    }
+
+    func toggleRepeat() async {
+        let newRepeatMode = (playbackState.repeatMode == .off) ? 3 : (playbackState.repeatMode.rawValue - 1)
+        playbackState.repeatMode = RepeatMode(rawValue: newRepeatMode) ?? .off
+        MRMediaRemoteSetRepeatModeFunction(newRepeatMode)
+    }
+
+    private func setupNowPlayingObserver() async {
+        let process = Process()
+        guard
+            let scriptURL = Bundle.main.url(forResource: "mediaremote-adapter", withExtension: "pl"),
+            let frameworkPath =
+                Bundle.main.resourceURL?
+                    .appendingPathComponent("MediaRemoteAdapter.framework")
+                    .path
+        else {
+            assertionFailure("Could not find mediaremote-adapter.pl script or framework path")
+            return
+        }
+
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/perl")
+        process.arguments = [scriptURL.path, frameworkPath, "stream"]
+
+        let pipeHandler = JSONLinesPipeHandler()
+        process.standardOutput = await pipeHandler.getPipe()
+
+        let stderrPipe = Pipe()
+        process.standardError = stderrPipe
+        stderrPipe.fileHandleForReading.readabilityHandler = { handle in
+            let data = handle.availableData
+            guard !data.isEmpty,
+                  let message = String(data: data, encoding: .utf8)?
+                    .trimmingCharacters(in: .whitespacesAndNewlines),
+                  !message.isEmpty
+            else { return }
+            print("QQMusicController [stderr]: \(message)")
+        }
+
+        self.process = process
+        self.pipeHandler = pipeHandler
+
+        do {
+            try process.run()
+            streamTask = Task { [weak self] in
+                await self?.processJSONStream()
+            }
+        } catch {
+            assertionFailure("Failed to launch mediaremote-adapter.pl: \(error)")
+        }
+    }
+
+    private func processJSONStream() async {
+        guard let pipeHandler = self.pipeHandler else { return }
+
+        await pipeHandler.readJSONLines(as: NowPlayingUpdate.self) { [weak self] update in
+            await self?.handleAdapterUpdate(update)
+        }
+    }
+
+    private static func makeIdlePlaybackState() -> PlaybackState {
+        var state = PlaybackState(bundleIdentifier: Self.bundleIdentifier)
+        state.title = "Unknown"
+        state.artist = "Unknown"
+        state.album = ""
+        state.isPlaying = false
+        state.artwork = nil
+        state.duration = 0
+        state.currentTime = 0
+        state.isShuffled = false
+        state.repeatMode = .off
+        state.lastUpdated = Date()
+        return state
+    }
+
+    private func applyIdleBecauseNonQQMusicSource() {
+        qqMusicSessionActive = false
+        playbackState = Self.makeIdlePlaybackState()
+    }
+
+    private func handleAdapterUpdate(_ update: NowPlayingUpdate) async {
+        let payload = update.payload
+        let diff = update.diff ?? false
+
+        let explicitParent = payload.parentApplicationBundleIdentifier?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let explicitBundle = payload.bundleIdentifier?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let explicitSource: String? = {
+            if let p = explicitParent, !p.isEmpty { return p }
+            if let b = explicitBundle, !b.isEmpty { return b }
+            return nil
+        }()
+
+        if let source = explicitSource {
+            if source != Self.bundleIdentifier {
+                applyIdleBecauseNonQQMusicSource()
+                return
+            }
+            qqMusicSessionActive = true
+        } else if !diff {
+            applyIdleBecauseNonQQMusicSource()
+            return
+        } else if !qqMusicSessionActive {
+            return
+        }
+
+        var newPlaybackState = PlaybackState(bundleIdentifier: Self.bundleIdentifier)
+
+        newPlaybackState.title = payload.title ?? (diff ? self.playbackState.title : "")
+        newPlaybackState.artist = payload.artist ?? (diff ? self.playbackState.artist : "")
+        newPlaybackState.album = payload.album ?? (diff ? self.playbackState.album : "")
+        newPlaybackState.duration = payload.duration ?? (diff ? self.playbackState.duration : 0)
+        newPlaybackState.currentTime = payload.elapsedTime ?? (diff ? self.playbackState.currentTime : 0)
+
+        if let shuffleMode = payload.shuffleMode {
+            newPlaybackState.isShuffled = shuffleMode != 1
+        } else if !diff {
+            newPlaybackState.isShuffled = false
+        } else {
+            newPlaybackState.isShuffled = self.playbackState.isShuffled
+        }
+        if let repeatModeValue = payload.repeatMode {
+            newPlaybackState.repeatMode = RepeatMode(rawValue: repeatModeValue) ?? .off
+        } else if !diff {
+            newPlaybackState.repeatMode = .off
+        } else {
+            newPlaybackState.repeatMode = self.playbackState.repeatMode
+        }
+
+        if let artworkDataString = payload.artworkData {
+            newPlaybackState.artwork = Data(
+                base64Encoded: artworkDataString.trimmingCharacters(in: .whitespacesAndNewlines)
+            )
+        } else if !diff {
+            newPlaybackState.artwork = nil
+        }
+
+        if let dateString = payload.timestamp,
+           let date = ISO8601DateFormatter().date(from: dateString) {
+            newPlaybackState.lastUpdated = date
+        } else if !diff {
+            newPlaybackState.lastUpdated = Date()
+        } else {
+            newPlaybackState.lastUpdated = self.playbackState.lastUpdated
+        }
+
+        newPlaybackState.playbackRate = payload.playbackRate ?? (diff ? self.playbackState.playbackRate : 1.0)
+        newPlaybackState.isPlaying = payload.playing ?? (diff ? self.playbackState.isPlaying : false)
+        newPlaybackState.bundleIdentifier = Self.bundleIdentifier
+
+        self.playbackState = newPlaybackState
+    }
+}

--- a/DynamicIsland/components/Onboarding/MusicControllerSelectionView.swift
+++ b/DynamicIsland/components/Onboarding/MusicControllerSelectionView.swift
@@ -145,6 +145,8 @@ extension MediaControllerType {
             return String(localized: "Requires a third-party client with API plugin enabled.")
         case .amazonMusic:
             return String(localized: "Uses macOS Now Playing when the Amazon Music app is the active media source. Playback controls follow the system Now Playing target. Scrubbing the timeline may not work if the Amazon Music app does not support remote seek.")
+        case .qqMusic:
+            return String(localized: "Uses macOS Now Playing when the QQ Music app is the active media source. Playback controls follow the system Now Playing target. Scrubbing the timeline may not work if the QQ Music app does not support remote seek.")
         }
     }
 }

--- a/DynamicIsland/components/Onboarding/MusicControllerSelectionView.swift
+++ b/DynamicIsland/components/Onboarding/MusicControllerSelectionView.swift
@@ -146,7 +146,7 @@ extension MediaControllerType {
         case .amazonMusic:
             return String(localized: "Uses macOS Now Playing when the Amazon Music app is the active media source. Playback controls follow the system Now Playing target. Scrubbing the timeline may not work if the Amazon Music app does not support remote seek.")
         case .qqMusic:
-            return String(localized: "Uses macOS Now Playing when the QQ Music app is the active media source. Playback controls follow the system Now Playing target. Scrubbing the timeline may not work if the QQ Music app does not support remote seek.")
+            return String(localized: "Uses macOS Now Playing when the QQ Music app is the active media source. Playback (including play/pause, track skip, and timeline scrubbing) is controlled through the system Now Playing target.")
         }
     }
 }

--- a/DynamicIsland/components/Settings/SettingsView.swift
+++ b/DynamicIsland/components/Settings/SettingsView.swift
@@ -2801,7 +2801,7 @@ struct Media: View {
                 } else {
                     VStack(alignment: .leading, spacing: 6) {
                         Text(String(localized: "'Now Playing' was the only option on previous versions and works with all media apps."))
-                        Text(String(localized: "Uses macOS Now Playing when the Amazon Music app is the active media source. Playback controls follow the system Now Playing target. Scrubbing the timeline may not work if the Amazon Music app does not support remote seek."))
+                        Text(mediaController.description)
                     }
                     .foregroundStyle(.secondary)
                     .font(.caption)

--- a/DynamicIsland/managers/MusicManager.swift
+++ b/DynamicIsland/managers/MusicManager.swift
@@ -681,6 +681,8 @@ class MusicManager: ObservableObject {
             newController = YouTubeMusicController()
         case .amazonMusic:
             newController = AmazonMusicController()
+        case .qqMusic:
+            newController = QQMusicController()
         }
 
         // Set up state observation for the new controller
@@ -1724,6 +1726,8 @@ extension MusicManager {
             return spotifyGreen
         case .amazonMusic:
             return amazonOrange
+        case .qqMusic:
+            return qqMusicGreen
         case .nowPlaying:
             if let bundleIdentifier,
                let bundleColor = brandAccentColor(forBundleIdentifier: bundleIdentifier) {
@@ -1743,6 +1747,8 @@ extension MusicManager {
             return spotifyGreen
         case AmazonMusicController.bundleIdentifier:
             return amazonOrange
+        case QQMusicController.bundleIdentifier:
+            return qqMusicGreen
         default:
             return nil
         }
@@ -1751,6 +1757,7 @@ extension MusicManager {
     private static let appleMusicPink = Color(red: 0.999, green: 0.171, blue: 0.331)
     private static let spotifyGreen = Color(red: 0.0, green: 0.857, blue: 0.302)
     private static let amazonOrange = Color(red: 1.0, green: 0.6, blue: 0.0)
+    private static let qqMusicGreen = Color(red: 0.192, green: 0.761, blue: 0.486)
 }
 
 // MARK: - Album Art Flip Helper

--- a/DynamicIsland/models/Constants.swift
+++ b/DynamicIsland/models/Constants.swift
@@ -406,9 +406,10 @@ enum MediaControllerType: String, CaseIterable, Identifiable, Defaults.Serializa
     case spotify = "Spotify"
     case youtubeMusic = "Youtube Music"
     case amazonMusic = "Amazon Music"
-    
+    case qqMusic = "QQ Music"
+
     var id: String { self.rawValue }
-    
+
     var localizedName: String {
         switch self {
         case .nowPlaying: return String(localized: "Now Playing")
@@ -416,6 +417,7 @@ enum MediaControllerType: String, CaseIterable, Identifiable, Defaults.Serializa
         case .spotify: return String(localized: "Spotify")
         case .youtubeMusic: return String(localized: "Youtube Music")
         case .amazonMusic: return String(localized: "Amazon Music")
+        case .qqMusic: return String(localized: "QQ Music")
         }
     }
 }


### PR DESCRIPTION
## What

Adds **QQ Music** (`com.tencent.QQMusicMac`) as a selectable media source.

## Why

QQ Music is one of the most-used music apps among Chinese users, and there is an
open request for it upstream in boring.notch (TheBoredTeam/boring.notch#944).

QQ Music for Mac ships **no AppleScript dictionary**, so the Apple Music / Spotify
style of direct scripting can't be used. It does weak-link `MediaPlayer.framework`
and publishes to the macOS **Now Playing** center, so it can be driven through
MediaRemote — exactly like the existing Amazon Music source.

## How

`QQMusicController` is modeled directly on the existing `AmazonMusicController`: a
MediaRemote stream **scoped to QQ Music's bundle id**. It surfaces playback state
only while QQ Music owns the system Now Playing session, and idles otherwise (so
stale metadata is never shown when another app is playing). Playback controls
(play/pause/next/previous) follow the system Now Playing target.

Wiring is minimal and isolated:

- new `QQMusicController.swift`
- one `.qqMusic` case each in `MediaControllerType` (enum + `localizedName`),
  `MusicManager` (controller factory + brand-accent color), and the onboarding
  picker description.

This PR also includes a small drive-by fix: the **Settings → Media** footer under
"Music Source" previously hard-coded the Amazon Music description for *every*
source. It now shows the selected source's own description (reusing the existing
per-case `MediaControllerType.description`), so QQ Music — and every other source —
shows the correct hint.

## Testing

- Built and run on macOS (Apple Silicon + Intel universal build), Xcode 26.
- Verified against QQ Music for Mac v11.5.0: track title/artist/album, artwork,
  play/pause, next/previous, and timeline scrubbing all work; the source correctly
  idles when QQ Music isn't the active Now Playing app.

## Notes

- Relies on the system Now Playing pipeline, like the existing `nowPlaying` and
  `amazonMusic` controllers.

## Screenshots

<!-- I'll drag a screenshot in here: QQ Music selected in Settings → Media and the
notch showing a QQ Music track. -->

---

Refs the QQ Music request tracked in boring.notch#944.
