### PR TITLE
Add 'Custom App' media source (track any Now Playing app)

### DIFF
--- a/DynamicIsland/MediaControllers/CustomNowPlayingController.swift
+++ b/DynamicIsland/MediaControllers/CustomNowPlayingController.swift
@@ -1,0 +1,309 @@
+/*
+ * Atoll (DynamicIsland)
+ * Copyright (C) 2024-2026 Atoll Contributors
+ *
+ * Originally from boring.notch project
+ * Modified and adapted for Atoll (DynamicIsland)
+ * See NOTICE for details.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import AppKit
+import Combine
+import Foundation
+
+/// A user-configurable scoped Now Playing controller.
+///
+/// This is the generalized form of `AmazonMusicController`:
+/// it consumes the system-wide MediaRemote stream and surfaces playback state
+/// only while the user-specified bundle id owns the Now Playing session. Any app
+/// that publishes to the macOS Now Playing center (i.e. weak-links
+/// `MediaPlayer.framework` and reports via `MPNowPlayingInfoCenter`) can be
+/// targeted this way without app-specific scripting.
+///
+/// The target bundle id is supplied at init from `Defaults[.customMediaBundleID]`.
+/// When it changes, `MusicManager` recreates the controller.
+final class CustomNowPlayingController: ObservableObject, MediaControllerProtocol {
+    /// Bundle id this controller is scoped to. Empty means "not configured" → always idle.
+    private let targetBundleIdentifier: String
+
+    func updatePlaybackInfo() async {}
+
+    @Published private(set) var playbackState: PlaybackState
+
+    var playbackStatePublisher: AnyPublisher<PlaybackState, Never> {
+        $playbackState.eraseToAnyPublisher()
+    }
+
+    var isWorking: Bool {
+        process != nil && process?.isRunning == true
+    }
+
+    private let mediaRemoteBundle: CFBundle
+    private let MRMediaRemoteSendCommandFunction: @convention(c) (Int, AnyObject?) -> Void
+    private let MRMediaRemoteSetElapsedTimeFunction: @convention(c) (Double) -> Void
+    private let MRMediaRemoteSetShuffleModeFunction: @convention(c) (Int) -> Void
+    private let MRMediaRemoteSetRepeatModeFunction: @convention(c) (Int) -> Void
+
+    private var process: Process?
+    private var pipeHandler: JSONLinesPipeHandler?
+    private var streamTask: Task<Void, Never>?
+
+    /// True only after a stream line explicitly identified the target as the now playing source.
+    private var targetSessionActive = false
+
+    init?(bundleID: String) {
+        let trimmed = bundleID.trimmingCharacters(in: .whitespacesAndNewlines)
+        self.targetBundleIdentifier = trimmed
+        self.playbackState = CustomNowPlayingController.makeIdlePlaybackState(bundleID: trimmed)
+
+        guard
+            let bundle = CFBundleCreate(
+                kCFAllocatorDefault,
+                NSURL(fileURLWithPath: "/System/Library/PrivateFrameworks/MediaRemote.framework")),
+            let MRMediaRemoteSendCommandPointer = CFBundleGetFunctionPointerForName(
+                bundle, "MRMediaRemoteSendCommand" as CFString),
+            let MRMediaRemoteSetElapsedTimePointer = CFBundleGetFunctionPointerForName(
+                bundle, "MRMediaRemoteSetElapsedTime" as CFString),
+            let MRMediaRemoteSetShuffleModePointer = CFBundleGetFunctionPointerForName(
+                bundle, "MRMediaRemoteSetShuffleMode" as CFString),
+            let MRMediaRemoteSetRepeatModePointer = CFBundleGetFunctionPointerForName(
+                bundle, "MRMediaRemoteSetRepeatMode" as CFString)
+        else { return nil }
+
+        self.mediaRemoteBundle = bundle
+        MRMediaRemoteSendCommandFunction = unsafeBitCast(
+            MRMediaRemoteSendCommandPointer, to: (@convention(c) (Int, AnyObject?) -> Void).self)
+        MRMediaRemoteSetElapsedTimeFunction = unsafeBitCast(
+            MRMediaRemoteSetElapsedTimePointer, to: (@convention(c) (Double) -> Void).self)
+        MRMediaRemoteSetShuffleModeFunction = unsafeBitCast(
+            MRMediaRemoteSetShuffleModePointer, to: (@convention(c) (Int) -> Void).self)
+        MRMediaRemoteSetRepeatModeFunction = unsafeBitCast(
+            MRMediaRemoteSetRepeatModePointer, to: (@convention(c) (Int) -> Void).self)
+
+        // With no target configured there is nothing to observe; stay idle.
+        guard !trimmed.isEmpty else { return }
+
+        Task { await setupNowPlayingObserver() }
+    }
+
+    deinit {
+        streamTask?.cancel()
+
+        if let pipeHandler = self.pipeHandler {
+            Task { await pipeHandler.close() }
+        }
+
+        if let process = self.process {
+            if process.isRunning {
+                process.terminate()
+                process.waitUntilExit()
+            }
+        }
+
+        self.process = nil
+        self.pipeHandler = nil
+    }
+
+    func play() async {
+        MRMediaRemoteSendCommandFunction(0, nil)
+    }
+
+    func pause() async {
+        MRMediaRemoteSendCommandFunction(1, nil)
+    }
+
+    func togglePlay() async {
+        MRMediaRemoteSendCommandFunction(2, nil)
+    }
+
+    func nextTrack() async {
+        MRMediaRemoteSendCommandFunction(4, nil)
+    }
+
+    func previousTrack() async {
+        MRMediaRemoteSendCommandFunction(5, nil)
+    }
+
+    func seek(to time: Double) async {
+        await MainActor.run {
+            MRMediaRemoteSetElapsedTimeFunction(time)
+        }
+    }
+
+    func isActive() -> Bool {
+        guard !targetBundleIdentifier.isEmpty else { return false }
+        return NSWorkspace.shared.runningApplications.contains {
+            $0.bundleIdentifier == targetBundleIdentifier
+        }
+    }
+
+    func toggleShuffle() async {
+        MRMediaRemoteSetShuffleModeFunction(playbackState.isShuffled ? 1 : 3)
+        playbackState.isShuffled.toggle()
+    }
+
+    func toggleRepeat() async {
+        let newRepeatMode = (playbackState.repeatMode == .off) ? 3 : (playbackState.repeatMode.rawValue - 1)
+        playbackState.repeatMode = RepeatMode(rawValue: newRepeatMode) ?? .off
+        MRMediaRemoteSetRepeatModeFunction(newRepeatMode)
+    }
+
+    private func setupNowPlayingObserver() async {
+        let process = Process()
+        guard
+            let scriptURL = Bundle.main.url(forResource: "mediaremote-adapter", withExtension: "pl"),
+            let frameworkPath =
+                Bundle.main.resourceURL?
+                    .appendingPathComponent("MediaRemoteAdapter.framework")
+                    .path
+        else {
+            assertionFailure("Could not find mediaremote-adapter.pl script or framework path")
+            return
+        }
+
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/perl")
+        process.arguments = [scriptURL.path, frameworkPath, "stream"]
+
+        let pipeHandler = JSONLinesPipeHandler()
+        process.standardOutput = await pipeHandler.getPipe()
+
+        let stderrPipe = Pipe()
+        process.standardError = stderrPipe
+        stderrPipe.fileHandleForReading.readabilityHandler = { handle in
+            let data = handle.availableData
+            guard !data.isEmpty,
+                  let message = String(data: data, encoding: .utf8)?
+                    .trimmingCharacters(in: .whitespacesAndNewlines),
+                  !message.isEmpty
+            else { return }
+            print("CustomNowPlayingController [stderr]: \(message)")
+        }
+
+        self.process = process
+        self.pipeHandler = pipeHandler
+
+        do {
+            try process.run()
+            streamTask = Task { [weak self] in
+                await self?.processJSONStream()
+            }
+        } catch {
+            assertionFailure("Failed to launch mediaremote-adapter.pl: \(error)")
+        }
+    }
+
+    private func processJSONStream() async {
+        guard let pipeHandler = self.pipeHandler else { return }
+
+        await pipeHandler.readJSONLines(as: NowPlayingUpdate.self) { [weak self] update in
+            await self?.handleAdapterUpdate(update)
+        }
+    }
+
+    private static func makeIdlePlaybackState(bundleID: String) -> PlaybackState {
+        var state = PlaybackState(bundleIdentifier: bundleID)
+        state.title = "Unknown"
+        state.artist = "Unknown"
+        state.album = ""
+        state.isPlaying = false
+        state.artwork = nil
+        state.duration = 0
+        state.currentTime = 0
+        state.isShuffled = false
+        state.repeatMode = .off
+        state.lastUpdated = Date()
+        return state
+    }
+
+    private func applyIdleBecauseNonTargetSource() {
+        targetSessionActive = false
+        playbackState = Self.makeIdlePlaybackState(bundleID: targetBundleIdentifier)
+    }
+
+    private func handleAdapterUpdate(_ update: NowPlayingUpdate) async {
+        guard !targetBundleIdentifier.isEmpty else { return }
+
+        let payload = update.payload
+        let diff = update.diff ?? false
+
+        let explicitParent = payload.parentApplicationBundleIdentifier?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let explicitBundle = payload.bundleIdentifier?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let explicitSource: String? = {
+            if let p = explicitParent, !p.isEmpty { return p }
+            if let b = explicitBundle, !b.isEmpty { return b }
+            return nil
+        }()
+
+        if let source = explicitSource {
+            if source != targetBundleIdentifier {
+                applyIdleBecauseNonTargetSource()
+                return
+            }
+            targetSessionActive = true
+        } else if !diff {
+            applyIdleBecauseNonTargetSource()
+            return
+        } else if !targetSessionActive {
+            return
+        }
+
+        var newPlaybackState = PlaybackState(bundleIdentifier: targetBundleIdentifier)
+
+        newPlaybackState.title = payload.title ?? (diff ? self.playbackState.title : "")
+        newPlaybackState.artist = payload.artist ?? (diff ? self.playbackState.artist : "")
+        newPlaybackState.album = payload.album ?? (diff ? self.playbackState.album : "")
+        newPlaybackState.duration = payload.duration ?? (diff ? self.playbackState.duration : 0)
+        newPlaybackState.currentTime = payload.elapsedTime ?? (diff ? self.playbackState.currentTime : 0)
+
+        if let shuffleMode = payload.shuffleMode {
+            newPlaybackState.isShuffled = shuffleMode != 1
+        } else if !diff {
+            newPlaybackState.isShuffled = false
+        } else {
+            newPlaybackState.isShuffled = self.playbackState.isShuffled
+        }
+        if let repeatModeValue = payload.repeatMode {
+            newPlaybackState.repeatMode = RepeatMode(rawValue: repeatModeValue) ?? .off
+        } else if !diff {
+            newPlaybackState.repeatMode = .off
+        } else {
+            newPlaybackState.repeatMode = self.playbackState.repeatMode
+        }
+
+        if let artworkDataString = payload.artworkData {
+            newPlaybackState.artwork = Data(
+                base64Encoded: artworkDataString.trimmingCharacters(in: .whitespacesAndNewlines)
+            )
+        } else if !diff {
+            newPlaybackState.artwork = nil
+        }
+
+        if let dateString = payload.timestamp,
+           let date = ISO8601DateFormatter().date(from: dateString) {
+            newPlaybackState.lastUpdated = date
+        } else if !diff {
+            newPlaybackState.lastUpdated = Date()
+        } else {
+            newPlaybackState.lastUpdated = self.playbackState.lastUpdated
+        }
+
+        newPlaybackState.playbackRate = payload.playbackRate ?? (diff ? self.playbackState.playbackRate : 1.0)
+        newPlaybackState.isPlaying = payload.playing ?? (diff ? self.playbackState.isPlaying : false)
+        newPlaybackState.bundleIdentifier = targetBundleIdentifier
+
+        self.playbackState = newPlaybackState
+    }
+}

--- a/DynamicIsland/components/Onboarding/MusicControllerSelectionView.swift
+++ b/DynamicIsland/components/Onboarding/MusicControllerSelectionView.swift
@@ -145,6 +145,8 @@ extension MediaControllerType {
             return String(localized: "Requires a third-party client with API plugin enabled.")
         case .amazonMusic:
             return String(localized: "Uses macOS Now Playing when the Amazon Music app is the active media source. Playback controls follow the system Now Playing target. Scrubbing the timeline may not work if the Amazon Music app does not support remote seek.")
+        case .custom:
+            return String(localized: "Pick any running app to track via macOS Now Playing. Works with any app that reports to the system Now Playing center. Choose the target app in Settings → Media.")
         }
     }
 }

--- a/DynamicIsland/components/Settings/SettingsView.swift
+++ b/DynamicIsland/components/Settings/SettingsView.swift
@@ -2738,6 +2738,8 @@ struct HUD: View {
 struct Media: View {
     @Default(.waitInterval) var waitInterval
     @Default(.mediaController) var mediaController
+    @Default(.customMediaBundleID) var customMediaBundleID
+    @State private var runningAppsRefreshToken = 0
     @ObservedObject var coordinator = DynamicIslandViewCoordinator.shared
     @Default(.hideNotchOption) var hideNotchOption
     @Default(.enableSneakPeek) private var enableSneakPeek
@@ -2771,6 +2773,30 @@ struct Media: View {
         !showStandardMediaControls && !enableMinimalisticUI
     }
 
+    /// Running, user-facing apps offered as targets for the "Custom App" media source.
+    /// The currently-saved bundle id is always included so the selection is never lost
+    /// even if that app isn't running right now.
+    private var customAppOptions: [(name: String, bundleID: String)] {
+        var seen = Set<String>()
+        var options: [(name: String, bundleID: String)] = NSWorkspace.shared.runningApplications
+            .filter { $0.activationPolicy == .regular }
+            .compactMap { app in
+                guard let bundleID = app.bundleIdentifier, !bundleID.isEmpty else { return nil }
+                let name = app.localizedName ?? bundleID
+                return (name, bundleID)
+            }
+            .filter { seen.insert($0.bundleID).inserted }
+            .sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
+
+        if !customMediaBundleID.isEmpty, !seen.contains(customMediaBundleID) {
+            let savedName = NSWorkspace.shared.runningApplications
+                .first { $0.bundleIdentifier == customMediaBundleID }?.localizedName
+            options.insert((savedName ?? customMediaBundleID, customMediaBundleID), at: 0)
+        }
+
+        return options
+    }
+
     var body: some View {
         Form {
             Section {
@@ -2802,6 +2828,41 @@ struct Media: View {
                     VStack(alignment: .leading, spacing: 6) {
                         Text(String(localized: "'Now Playing' was the only option on previous versions and works with all media apps."))
                         Text(String(localized: "Uses macOS Now Playing when the Amazon Music app is the active media source. Playback controls follow the system Now Playing target. Scrubbing the timeline may not work if the Amazon Music app does not support remote seek."))
+                    }
+                    .foregroundStyle(.secondary)
+                    .font(.caption)
+                }
+            }
+
+            if mediaController == .custom {
+                Section {
+                    Picker("Target App", selection: $customMediaBundleID) {
+                        if customMediaBundleID.isEmpty {
+                            Text("Select an app…").tag("")
+                        }
+                        ForEach(customAppOptions, id: \.bundleID) { option in
+                            Text(option.name).tag(option.bundleID)
+                        }
+                    }
+                    .id(runningAppsRefreshToken)
+                    .onChange(of: customMediaBundleID) { _, _ in
+                        NotificationCenter.default.post(
+                            name: Notification.Name.mediaControllerChanged,
+                            object: nil
+                        )
+                    }
+
+                    Button("Refresh app list") {
+                        runningAppsRefreshToken &+= 1
+                    }
+                } header: {
+                    Text("Custom App")
+                } footer: {
+                    VStack(alignment: .leading, spacing: 6) {
+                        Text(String(localized: "Pick any running app. Atoll shows it while that app owns the system Now Playing session, like the Apple Music / Spotify sources. Any app that reports to macOS Now Playing works; scrubbing may not work if the app does not support remote seek."))
+                        if !customMediaBundleID.isEmpty {
+                            Text(verbatim: customMediaBundleID).foregroundStyle(.tertiary)
+                        }
                     }
                     .foregroundStyle(.secondary)
                     .font(.caption)

--- a/DynamicIsland/managers/MusicManager.swift
+++ b/DynamicIsland/managers/MusicManager.swift
@@ -576,6 +576,17 @@ class MusicManager: ObservableObject {
             }
             .store(in: &cancellables)
 
+        // Rebuild the controller when the user changes the custom target app,
+        // but only while the "Custom App" source is the active preference.
+        Defaults.publisher(.customMediaBundleID)
+            .receive(on: RunLoop.main)
+            .sink { [weak self] _ in
+                guard let self, Defaults[.mediaController] == .custom else { return }
+                self.isPearDesktopAutoSwitched = false
+                self.setActiveControllerBasedOnPreference()
+            }
+            .store(in: &cancellables)
+
         // Observe Pear Desktop launch/terminate for auto-detection
         setupPearDesktopAutoDetection()
 
@@ -681,6 +692,8 @@ class MusicManager: ObservableObject {
             newController = YouTubeMusicController()
         case .amazonMusic:
             newController = AmazonMusicController()
+        case .custom:
+            newController = CustomNowPlayingController(bundleID: Defaults[.customMediaBundleID])
         }
 
         // Set up state observation for the new controller
@@ -1724,6 +1737,8 @@ extension MusicManager {
             return spotifyGreen
         case .amazonMusic:
             return amazonOrange
+        case .custom:
+            return .accentColor
         case .nowPlaying:
             if let bundleIdentifier,
                let bundleColor = brandAccentColor(forBundleIdentifier: bundleIdentifier) {

--- a/DynamicIsland/models/Constants.swift
+++ b/DynamicIsland/models/Constants.swift
@@ -406,9 +406,10 @@ enum MediaControllerType: String, CaseIterable, Identifiable, Defaults.Serializa
     case spotify = "Spotify"
     case youtubeMusic = "Youtube Music"
     case amazonMusic = "Amazon Music"
-    
+    case custom = "Custom App"
+
     var id: String { self.rawValue }
-    
+
     var localizedName: String {
         switch self {
         case .nowPlaying: return String(localized: "Now Playing")
@@ -416,6 +417,7 @@ enum MediaControllerType: String, CaseIterable, Identifiable, Defaults.Serializa
         case .spotify: return String(localized: "Spotify")
         case .youtubeMusic: return String(localized: "Youtube Music")
         case .amazonMusic: return String(localized: "Amazon Music")
+        case .custom: return String(localized: "Custom App")
         }
     }
 }
@@ -1060,6 +1062,9 @@ extension Defaults.Keys {
     
     // MARK: Media Controller
     static let mediaController = Key<MediaControllerType>("mediaController", default: defaultMediaController)
+    /// Bundle id targeted by the "Custom App" media source (e.g. com.netease.163music).
+    /// Empty means not configured; the custom controller stays idle until set.
+    static let customMediaBundleID = Key<String>("customMediaBundleID", default: "")
     static let spotifySPDCCookie = Key<String>("spotifySPDCCookie", default: "")
     static let spotifyAuthAccessToken = Key<String>("spotifyAuthAccessToken", default: "")
     static let spotifyAuthAccessTokenExpiration = Key<Double>("spotifyAuthAccessTokenExpiration", default: 0)


### PR DESCRIPTION
## What

Adds a **Custom App** media source: pick any running app in **Settings → Media**
and Atoll tracks it via the system Now Playing center.

## Why

Atoll already has app-scoped Now Playing sources (Amazon Music, and there's an
open request for QQ Music — #537 / boring.notch#944). Every one of these is the
same thing under the hood: the generic Now Playing stream filtered to a single
bundle id. Rather than hard-coding one controller per app, this exposes that
pattern to the user, so **any** app that reports to macOS Now Playing
(NetEase Cloud Music, podcast apps, browsers' PiP, etc.) can be targeted with no
code changes.

## How

`CustomNowPlayingController(bundleID:)` is the parameterized form of
`AmazonMusicController`: a MediaRemote stream scoped to a user-chosen bundle id.
It surfaces playback state only while that app owns the system Now Playing
session and idles otherwise; play/pause/next/previous follow the system target.

- `MediaControllerType.custom` + `Defaults[.customMediaBundleID]`
- `MusicManager` creates the controller from the saved bundle id and recreates it
  when the target changes
- **Settings → Media** shows a dropdown of currently-running apps (with a refresh
  button) when "Custom App" is selected; the saved app is always kept in the list
  even if it isn't running

## Testing

- Built and run on macOS (Apple Silicon + Intel universal build), Xcode 26.
- Verified by targeting QQ Music (`com.tencent.QQMusicMac`): metadata, artwork,
  play/pause and next/previous work; the source idles when that app isn't the
  active Now Playing app.

## Known limitations

- Timeline scrubbing (seek) depends on the target app implementing remote
  `changePlaybackPosition`; it may be a no-op (same caveat as the Amazon source).
- Relies on the system Now Playing pipeline, like the existing `nowPlaying` and
  `amazonMusic` controllers.

## Notes

- This is an alternative/complement to the dedicated QQ Music PR (#537). They
  touch the same enum/factory, so whichever lands first, the other needs a small
  rebase. Happy to combine or drop one if you prefer a single approach.

## Screenshots

<!-- I'll drag in a screenshot of the Custom App dropdown in Settings → Media. -->
