### PR TITLE
Atoll: Add OpenRouter to credits as well

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -123,6 +123,8 @@ Atoll builds upon the work of several open-source projects and draws inspiration
 
 - [**OpenUsage**](https://github.com/robinebers/openusage) - LLM Usage Tracking features
 
+- [**OpenRouter**](https://openrouter.ai) - API for getting automated model pricing
+
 ## Contributors
 
 <a href="https://github.com/Ebullioscopic/Atoll/graphs/contributors">


### PR DESCRIPTION
Missed in https://github.com/Ebullioscopic/Atoll/pull/558

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the acknowledgments section to include OpenRouter as a credited service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->