### PR TITLE
Fix stats popovers for localized graph titles

### DIFF
--- a/DynamicIsland/components/Notch/NotchStatsView.swift
+++ b/DynamicIsland/components/Notch/NotchStatsView.swift
@@ -25,6 +25,7 @@ protocol GraphData {
     var color: Color { get }
     var icon: String { get }
     var type: GraphType { get }
+    var rankingType: ProcessRankingType? { get }
 }
 
 enum GraphType {
@@ -40,6 +41,7 @@ struct SingleGraphData: GraphData {
     let color: Color
     let icon: String
     let type: GraphType = .single
+    let rankingType: ProcessRankingType?
 }
 
 // Dual value graph data (for network/disk)
@@ -54,6 +56,7 @@ struct DualGraphData: GraphData {
     let color: Color // Primary color for the component
     let icon: String
     let type: GraphType = .dual
+    let rankingType: ProcessRankingType?
 }
 
 struct NotchStatsView: View {
@@ -86,7 +89,8 @@ struct NotchStatsView: View {
                 value: statsManager.cpuUsageString,
                 data: statsManager.cpuHistory,
                 color: .blue,
-                icon: "cpu"
+                icon: "cpu",
+                rankingType: .cpu
             ))
         }
 
@@ -96,7 +100,8 @@ struct NotchStatsView: View {
                 value: statsManager.memoryUsageString,
                 data: statsManager.memoryHistory,
                 color: .green,
-                icon: "memorychip"
+                icon: "memorychip",
+                rankingType: .memory
             ))
         }
 
@@ -106,7 +111,8 @@ struct NotchStatsView: View {
                 value: statsManager.gpuUsageString,
                 data: statsManager.gpuHistory,
                 color: .purple,
-                icon: "display"
+                icon: "display",
+                rankingType: .gpu
             ))
         }
 
@@ -120,7 +126,8 @@ struct NotchStatsView: View {
                 positiveColor: .orange,
                 negativeColor: .red,
                 color: .orange,
-                icon: "network"
+                icon: "network",
+                rankingType: .network
             ))
         }
 
@@ -134,7 +141,8 @@ struct NotchStatsView: View {
                 positiveColor: .cyan,
                 negativeColor: .yellow,
                 color: .cyan,
-                icon: "internaldrive"
+                icon: "internaldrive",
+                rankingType: .disk
             ))
         }
 
@@ -214,36 +222,32 @@ struct NotchStatsView: View {
                 RankedProcessPopover(
                     rankingType: rankingType,
                     onHoverChange: { hovering in
-                        switch graphData.title {
-                        case "CPU":
+                        switch rankingType {
+                        case .cpu:
                             isHoveringCPUPopover = hovering
-                        case "Memory":
+                        case .memory:
                             isHoveringMemoryPopover = hovering
-                        case "GPU":
+                        case .gpu:
                             isHoveringGPUPopover = hovering
-                        case "Network":
+                        case .network:
                             isHoveringNetworkPopover = hovering
-                        case "Disk":
+                        case .disk:
                             isHoveringDiskPopover = hovering
-                        default:
-                            break
                         }
                     }
                 )
                 .onDisappear {
-                    switch graphData.title {
-                    case "CPU":
+                    switch rankingType {
+                    case .cpu:
                         isHoveringCPUPopover = false
-                    case "Memory":
+                    case .memory:
                         isHoveringMemoryPopover = false
-                    case "GPU":
+                    case .gpu:
                         isHoveringGPUPopover = false
-                    case "Network":
+                    case .network:
                         isHoveringNetworkPopover = false
-                    case "Disk":
+                    case .disk:
                         isHoveringDiskPopover = false
-                    default:
-                        break
                     }
                     DispatchQueue.main.async {
                         updateStatsPopoverState()
@@ -264,54 +268,41 @@ struct NotchStatsView: View {
     }
 
     private func handleGraphClick(for graphData: GraphData) {
-        switch graphData.title {
-        case "CPU":
+        switch graphData.rankingType {
+        case .cpu:
             showingCPUPopover = true
-        case "Memory":
+        case .memory:
             showingMemoryPopover = true
-        case "GPU":
+        case .gpu:
             showingGPUPopover = true
-        case "Network":
+        case .network:
             showingNetworkPopover = true
-        case "Disk":
+        case .disk:
             showingDiskPopover = true
-        default:
+        case nil:
             break
         }
     }
 
     private func bindingForGraph(_ graphData: GraphData) -> Binding<Bool> {
-        switch graphData.title {
-        case "CPU":
+        switch graphData.rankingType {
+        case .cpu:
             return $showingCPUPopover
-        case "Memory":
+        case .memory:
             return $showingMemoryPopover
-        case "GPU":
+        case .gpu:
             return $showingGPUPopover
-        case "Network":
+        case .network:
             return $showingNetworkPopover
-        case "Disk":
+        case .disk:
             return $showingDiskPopover
-        default:
+        case nil:
             return .constant(false)
         }
     }
 
     private func rankingTypeForGraph(_ graphData: GraphData) -> ProcessRankingType? {
-        switch graphData.title {
-        case "CPU":
-            return .cpu
-        case "Memory":
-            return .memory
-        case "GPU":
-            return .gpu
-        case "Network":
-            return .network
-        case "Disk":
-            return .disk
-        default:
-            return nil
-        }
+        graphData.rankingType
     }
     
     // Helper function to create graph views using unified component
@@ -495,7 +486,7 @@ struct UnifiedStatsCard: View {
             .frame(height: 36) // Match boring.notch exactly - reduced from 50
             
             // Click hint - shown for graphs that open popovers
-            if ["CPU", "Memory", "GPU", "Network", "Disk"].contains(graphData.title) {
+            if graphData.rankingType != nil {
                 Text("Click for details")
                     .font(.caption2)
                     .foregroundStyle(Color.white.opacity(0.75))


### PR DESCRIPTION
## Summary

Fixes stats detail popovers so they are keyed by a stable `ProcessRankingType` instead of the localized graph title string.

## Root cause

`NotchStatsView` used the displayed graph title to decide whether a stats card was clickable and which popover binding to open:

- `"CPU"`
- `"Memory"`
- `"GPU"`
- `"Network"`
- `"Disk"`

Those titles are localized before rendering. In non-English locales, for example Simplified Chinese, `Memory` becomes `内存`, so checks such as `graphData.title == "Memory"` no longer match. That makes localized stats cards lose the hover hint and can prevent the correct detail popover from opening.

## What changed

- Added an optional `rankingType` to `GraphData`.
- Assigned stable ranking types when constructing CPU, Memory, GPU, Network, and Disk graph data.
- Updated click handling, popover bindings, hover state, and the "Click for details" hint to use `rankingType` instead of localized display text.
- Kept the localized title only for UI display.

## User impact

This should restore consistent stats card behavior in localized environments. For example, in Simplified Chinese, the `内存`, `网络`, and `磁盘` cards can still show the detail hint and open the correct detail popover.

## Validation

- Reproduced the old string-matching failure with a localized memory title (`内存`).
- Built the app successfully:

```bash
xcodebuild -project DynamicIsland.xcodeproj -scheme DynamicIsland -configuration Debug -derivedDataPath /tmp/AtollDerivedData CODE_SIGNING_ALLOWED=NO build
```

Result: `BUILD SUCCEEDED`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stats card interactions so clicks and hover behavior now open the correct details more reliably.
  * The “Click for details” hint now appears more consistently for supported charts.
  * Updated chart navigation to work across CPU, Memory, GPU, Network, and Disk views without relying on title text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->