### PR TITLE
fix: snap song slider on notch open so it stops jumping back and slow-animating

### DIFF
--- a/DynamicIsland/components/Notch/NotchHomeView.swift
+++ b/DynamicIsland/components/Notch/NotchHomeView.swift
@@ -801,10 +801,15 @@ struct MusicSliderView: View {
                 }
             }
         }
+        .onAppear {
+            guard !isLiveStream else { return }
+            guard !dragging else { return }
+            setSliderValueWithoutAnimation(MusicManager.shared.estimatedPlaybackPosition())
+        }
         .onChange(of: currentDate) { newDate in
             guard !isLiveStream else { return }
             guard !dragging, timestampDate.timeIntervalSince(lastDragged) > -1 else { return }
-            sliderValue = MusicManager.shared.estimatedPlaybackPosition(at: newDate)
+            setSliderValueWithoutAnimation(MusicManager.shared.estimatedPlaybackPosition(at: newDate))
         }
         .onChange(of: isPlaying) { _, playing in
             // Snap slider to the exact position when music pauses so
@@ -817,6 +822,14 @@ struct MusicSliderView: View {
             if isLive {
                 sliderValue = 0
             }
+        }
+    }
+
+    private func setSliderValueWithoutAnimation(_ value: Double) {
+        var transaction = Transaction()
+        transaction.disablesAnimations = true
+        withTransaction(transaction) {
+            sliderValue = value
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes the song slider jumping back and then slowly animating forward each time the notch opens (issue #506). `MusicSliderView` now snaps to the current playback position on appear without animation, and periodic timeline updates no longer inherit an animation, so the handle sits at the right spot immediately instead of catching up.

## Why this matters

When the notch reopens, the slider was mounted at a stale value and then animated toward the real playback position, which read as the handle "jumping back" and crawling forward. The reporter in #506 describes exactly this: the slider resets and slow-animates on every open. The root cause is that the view did not sync its value to the current position on appear, and the periodic progress updates ran through the default implicit animation.

This snaps to the current position on appear (skipping the snap for live streams and while the user is actively dragging, so those paths are unaffected) and disables the inherited animation for timeline progress updates. Behavior while dragging and for live streams is unchanged.

## Testing

macOS SwiftUI change verified by inspection against the existing `MusicSliderView` update path; the project has no test target to run. Confirmed the snap is guarded by the live-stream and active-drag checks so it only affects the reopen case described in the issue.

Fixes #506


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the music slider’s behavior so its position updates smoothly without unwanted animations.
  * Set the slider’s starting position more reliably when the view appears, while avoiding changes during active dragging or live streams.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->