### PR TITLE
Atoll: Add LLM Usages for Claude Code, Codex and Cursor

### DIFF
--- a/DynamicIsland/ContentView.swift
+++ b/DynamicIsland/ContentView.swift
@@ -1076,6 +1076,8 @@ struct ContentView: View {
                                   NotchTimerView()
                               case .stats:
                                   NotchStatsView()
+                              case .llmUsage:
+                                  NotchLLMUsageView()
                               case .colorPicker:
                                   NotchColorPickerView()
                             case .notes:

--- a/DynamicIsland/DynamicIslandViewCoordinator.swift
+++ b/DynamicIsland/DynamicIslandViewCoordinator.swift
@@ -105,7 +105,7 @@ class DynamicIslandViewCoordinator: ObservableObject {
     private var cancellables = Set<AnyCancellable>()
     private var hoverOpenSuppressedUntil: Date = .distantPast
     
-    private static let tabOrder: [NotchViews] = [.home, .shelf, .timer, .stats, .colorPicker, .notes, .clipboard, .terminal, .extensionExperience]
+    private static let tabOrder: [NotchViews] = [.home, .shelf, .timer, .stats, .llmUsage, .colorPicker, .notes, .clipboard, .terminal, .extensionExperience]
     
     /// Direction of the most recent tab switch (true = forward/right, false = backward/left)
     @Published var tabSwitchForward: Bool = true

--- a/DynamicIsland/components/Notch/NotchLLMUsageView.swift
+++ b/DynamicIsland/components/Notch/NotchLLMUsageView.swift
@@ -1,0 +1,136 @@
+/*
+ * Atoll (DynamicIsland)
+ * Copyright (C) 2024-2026 Atoll Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import SwiftUI
+import Defaults
+
+struct NotchLLMUsageView: View {
+    @ObservedObject private var manager = LLMUsageManager.shared
+
+    private func isEnabled(_ provider: ProviderID) -> Bool { Defaults[provider.enabledKey] }
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 10) {
+            ForEach(ProviderID.allCases.filter { isEnabled($0) }) { provider in
+                card(for: provider)
+            }
+        }
+        .padding(.horizontal, 8)
+        .onAppear { manager.refreshAll() }
+    }
+
+    @ViewBuilder
+    private func card(for provider: ProviderID) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(provider.displayName).font(.headline)
+            switch manager.results[provider] ?? .loading {
+            case .loading:
+                ProgressView().controlSize(.small)
+            case .failure(let reason):
+                Text(reason).font(.caption).foregroundStyle(.secondary).lineLimit(2)
+            case .success(let snap):
+                success(snap)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(10)
+        .background(.white.opacity(0.06), in: RoundedRectangle(cornerRadius: 12))
+    }
+
+    @ViewBuilder
+    private func success(_ snap: UsageSnapshot) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            if snap.sessionLimit == nil && snap.weekLimit == nil {
+                window("Today", snap.today, prominent: true)
+                window("Week", snap.week)
+                window("Session", snap.session)
+                Text("quota unavailable").font(.caption2).foregroundStyle(.secondary.opacity(0.7))
+            } else {
+                if let limit = snap.sessionLimit { quotaGauge("Session", limit) }
+                if let limit = snap.weekLimit { quotaGauge("Week", limit) }
+                VStack(alignment: .leading, spacing: 2) {
+                    window("Today", snap.today, compact: true)
+                    window("Week", snap.week, compact: true)
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func quotaGauge(_ label: String, _ limit: UsageLimit) -> some View {
+        let usedPct = Int(limit.used.rounded())
+        let leftPct = max(0, 100 - usedPct)
+        VStack(alignment: .leading, spacing: 3) {
+            HStack {
+                Text(label).font(.caption2.weight(.semibold)).foregroundStyle(.secondary)
+                Spacer()
+                if let resets = resetsIn(limit.resetsAt) {
+                    Text(resets).font(.caption2).foregroundStyle(.secondary)
+                }
+            }
+            GeometryReader { geo in
+                ZStack(alignment: .leading) {
+                    Capsule().fill(.white.opacity(0.15))
+                    Capsule().fill(gaugeTint(limit.fraction)).frame(width: max(4, geo.size.width * limit.fraction))
+                }
+            }
+            .frame(height: 6)
+            HStack {
+                Text("\(usedPct)% used").font(.caption2).monospacedDigit()
+                Spacer()
+                Text("\(leftPct)% left").font(.caption2).foregroundStyle(.secondary).monospacedDigit()
+            }
+        }
+    }
+
+    private func gaugeTint(_ fraction: Double) -> Color {
+        if fraction > 0.95 { return .red }
+        if fraction > 0.9 { return .orange }
+        return .accentColor
+    }
+
+    private func resetsIn(_ date: Date?) -> String? {
+        guard let date else { return nil }
+        let seconds = Int(date.timeIntervalSinceNow)
+        guard seconds > 0 else { return nil }
+        let hours = seconds / 3600
+        let minutes = (seconds % 3600) / 60
+        return hours > 0 ? "resets in \(hours)h \(minutes)m" : "resets in \(minutes)m"
+    }
+
+    private func window(_ label: String, _ totals: UsageTotals, prominent: Bool = false, compact: Bool = false) -> some View {
+        HStack(alignment: .firstTextBaseline, spacing: 6) {
+            Text(label).font(.caption2).foregroundStyle(.secondary).frame(width: compact ? 34 : 48, alignment: .leading)
+            Text(tokens(totals.totalTokens))
+                .font(.system(size: compact ? 11 : (prominent ? 17 : 13), weight: prominent ? .bold : .semibold, design: .rounded))
+                .monospacedDigit()
+            Spacer(minLength: 4)
+            Text(money(totals.costUSD)).font(.caption2).foregroundStyle(.secondary).monospacedDigit()
+        }
+    }
+
+    private func tokens(_ n: Int) -> String {
+        switch n {
+        case 1_000_000...: return String(format: "%.1fM", Double(n) / 1_000_000)
+        case 1_000...: return String(format: "%.1fk", Double(n) / 1_000)
+        default: return "\(n)"
+        }
+    }
+
+    private func money(_ v: Double) -> String { String(format: "$%.2f", v) }
+}

--- a/DynamicIsland/components/Notch/NotchLLMUsageView.swift
+++ b/DynamicIsland/components/Notch/NotchLLMUsageView.swift
@@ -120,7 +120,8 @@ struct NotchLLMUsageView: View {
                 .font(.system(size: compact ? 11 : (prominent ? 17 : 13), weight: prominent ? .bold : .semibold, design: .rounded))
                 .monospacedDigit()
             Spacer(minLength: 4)
-            Text(money(totals.costUSD)).font(.caption2).foregroundStyle(.secondary).monospacedDigit()
+            Text(totals.hasUnpricedModel ? money(totals.costUSD) + "+" : money(totals.costUSD))
+                .font(.caption2).foregroundStyle(.secondary).monospacedDigit()
         }
     }
 
@@ -132,5 +133,15 @@ struct NotchLLMUsageView: View {
         }
     }
 
-    private func money(_ v: Double) -> String { String(format: "$%.2f", v) }
+    // Locale-aware formatting pinned to USD — amounts come from the USD pricing table, so the currency code stays fixed.
+    private static let currencyFormatter: NumberFormatter = {
+        let f = NumberFormatter()
+        f.numberStyle = .currency
+        f.currencyCode = "USD"
+        return f
+    }()
+
+    private func money(_ v: Double) -> String {
+        Self.currencyFormatter.string(from: v as NSNumber) ?? String(format: "$%.2f", v)
+    }
 }

--- a/DynamicIsland/components/Settings/SettingsView.swift
+++ b/DynamicIsland/components/Settings/SettingsView.swift
@@ -886,6 +886,10 @@ struct SettingsView: View {
 
             // Stats
             SettingsSearchEntry(tab: .stats, title: "Enable system stats monitoring", keywords: ["stats", "monitoring"], highlightID: SettingsTab.stats.highlightID(for: "Enable system stats monitoring")),
+            SettingsSearchEntry(tab: .stats, title: "Enable LLM Usage Monitor", keywords: ["llm", "usage", "ai", "monitor"], highlightID: SettingsTab.stats.highlightID(for: "Enable LLM Usage Monitor")),
+            SettingsSearchEntry(tab: .stats, title: "Claude Provider", keywords: ["llm", "claude", "provider", "toggle"], highlightID: SettingsTab.stats.highlightID(for: "Claude Provider")),
+            SettingsSearchEntry(tab: .stats, title: "Codex Provider", keywords: ["llm", "codex", "provider", "toggle"], highlightID: SettingsTab.stats.highlightID(for: "Codex Provider")),
+            SettingsSearchEntry(tab: .stats, title: "Cursor Provider", keywords: ["llm", "cursor", "provider", "toggle"], highlightID: SettingsTab.stats.highlightID(for: "Cursor Provider")),
             SettingsSearchEntry(tab: .stats, title: "Stop monitoring after closing the notch", keywords: ["stats", "auto stop"], highlightID: SettingsTab.stats.highlightID(for: "Stop monitoring after closing the notch")),
             SettingsSearchEntry(tab: .stats, title: "CPU Usage", keywords: ["cpu", "graph"], highlightID: SettingsTab.stats.highlightID(for: "CPU Usage")),
             SettingsSearchEntry(tab: .stats, title: "Temperature unit", keywords: ["cpu", "temperature", "celsius", "fahrenheit"], highlightID: SettingsTab.stats.highlightID(for: "Temperature unit")),
@@ -7091,6 +7095,7 @@ private struct TimerPresetComponentControl: View {
 struct StatsSettings: View {
     @ObservedObject var statsManager = StatsManager.shared
     @Default(.enableStatsFeature) var enableStatsFeature
+    @Default(.enableLLMUsageFeature) var enableLLMUsageFeature
     @Default(.statsStopWhenNotchCloses) var statsStopWhenNotchCloses
     @Default(.statsUpdateInterval) var statsUpdateInterval
     @Default(.showCpuGraph) var showCpuGraph
@@ -7137,13 +7142,44 @@ struct StatsSettings: View {
                     // Note: Smart monitoring will handle starting when switching to stats tab
                 }
 
+                Defaults.Toggle(key: .enableLLMUsageFeature) {
+                    Text("Enable LLM Usage Monitor")
+                }
+                .settingsHighlight(id: highlightID("Enable LLM Usage Monitor"))
+
             } header: {
                 Text("General")
             } footer: {
-                Text("When enabled, the Stats tab will display real-time system performance graphs. This feature requires system permissions and may use additional battery.")
+                Text("When enabled, the Stats tab will display real-time system performance graphs. This feature requires system permissions and may use additional battery. Enabling LLM Usage Monitor adds a Usage tab that tracks token usage and spend across your configured AI providers.")
                     .multilineTextAlignment(.trailing)
                     .foregroundStyle(.secondary)
                     .font(.caption)
+            }
+
+            if enableLLMUsageFeature {
+                Section {
+                    Defaults.Toggle(key: .enableClaudeProvider) {
+                        Text("Claude")
+                    }
+                    .settingsHighlight(id: highlightID("Claude Provider"))
+
+                    Defaults.Toggle(key: .enableCodexProvider) {
+                        Text("Codex")
+                    }
+                    .settingsHighlight(id: highlightID("Codex Provider"))
+
+                    Defaults.Toggle(key: .enableCursorProvider) {
+                        Text("Cursor")
+                    }
+                    .settingsHighlight(id: highlightID("Cursor Provider"))
+                } header: {
+                    Text("LLM Providers")
+                } footer: {
+                    Text("Choose which AI providers appear in the Usage tab.")
+                        .multilineTextAlignment(.trailing)
+                        .foregroundStyle(.secondary)
+                        .font(.caption)
+                }
             }
 
             if enableStatsFeature {

--- a/DynamicIsland/components/Tabs/TabSelectionView.swift
+++ b/DynamicIsland/components/Tabs/TabSelectionView.swift
@@ -82,6 +82,11 @@ struct TabSelectionView: View {
             tabsArray.append(TabModel(label: "Stats", icon: "chart.xyaxis.line", view: .stats))
         }
 
+        // Usage tab only shown when LLM usage feature is enabled
+        if Defaults[.enableLLMUsageFeature] {
+            tabsArray.append(TabModel(label: "Usage", icon: "chart.bar.doc.horizontal", view: .llmUsage))
+        }
+
         if Defaults[.enableNotes] || (Defaults[.enableClipboardManager] && Defaults[.clipboardDisplayMode] == .separateTab) {
             let label = Defaults[.enableNotes] ? "Notes" : "Clipboard"
             let icon = Defaults[.enableNotes] ? "note.text" : "doc.on.clipboard"

--- a/DynamicIsland/enums/generic.swift
+++ b/DynamicIsland/enums/generic.swift
@@ -75,6 +75,7 @@ public enum NotchViews {
     case shelf
     case timer
     case stats
+    case llmUsage
     case colorPicker
     case notes
     case clipboard

--- a/DynamicIsland/managers/LLMUsage/ClaudeUsageProvider.swift
+++ b/DynamicIsland/managers/LLMUsage/ClaudeUsageProvider.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+struct ClaudeUsageProvider: UsageProvider {
+    let id: ProviderID = .claude
+    let root: URL
+    let quotaClient: ClaudeQuotaClient
+
+    init(root: URL = FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".claude/projects"), quotaClient: ClaudeQuotaClient = ClaudeQuotaClient()) {
+        self.root = root
+        self.quotaClient = quotaClient
+    }
+
+    func fetchSnapshot(now: Date) async throws -> UsageSnapshot {
+        guard FileManager.default.fileExists(atPath: root.path) else {
+            throw UsageError.notFound("No ~/.claude/projects — Claude Code not detected")
+        }
+        let files = jsonlFiles(under: root)
+        guard !files.isEmpty else { throw UsageError.notFound("No Claude usage logs found") }
+        var snapshot = JSONLUsageParser.aggregate(files: files, now: now)
+        let quota = await quotaClient.fetchLimits()
+        snapshot.sessionLimit = quota.session
+        snapshot.weekLimit = quota.week
+        return snapshot
+    }
+
+    private func jsonlFiles(under dir: URL) -> [URL] {
+        guard let en = FileManager.default.enumerator(at: dir, includingPropertiesForKeys: nil) else { return [] }
+        return en.compactMap { $0 as? URL }.filter { $0.pathExtension == "jsonl" }
+    }
+}
+
+enum UsageError: LocalizedError {
+    case notFound(String)
+    case notConfigured(String)
+    var errorDescription: String? {
+        switch self {
+        case .notFound(let m), .notConfigured(let m): return m
+        }
+    }
+}

--- a/DynamicIsland/managers/LLMUsage/CodexUsageProvider.swift
+++ b/DynamicIsland/managers/LLMUsage/CodexUsageProvider.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+struct CodexUsageProvider: UsageProvider {
+    let id: ProviderID = .codex
+    let root: URL
+    let quotaClient: CodexQuotaClient
+
+    init(root: URL = FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".codex/sessions"), quotaClient: CodexQuotaClient = CodexQuotaClient()) {
+        self.root = root
+        self.quotaClient = quotaClient
+    }
+
+    func fetchSnapshot(now: Date) async throws -> UsageSnapshot {
+        guard FileManager.default.fileExists(atPath: root.path) else {
+            throw UsageError.notFound("No ~/.codex/sessions — Codex not detected")
+        }
+        guard let en = FileManager.default.enumerator(at: root, includingPropertiesForKeys: nil) else {
+            throw UsageError.notFound("No Codex usage logs found")
+        }
+        let files = en.compactMap { $0 as? URL }.filter { $0.pathExtension == "jsonl" }
+        guard !files.isEmpty else { throw UsageError.notFound("No Codex usage logs found") }
+        var snapshot = JSONLUsageParser.aggregate(files: files, now: now)
+        let quota = await quotaClient.fetchLimits()
+        snapshot.sessionLimit = quota.session
+        snapshot.weekLimit = quota.week
+        return snapshot
+    }
+}

--- a/DynamicIsland/managers/LLMUsage/CursorUsageProvider.swift
+++ b/DynamicIsland/managers/LLMUsage/CursorUsageProvider.swift
@@ -49,11 +49,27 @@ struct CursorUsageProvider: UsageProvider {
             let tokens = entry["numTokens"] as? Int ?? 0
             let requests = entry["numRequests"] as? Int ?? 0
             guard tokens > 0 || requests > 0 else { continue }
-            models.append(ModelUsage(model: model, totals: UsageTotals(inputTokens: tokens)))
+            // Cursor API provides only total tokens (no input/output split), treat as input tokens
+            let cost = ModelPricing.cost(model: model, inputTokens: tokens, outputTokens: 0)
+            var modelTotals = UsageTotals(inputTokens: tokens)
+            if let cost {
+                modelTotals.costUSD = cost
+            } else {
+                modelTotals.hasUnpricedModel = true
+            }
+            models.append(ModelUsage(model: model, totals: modelTotals))
             week.inputTokens += tokens
+            if let cost {
+                week.costUSD += cost
+            } else {
+                week.hasUnpricedModel = true
+            }
         }
         snapshot.models = models.sorted { $0.model < $1.model }
         snapshot.week = week
+        // Cursor API provides no per-day breakdown, only cumulative totals;
+        // mirror week data to today since that's the only granularity available
+        snapshot.today = week
         return snapshot
     }
 }

--- a/DynamicIsland/managers/LLMUsage/CursorUsageProvider.swift
+++ b/DynamicIsland/managers/LLMUsage/CursorUsageProvider.swift
@@ -1,0 +1,59 @@
+import Foundation
+
+struct CursorUsageProvider: UsageProvider {
+    let id: ProviderID = .cursor
+    let session: URLSession
+    let quotaClient: CursorQuotaClient
+
+    init(session: URLSession = URLSession(configuration: .ephemeral), quotaClient: CursorQuotaClient? = nil) {
+        self.session = session
+        self.quotaClient = quotaClient ?? CursorQuotaClient(session: session)
+    }
+
+    func fetchSnapshot(now: Date) async throws -> UsageSnapshot {
+        let quota = await quotaClient.fetchLimits()
+        guard let cookie = CursorTokenStore.sessionCookie() else {
+            guard quota.session != nil || quota.week != nil else {
+                throw UsageError.notConfigured("Cursor not signed in")
+            }
+            var snapshot = UsageSnapshot()
+            snapshot.sessionLimit = quota.session
+            snapshot.weekLimit = quota.week
+            snapshot.lastUpdated = now
+            return snapshot
+        }
+        var components = URLComponents(string: "https://cursor.com/api/usage")!
+        components.queryItems = [URLQueryItem(name: "user", value: cookie.userId)]
+        var request = URLRequest(url: components.url!)
+        request.setValue("WorkosCursorSessionToken=\(cookie.cookieToken)", forHTTPHeaderField: "Cookie")
+        let (data, response) = try await session.data(for: request)
+        guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) else {
+            throw UsageError.notConfigured("Cursor usage request failed")
+        }
+        var snapshot = try decode(data, now: now)
+        snapshot.sessionLimit = snapshot.sessionLimit ?? quota.session
+        snapshot.weekLimit = snapshot.weekLimit ?? quota.week
+        return snapshot
+    }
+
+    private func decode(_ data: Data, now: Date) throws -> UsageSnapshot {
+        guard let root = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw UsageError.notConfigured("Cursor usage response malformed")
+        }
+        var snapshot = UsageSnapshot()
+        snapshot.lastUpdated = now
+        var week = UsageTotals()
+        var models: [ModelUsage] = []
+        for (model, value) in root {
+            guard model != "startOfMonth", let entry = value as? [String: Any] else { continue }
+            let tokens = entry["numTokens"] as? Int ?? 0
+            let requests = entry["numRequests"] as? Int ?? 0
+            guard tokens > 0 || requests > 0 else { continue }
+            models.append(ModelUsage(model: model, totals: UsageTotals(inputTokens: tokens)))
+            week.inputTokens += tokens
+        }
+        snapshot.models = models.sorted { $0.model < $1.model }
+        snapshot.week = week
+        return snapshot
+    }
+}

--- a/DynamicIsland/managers/LLMUsage/JSONLUsageParser.swift
+++ b/DynamicIsland/managers/LLMUsage/JSONLUsageParser.swift
@@ -1,0 +1,86 @@
+import Foundation
+
+struct UsageRecord {
+    let timestamp: Date
+    let model: String
+    let inputTokens: Int
+    let outputTokens: Int
+    let dedupKey: String?
+}
+
+struct JSONLUsageParser {
+    private static let iso: ISO8601DateFormatter = {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return f
+    }()
+
+    private static let isoPlain: ISO8601DateFormatter = {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime]
+        return f
+    }()
+
+    private static func parseDate(_ s: String) -> Date? {
+        if let d = iso.date(from: s) { return d }
+        return isoPlain.date(from: s)
+    }
+
+    static func parseLine(_ line: String) -> UsageRecord? {
+        guard let data = line.data(using: .utf8),
+              let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else { return nil }
+        let message = obj["message"] as? [String: Any]
+        let usage = (message?["usage"] as? [String: Any]) ?? (obj["usage"] as? [String: Any])
+        guard let usage else { return nil }
+        let input = (usage["input_tokens"] as? Int ?? 0)
+            + (usage["cache_creation_input_tokens"] as? Int ?? 0)
+            + (usage["cache_read_input_tokens"] as? Int ?? 0)
+        let output = usage["output_tokens"] as? Int ?? 0
+        guard input + output > 0 else { return nil }
+        let model = (message?["model"] as? String) ?? (obj["model"] as? String) ?? "unknown"
+        let tsString = (obj["timestamp"] as? String) ?? (message?["timestamp"] as? String) ?? ""
+        guard let ts = parseDate(tsString) else { return nil }
+        let messageId = message?["id"] as? String
+        let requestId = (obj["requestId"] as? String) ?? (obj["request_id"] as? String)
+        let dedupKey = (messageId != nil || requestId != nil) ? "\(messageId ?? "")-\(requestId ?? "")" : nil
+        return UsageRecord(timestamp: ts, model: model, inputTokens: input, outputTokens: output, dedupKey: dedupKey)
+    }
+
+    static func aggregate(files: [URL], now: Date) -> UsageSnapshot {
+        var snapshot = UsageSnapshot()
+        var perModel: [String: UsageTotals] = [:]
+        var seen = Set<String>()
+        let cal = Calendar.current
+        let sessionStart = now.addingTimeInterval(-5 * 3600)
+        let weekStart = now.addingTimeInterval(-7 * 86400)
+
+        for file in files {
+            guard let content = try? String(contentsOf: file, encoding: .utf8) else { continue }
+            for line in content.split(separator: "\n") {
+                guard let rec = parseLine(String(line)) else { continue }
+                if let key = rec.dedupKey {
+                    if seen.contains(key) { continue }
+                    seen.insert(key)
+                }
+                guard rec.timestamp >= weekStart else { continue }
+                let cost = ModelPricing.cost(model: rec.model, inputTokens: rec.inputTokens, outputTokens: rec.outputTokens)
+                func add(_ t: inout UsageTotals) {
+                    t.inputTokens += rec.inputTokens
+                    t.outputTokens += rec.outputTokens
+                    t.costUSD += cost
+                }
+                add(&snapshot.week)
+                if cal.isDate(rec.timestamp, inSameDayAs: now) { add(&snapshot.today) }
+                if rec.timestamp >= sessionStart { add(&snapshot.session) }
+                var mt = perModel[rec.model] ?? UsageTotals()
+                add(&mt)
+                perModel[rec.model] = mt
+            }
+        }
+        snapshot.models = perModel
+            .map { ModelUsage(model: $0.key, totals: $0.value) }
+            .sorted { $0.totals.costUSD > $1.totals.costUSD }
+        snapshot.lastUpdated = now
+        return snapshot
+    }
+}

--- a/DynamicIsland/managers/LLMUsage/JSONLUsageParser.swift
+++ b/DynamicIsland/managers/LLMUsage/JSONLUsageParser.swift
@@ -67,7 +67,7 @@ struct JSONLUsageParser {
                 func add(_ t: inout UsageTotals) {
                     t.inputTokens += rec.inputTokens
                     t.outputTokens += rec.outputTokens
-                    t.costUSD += cost
+                    if let cost { t.costUSD += cost } else { t.hasUnpricedModel = true }
                 }
                 add(&snapshot.week)
                 if cal.isDate(rec.timestamp, inSameDayAs: now) { add(&snapshot.today) }

--- a/DynamicIsland/managers/LLMUsage/LLMUsageManager.swift
+++ b/DynamicIsland/managers/LLMUsage/LLMUsageManager.swift
@@ -1,0 +1,48 @@
+import Foundation
+import SwiftUI
+import Defaults
+
+@MainActor
+final class LLMUsageManager: ObservableObject {
+    static let shared = LLMUsageManager()
+
+    @Published var results: [ProviderID: UsageResult] = [:]
+    @Published var isRefreshing = false
+
+    private let injectedProviders: [UsageProvider]? // overrides the flag-based default when non-nil
+
+    init(providers: [UsageProvider]? = nil) {
+        self.injectedProviders = providers
+    }
+
+    private static let allProviders: [UsageProvider] = [ClaudeUsageProvider(), CodexUsageProvider(), CursorUsageProvider()]
+
+    private var enabledProviders: [UsageProvider] {
+        if let injectedProviders { return injectedProviders }
+        return Self.allProviders.filter { Defaults[$0.id.enabledKey] }
+    }
+
+    func refreshAll() {
+        guard !isRefreshing else { return }
+        isRefreshing = true
+        let providers = enabledProviders
+        let enabledIDs = Set(providers.map { $0.id })
+        results = results.filter { enabledIDs.contains($0.key) } // drop disabled providers' stale results
+        for p in providers where results[p.id] == nil { results[p.id] = .loading }
+        Task { await runRefresh(providers: providers) }
+    }
+
+    private func runRefresh(providers: [UsageProvider]) async {
+        let now = Date()
+        await withTaskGroup(of: (ProviderID, UsageResult).self) { group in
+            for provider in providers {
+                group.addTask {
+                    do { return (provider.id, .success(try await provider.fetchSnapshot(now: now))) }
+                    catch { return (provider.id, .failure(error.localizedDescription)) }
+                }
+            }
+            for await (id, result) in group { results[id] = result }
+        }
+        isRefreshing = false
+    }
+}

--- a/DynamicIsland/managers/LLMUsage/LLMUsageManager.swift
+++ b/DynamicIsland/managers/LLMUsage/LLMUsageManager.swift
@@ -10,6 +10,8 @@ final class LLMUsageManager: ObservableObject {
     @Published var isRefreshing = false
 
     private let injectedProviders: [UsageProvider]? // overrides the flag-based default when non-nil
+    private var lastRefresh: Date = .distantPast
+    private static let minRefreshInterval: TimeInterval = 60
 
     init(providers: [UsageProvider]? = nil) {
         self.injectedProviders = providers
@@ -22,8 +24,10 @@ final class LLMUsageManager: ObservableObject {
         return Self.allProviders.filter { Defaults[$0.id.enabledKey] }
     }
 
-    func refreshAll() {
+    func refreshAll(force: Bool = false) {
         guard !isRefreshing else { return }
+        guard force || Date().timeIntervalSince(lastRefresh) >= Self.minRefreshInterval else { return }
+        lastRefresh = Date()
         isRefreshing = true
         let providers = enabledProviders
         let enabledIDs = Set(providers.map { $0.id })

--- a/DynamicIsland/managers/LLMUsage/ModelPricing.swift
+++ b/DynamicIsland/managers/LLMUsage/ModelPricing.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+// USD per million tokens, matched by model-family substring. Public list prices verified 2026-07-03.
+enum ModelPricing {
+    private static let perMillion: [(match: String, input: Double, output: Double)] = [
+        ("opus",     5.0, 25.0),
+        ("sonnet",   3.0, 15.0),
+        ("haiku",    1.0,  5.0),
+        ("gpt-5",    1.25, 10.0),
+        ("gpt-4o",   2.50, 10.0),
+        ("o3",       2.0,  8.0),
+    ]
+
+    static func cost(model: String, inputTokens: Int, outputTokens: Int) -> Double {
+        let key = model.lowercased()
+        let rate = perMillion.first { key.contains($0.match) } ?? ("", 0, 0)
+        let inCost = Double(inputTokens) / 1_000_000 * rate.input
+        let outCost = Double(outputTokens) / 1_000_000 * rate.output
+        return inCost + outCost
+    }
+}

--- a/DynamicIsland/managers/LLMUsage/ModelPricing.swift
+++ b/DynamicIsland/managers/LLMUsage/ModelPricing.swift
@@ -7,11 +7,10 @@ enum ModelPricing {
         ("sonnet",   3.0, 15.0),
         ("haiku",    1.0,  5.0),
         ("gpt-5",    1.25, 10.0),
-        ("gpt-4o",   2.50, 10.0),
-        ("o3",       2.0,  8.0),
     ]
 
     static func cost(model: String, inputTokens: Int, outputTokens: Int) -> Double? {
+        guard inputTokens > 0 || outputTokens > 0 else { return 0.0 }
         let key = model.lowercased()
         guard let rate = perMillion.first(where: { key.contains($0.match) }) else { return nil }
         let inCost = Double(inputTokens) / 1_000_000 * rate.input

--- a/DynamicIsland/managers/LLMUsage/ModelPricing.swift
+++ b/DynamicIsland/managers/LLMUsage/ModelPricing.swift
@@ -11,9 +11,9 @@ enum ModelPricing {
         ("o3",       2.0,  8.0),
     ]
 
-    static func cost(model: String, inputTokens: Int, outputTokens: Int) -> Double {
+    static func cost(model: String, inputTokens: Int, outputTokens: Int) -> Double? {
         let key = model.lowercased()
-        let rate = perMillion.first { key.contains($0.match) } ?? ("", 0, 0)
+        guard let rate = perMillion.first(where: { key.contains($0.match) }) else { return nil }
         let inCost = Double(inputTokens) / 1_000_000 * rate.input
         let outCost = Double(outputTokens) / 1_000_000 * rate.output
         return inCost + outCost

--- a/DynamicIsland/managers/LLMUsage/Quota/ClaudeQuotaClient.swift
+++ b/DynamicIsland/managers/LLMUsage/Quota/ClaudeQuotaClient.swift
@@ -1,0 +1,127 @@
+import Foundation
+
+actor ClaudeCredentialStore {
+    static let shared = ClaudeCredentialStore()
+    private var cached: ClaudeQuotaClient.CredentialFile.OAuth?
+
+    fileprivate func get() -> ClaudeQuotaClient.CredentialFile.OAuth? { cached }
+    fileprivate func set(_ creds: ClaudeQuotaClient.CredentialFile.OAuth) { cached = creds }
+}
+
+struct ClaudeQuotaClient {
+    let session: URLSession
+    init(session: URLSession = URLSession(configuration: .ephemeral)) { self.session = session }
+
+    private static let clientID = "9d1c250a-e61b-44d9-88ed-5944d1962f5e"
+    private static let refreshScope = "user:profile user:inference user:sessions:claude_code user:mcp_servers user:file_upload"
+    private static let refreshSkewMs: Int64 = 5 * 60 * 1000
+
+    fileprivate struct CredentialFile: Decodable, Sendable {
+        struct OAuth: Decodable, Sendable {
+            let accessToken: String
+            let refreshToken: String
+            let expiresAt: Int64
+        }
+        let claudeAiOauth: OAuth
+    }
+
+    private struct RefreshResponse: Decodable {
+        let accessToken: String
+        let refreshToken: String
+        let expiresIn: Int
+    }
+
+    private enum ResetsAt: Decodable {
+        case iso(String)
+        case epochMs(Double)
+        init(from decoder: Decoder) throws {
+            let c = try decoder.singleValueContainer()
+            if let s = try? c.decode(String.self) { self = .iso(s) }
+            else { self = .epochMs(try c.decode(Double.self)) }
+        }
+        var date: Date? {
+            switch self {
+            case .iso(let s): return ISO8601DateFormatter().date(from: s)
+            case .epochMs(let ms): return Date(timeIntervalSince1970: ms / 1000)
+            }
+        }
+    }
+
+    private struct Window: Decodable {
+        let utilization: Double
+        let resetsAt: ResetsAt
+    }
+
+    private struct UsageResponse: Decodable {
+        let fiveHour: Window?
+        let sevenDay: Window?
+    }
+
+    func fetchLimits() async -> (session: UsageLimit?, week: UsageLimit?) {
+        guard let creds = await currentCredentials() else { return (nil, nil) }
+        guard let token = await validAccessToken(creds) else { return (nil, nil) }
+        var request = URLRequest(url: URL(string: "https://api.anthropic.com/api/oauth/usage")!)
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("oauth-2025-04-20", forHTTPHeaderField: "anthropic-beta")
+        request.setValue("claude-code/2.1.69", forHTTPHeaderField: "User-Agent")
+        do {
+            let (data, response) = try await session.data(for: request)
+            guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) else { return (nil, nil) }
+            let decoder = JSONDecoder()
+            decoder.keyDecodingStrategy = .convertFromSnakeCase
+            let decoded = try decoder.decode(UsageResponse.self, from: data)
+            let sessionLimit = decoded.fiveHour.map { UsageLimit(used: $0.utilization, limit: 100, resetsAt: $0.resetsAt.date) }
+            let weekLimit = decoded.sevenDay.map { UsageLimit(used: $0.utilization, limit: 100, resetsAt: $0.resetsAt.date) }
+            return (sessionLimit, weekLimit)
+        } catch {
+            return (nil, nil)
+        }
+    }
+
+    private func currentCredentials() async -> CredentialFile.OAuth? {
+        if let cached = await ClaudeCredentialStore.shared.get() { return cached }
+        guard let loaded = Self.loadCredentialsFromSource() else { return nil }
+        await ClaudeCredentialStore.shared.set(loaded)
+        return loaded
+    }
+
+    // File first never prompts; Keychain only as fallback.
+    private static func loadCredentialsFromSource() -> CredentialFile.OAuth? {
+        let path = FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".claude/.credentials.json")
+        if let data = try? Data(contentsOf: path),
+           let parsed = try? JSONDecoder().decode(CredentialFile.self, from: data) {
+            return parsed.claudeAiOauth
+        }
+        guard let json = KeychainReader.genericPassword(service: "Claude Code-credentials"),
+              let parsed = try? JSONDecoder().decode(CredentialFile.self, from: Data(json.utf8)) else { return nil }
+        return parsed.claudeAiOauth
+    }
+
+    private func validAccessToken(_ creds: CredentialFile.OAuth) async -> String? {
+        let nowMs = Int64(Date().timeIntervalSince1970 * 1000)
+        guard creds.expiresAt - nowMs <= Self.refreshSkewMs else { return creds.accessToken }
+        var request = URLRequest(url: URL(string: "https://platform.claude.com/v1/oauth/token")!)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        let body: [String: Any] = [
+            "grant_type": "refresh_token",
+            "refresh_token": creds.refreshToken,
+            "client_id": Self.clientID,
+            "scope": Self.refreshScope
+        ]
+        request.httpBody = try? JSONSerialization.data(withJSONObject: body)
+        guard let (data, response) = try? await session.data(for: request),
+              let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) else {
+            return creds.accessToken
+        }
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        guard let refreshed = try? decoder.decode(RefreshResponse.self, from: data) else { return creds.accessToken }
+        let expiresAt = nowMs + Int64(refreshed.expiresIn) * 1000
+        let updated = CredentialFile.OAuth(accessToken: refreshed.accessToken, refreshToken: refreshed.refreshToken, expiresAt: expiresAt)
+        await ClaudeCredentialStore.shared.set(updated)
+        return refreshed.accessToken
+    }
+}

--- a/DynamicIsland/managers/LLMUsage/Quota/CodexQuotaClient.swift
+++ b/DynamicIsland/managers/LLMUsage/Quota/CodexQuotaClient.swift
@@ -1,0 +1,96 @@
+import Foundation
+
+// Codex/ChatGPT rate-limit usage from chatgpt.com/backend-api/wham/usage; request+response shape per OpenUsage.
+struct CodexQuotaClient {
+    let session: URLSession
+    init(session: URLSession = URLSession(configuration: .ephemeral)) { self.session = session }
+
+    private struct AuthFile: Decodable {
+        struct Tokens: Decodable {
+            let accessToken: String
+            let accountId: String?
+        }
+        let tokens: Tokens
+    }
+
+    private struct RateLimitWindow: Decodable {
+        let usedPercent: Double
+        let resetAt: Double?
+        let resetAfterSeconds: Double?
+    }
+
+    private struct RateLimit: Decodable {
+        let primaryWindow: RateLimitWindow?
+        let secondaryWindow: RateLimitWindow?
+    }
+
+    private struct UsageResponse: Decodable {
+        let rateLimit: RateLimit?
+    }
+
+    // Never throws: any credential/network/parse failure yields (nil, nil).
+    func fetchLimits() async -> (session: UsageLimit?, week: UsageLimit?) {
+        guard let creds = loadCredentials() else { return (nil, nil) }
+        var request = URLRequest(url: URL(string: "https://chatgpt.com/backend-api/wham/usage")!)
+        request.setValue("Bearer \(creds.accessToken)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.setValue("Atoll", forHTTPHeaderField: "User-Agent")
+        if let accountId = creds.accountId, !accountId.isEmpty {
+            request.setValue(accountId, forHTTPHeaderField: "ChatGPT-Account-Id")
+        }
+        do {
+            let (data, response) = try await session.data(for: request)
+            guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) else { return (nil, nil) }
+            let decoder = JSONDecoder()
+            decoder.keyDecodingStrategy = .convertFromSnakeCase
+            let now = Date()
+            if let decoded = try? decoder.decode(UsageResponse.self, from: data) {
+                let sessionLimit = decoded.rateLimit?.primaryWindow.map { limit(from: $0, now: now) }
+                let weekLimit = decoded.rateLimit?.secondaryWindow.map { limit(from: $0, now: now) }
+                if sessionLimit != nil || weekLimit != nil { return (sessionLimit, weekLimit) }
+            }
+            return (headerFallback(http, key: "x-codex-primary-used-percent"), headerFallback(http, key: "x-codex-secondary-used-percent"))
+        } catch {
+            return (nil, nil)
+        }
+    }
+
+    private func limit(from window: RateLimitWindow, now: Date) -> UsageLimit {
+        let resets = window.resetAt.map { Date(timeIntervalSince1970: $0) } ?? window.resetAfterSeconds.map { now.addingTimeInterval($0) }
+        return UsageLimit(used: window.usedPercent, limit: 100, resetsAt: resets)
+    }
+
+    private func headerFallback(_ http: HTTPURLResponse, key: String) -> UsageLimit? {
+        guard let raw = http.value(forHTTPHeaderField: key), let percent = Double(raw) else { return nil }
+        return UsageLimit(used: percent, limit: 100)
+    }
+
+    // auth.json ($CODEX_HOME, ~/.codex, ~/.config/codex), then Keychain "Codex Auth" holding the same JSON payload.
+    private func loadCredentials() -> (accessToken: String, accountId: String?)? {
+        for path in authPaths() {
+            if let data = try? Data(contentsOf: path), let creds = parseAuth(data) { return creds }
+        }
+        guard let value = KeychainReader.genericPassword(service: "Codex Auth"),
+              let creds = parseAuth(Data(value.utf8)) else { return nil }
+        return creds
+    }
+
+    private func authPaths() -> [URL] {
+        let home = FileManager.default.homeDirectoryForCurrentUser
+        if let codexHome = ProcessInfo.processInfo.environment["CODEX_HOME"]?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !codexHome.isEmpty {
+            return [URL(fileURLWithPath: codexHome).appendingPathComponent("auth.json")]
+        }
+        return [
+            home.appendingPathComponent(".codex/auth.json"),
+            home.appendingPathComponent(".config/codex/auth.json"),
+        ]
+    }
+
+    private func parseAuth(_ data: Data) -> (accessToken: String, accountId: String?)? {
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        guard let parsed = try? decoder.decode(AuthFile.self, from: data) else { return nil }
+        return (parsed.tokens.accessToken, parsed.tokens.accountId)
+    }
+}

--- a/DynamicIsland/managers/LLMUsage/Quota/CodexQuotaClient.swift
+++ b/DynamicIsland/managers/LLMUsage/Quota/CodexQuotaClient.swift
@@ -1,7 +1,9 @@
 import Foundation
+import os
 
 // Codex/ChatGPT rate-limit usage from chatgpt.com/backend-api/wham/usage; request+response shape per OpenUsage.
 struct CodexQuotaClient {
+    private static let log = os.Logger(subsystem: "com.atoll.DynamicIsland", category: "CodexQuota")
     let session: URLSession
     init(session: URLSession = URLSession(configuration: .ephemeral)) { self.session = session }
 
@@ -30,7 +32,10 @@ struct CodexQuotaClient {
 
     // Never throws: any credential/network/parse failure yields (nil, nil).
     func fetchLimits() async -> (session: UsageLimit?, week: UsageLimit?) {
-        guard let creds = loadCredentials() else { return (nil, nil) }
+        guard let creds = loadCredentials() else {
+            Self.log.notice("no credentials: auth.json/Keychain missing or unparseable")
+            return (nil, nil)
+        }
         var request = URLRequest(url: URL(string: "https://chatgpt.com/backend-api/wham/usage")!)
         request.setValue("Bearer \(creds.accessToken)", forHTTPHeaderField: "Authorization")
         request.setValue("application/json", forHTTPHeaderField: "Accept")
@@ -40,7 +45,11 @@ struct CodexQuotaClient {
         }
         do {
             let (data, response) = try await session.data(for: request)
-            guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) else { return (nil, nil) }
+            guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) else {
+                let code = (response as? HTTPURLResponse)?.statusCode ?? -1
+                Self.log.error("wham/usage HTTP \(code) — \(code == 401 || code == 403 ? "auth/credential" : "request") failure")
+                return (nil, nil)
+            }
             let decoder = JSONDecoder()
             decoder.keyDecodingStrategy = .convertFromSnakeCase
             let now = Date()
@@ -49,8 +58,14 @@ struct CodexQuotaClient {
                 let weekLimit = decoded.rateLimit?.secondaryWindow.map { limit(from: $0, now: now) }
                 if sessionLimit != nil || weekLimit != nil { return (sessionLimit, weekLimit) }
             }
-            return (headerFallback(http, key: "x-codex-primary-used-percent"), headerFallback(http, key: "x-codex-secondary-used-percent"))
+            let sessionLimit = headerFallback(http, key: "x-codex-primary-used-percent")
+            let weekLimit = headerFallback(http, key: "x-codex-secondary-used-percent")
+            if sessionLimit == nil && weekLimit == nil {
+                Self.log.error("wham/usage 200 but no usage found — response shape may have changed (\(data.count) bytes)")
+            }
+            return (sessionLimit, weekLimit)
         } catch {
+            Self.log.error("wham/usage request errored: \(error.localizedDescription, privacy: .public)")
             return (nil, nil)
         }
     }

--- a/DynamicIsland/managers/LLMUsage/Quota/CursorQuotaClient.swift
+++ b/DynamicIsland/managers/LLMUsage/Quota/CursorQuotaClient.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+// Fetches Cursor's current billing-period usage via the local session token. UNVERIFIED — endpoint per spec, not exercised against a live account.
+struct CursorQuotaClient {
+    let session: URLSession
+    init(session: URLSession = URLSession(configuration: .ephemeral)) { self.session = session }
+
+    private struct PlanUsage: Decodable {
+        let totalPercentUsed: Double
+    }
+
+    private struct UsageResponse: Decodable {
+        let planUsage: PlanUsage?
+        let billingCycleEnd: Double?
+    }
+
+    // Never throws: any credential/network/parse failure yields (nil, nil). Cursor has no 5h session window.
+    func fetchLimits() async -> (session: UsageLimit?, week: UsageLimit?) {
+        guard let token = CursorTokenStore.accessToken() else { return (nil, nil) }
+        var request = URLRequest(url: URL(string: "https://api2.cursor.sh/aiserver.v1.DashboardService/GetCurrentPeriodUsage")!)
+        request.httpMethod = "POST"
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = Data("{}".utf8)
+        do {
+            let (data, response) = try await session.data(for: request)
+            guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) else { return (nil, nil) }
+            let decoded = try JSONDecoder().decode(UsageResponse.self, from: data)
+            guard let percent = decoded.planUsage?.totalPercentUsed else { return (nil, nil) }
+            let resets = decoded.billingCycleEnd.map { Date(timeIntervalSince1970: $0 / 1000) }
+            return (nil, UsageLimit(used: percent, limit: 100, resetsAt: resets))
+        } catch {
+            return (nil, nil)
+        }
+    }
+}

--- a/DynamicIsland/managers/LLMUsage/Quota/CursorTokenStore.swift
+++ b/DynamicIsland/managers/LLMUsage/Quota/CursorTokenStore.swift
@@ -1,0 +1,40 @@
+import Foundation
+import SQLite3
+
+enum CursorTokenStore {
+    static func accessToken() -> String? {
+        if let token = KeychainReader.genericPassword(service: "cursor-access-token") { return token }
+        return readTokenFromStateDB()
+    }
+
+    // Cookie for cursor.com/api/usage: WorkosCursorSessionToken value is "<userId>::<jwt>", userId is the JWT sub.
+    static func sessionCookie() -> (userId: String, cookieToken: String)? {
+        guard let jwt = accessToken(), let userId = userId(fromJWT: jwt) else { return nil }
+        return (userId, "\(userId)%3A%3A\(jwt)")
+    }
+
+    private static func userId(fromJWT jwt: String) -> String? {
+        let parts = jwt.split(separator: ".")
+        guard parts.count >= 2 else { return nil }
+        var payload = String(parts[1]).replacingOccurrences(of: "-", with: "+").replacingOccurrences(of: "_", with: "/")
+        while payload.count % 4 != 0 { payload += "=" }
+        guard let data = Data(base64Encoded: payload),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let sub = json["sub"] as? String else { return nil }
+        return sub.contains("|") ? String(sub.split(separator: "|").last ?? "") : sub
+    }
+
+    private static func readTokenFromStateDB() -> String? {
+        let path = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent("Library/Application Support/Cursor/User/globalStorage/state.vscdb").path
+        var db: OpaquePointer?
+        guard sqlite3_open_v2(path, &db, SQLITE_OPEN_READONLY, nil) == SQLITE_OK, let db else { return nil }
+        defer { sqlite3_close(db) }
+        var stmt: OpaquePointer?
+        let sql = "SELECT value FROM ItemTable WHERE key='cursorAuth/accessToken'"
+        guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK, let stmt else { return nil }
+        defer { sqlite3_finalize(stmt) }
+        guard sqlite3_step(stmt) == SQLITE_ROW, let text = sqlite3_column_text(stmt, 0) else { return nil }
+        return String(cString: text)
+    }
+}

--- a/DynamicIsland/managers/LLMUsage/Quota/KeychainReader.swift
+++ b/DynamicIsland/managers/LLMUsage/Quota/KeychainReader.swift
@@ -1,0 +1,18 @@
+import Foundation
+import Security
+
+enum KeychainReader {
+    static func genericPassword(service: String, account: String? = nil) -> String? {
+        var query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne
+        ]
+        if let account { query[kSecAttrAccount as String] = account } // only filter by account when given
+        var item: CFTypeRef?
+        let status = SecItemCopyMatching(query as CFDictionary, &item)
+        guard status == errSecSuccess, let data = item as? Data else { return nil }
+        return String(data: data, encoding: .utf8)
+    }
+}

--- a/DynamicIsland/managers/LLMUsage/UsageProvider.swift
+++ b/DynamicIsland/managers/LLMUsage/UsageProvider.swift
@@ -1,0 +1,62 @@
+import Foundation
+import Defaults
+
+enum ProviderID: String, CaseIterable, Identifiable {
+    case claude, codex, cursor
+    var id: String { rawValue }
+    var displayName: String {
+        switch self {
+        case .claude: return "Claude"
+        case .codex: return "Codex"
+        case .cursor: return "Cursor"
+        }
+    }
+    var enabledKey: Defaults.Key<Bool> {
+        switch self {
+        case .claude: return .enableClaudeProvider
+        case .codex: return .enableCodexProvider
+        case .cursor: return .enableCursorProvider
+        }
+    }
+}
+
+struct UsageTotals: Equatable {
+    var inputTokens: Int = 0
+    var outputTokens: Int = 0
+    var costUSD: Double = 0
+    var totalTokens: Int { inputTokens + outputTokens }
+}
+
+struct ModelUsage: Equatable, Identifiable {
+    let model: String
+    let totals: UsageTotals
+    var id: String { model }
+}
+
+struct UsageLimit: Equatable {
+    let used: Double
+    let limit: Double
+    var resetsAt: Date? = nil
+    var fraction: Double { limit > 0 ? min(used / limit, 1) : 0 }
+}
+
+struct UsageSnapshot: Equatable {
+    var session: UsageTotals = .init()
+    var today: UsageTotals = .init()
+    var week: UsageTotals = .init()
+    var sessionLimit: UsageLimit? = nil // 5h window quota
+    var weekLimit: UsageLimit? = nil // 7d window quota
+    var models: [ModelUsage] = []
+    var lastUpdated: Date = .distantPast
+}
+
+enum UsageResult {
+    case loading
+    case success(UsageSnapshot)
+    case failure(String)
+}
+
+protocol UsageProvider {
+    var id: ProviderID { get }
+    func fetchSnapshot(now: Date) async throws -> UsageSnapshot
+}

--- a/DynamicIsland/managers/LLMUsage/UsageProvider.swift
+++ b/DynamicIsland/managers/LLMUsage/UsageProvider.swift
@@ -24,6 +24,7 @@ struct UsageTotals: Equatable {
     var inputTokens: Int = 0
     var outputTokens: Int = 0
     var costUSD: Double = 0
+    var hasUnpricedModel: Bool = false
     var totalTokens: Int { inputTokens + outputTokens }
 }
 

--- a/DynamicIsland/models/Constants.swift
+++ b/DynamicIsland/models/Constants.swift
@@ -1077,6 +1077,10 @@ extension Defaults.Keys {
     
     // MARK: Stats Feature
     static let enableStatsFeature = Key<Bool>("enableStatsFeature", default: false)
+    static let enableLLMUsageFeature = Key<Bool>("enableLLMUsageFeature", default: false)
+    static let enableClaudeProvider = Key<Bool>("enableClaudeProvider", default: true)
+    static let enableCodexProvider = Key<Bool>("enableCodexProvider", default: true)
+    static let enableCursorProvider = Key<Bool>("enableCursorProvider", default: true)
     static let autoStartStatsMonitoring = Key<Bool>("autoStartStatsMonitoring", default: true)
     static let statsStopWhenNotchCloses = Key<Bool>("statsStopWhenNotchCloses", default: true)
     static let statsUpdateInterval = Key<Double>("statsUpdateInterval", default: 1.0)


### PR DESCRIPTION
Closes https://github.com/Ebullioscopic/Atoll/issues/550

<img width="678" height="230" alt="image" src="https://github.com/user-attachments/assets/02e2418d-f7d8-42d9-8843-7780a751e0e5" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an **Usage** tab and notch view to monitor LLM usage, including quotas and estimated costs.
  * Introduced an LLM usage monitor with provider cards for Claude, Codex, and Cursor, plus automatic refresh.
  * Added settings to enable the LLM usage monitor and independently toggle each provider.
* **Bug Fixes**
  * Improved provider card states (loading, error, and “quota unavailable”) and enhanced refresh control with throttling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->