### PR TITLE
fix: timer hour-format overflow and left gap in Live Activity

### DIFF
--- a/DynamicIsland/ContentView.swift
+++ b/DynamicIsland/ContentView.swift
@@ -2750,6 +2750,8 @@ private struct MusicTimerSupplementView: View {
             Text(countdownText)
                 .font(.system(size: 13, weight: .semibold, design: .monospaced))
                 .foregroundColor(timerManager.isOvertime ? .red : .white)
+                .lineLimit(1)
+                .fixedSize(horizontal: true, vertical: false)
                 .contentTransition(.numericText())
                 .animation(.smooth(duration: 0.25), value: timerManager.remainingTime)
                 .frame(width: countdownFrameWidth, alignment: .trailing)
@@ -2758,7 +2760,7 @@ private struct MusicTimerSupplementView: View {
                 barView(width: countdownTextWidth)
             }
         }
-        .padding(.trailing, 8)
+        .padding(.trailing, 2)
         .frame(maxWidth: .infinity, alignment: .trailing)
     }
 
@@ -2905,7 +2907,9 @@ private typealias MusicSupplementFont = UIFont
 
 private enum TimerSupplementMetrics {
     static func countdownTextWidth(for text: String) -> CGFloat {
-        musicMeasureText(text, font: MusicSupplementFont.monospacedDigitSystemFont(ofSize: 13, weight: .semibold))
+        // Measure with a fully monospaced font (matching the `.monospaced` design used
+        // to render) so hour-format times like 1:00:00 aren't under-measured and clipped.
+        musicMeasureText(text, font: MusicSupplementFont.monospacedSystemFont(ofSize: 13, weight: .semibold))
     }
 
     static func countdownFrameWidth(for text: String) -> CGFloat {

--- a/DynamicIsland/components/Timer/TimerLiveActivity.swift
+++ b/DynamicIsland/components/Timer/TimerLiveActivity.swift
@@ -105,7 +105,10 @@ struct TimerLiveActivity: View {
     }
 
     private var leftWingWidth: CGFloat {
-        var width = iconWidth + wingPadding
+        // Only reserve the outer half of the wing padding so the icon sits flush
+        // against the notch (matching the album-art / Toggl layout) instead of
+        // leaving an empty gap between the icon and the notch body.
+        var width = iconWidth + wingPadding / 2
         if showsInfoSection {
             width += 8 + infoWidth
         }
@@ -135,7 +138,7 @@ struct TimerLiveActivity: View {
     }
 
     private var countdownTextWidth: CGFloat {
-        measureTextWidth(timerManager.formattedRemainingTime(), font: monospacedDigitFont(size: 13, weight: .semibold))
+        measureTextWidth(timerManager.formattedRemainingTime(), font: monospacedFont(size: 13, weight: .semibold))
     }
 
     private var countdownWidth: CGFloat {
@@ -240,6 +243,17 @@ struct TimerLiveActivity: View {
         return NSFont.monospacedDigitSystemFont(ofSize: size, weight: weight)
         #else
         return UIFont.monospacedDigitSystemFont(ofSize: size, weight: weight)
+        #endif
+    }
+
+    // Fully monospaced font matching the countdown's `.monospaced` design so the
+    // measured width equals the rendered width (digit-only monospacing under-measures
+    // separators, clipping hour-format times like 1:00:00).
+    private func monospacedFont(size: CGFloat, weight: PlatformFont.Weight) -> PlatformFont {
+        #if canImport(AppKit)
+        return NSFont.monospacedSystemFont(ofSize: size, weight: weight)
+        #else
+        return UIFont.monospacedSystemFont(ofSize: size, weight: weight)
         #endif
     }
 
@@ -360,7 +374,9 @@ struct TimerLiveActivity: View {
                         countdownSection
                     }
                 }
-                .padding(.trailing, wingPadding / 2)
+                // Tighter trailing margin (~6px) so the countdown sits a little further
+                // right, keeping the leading hour digit clear of the notch region.
+                .padding(.trailing, wingPadding / 2 - 5)
                 .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .trailing)
             }
     }
@@ -466,10 +482,12 @@ struct TimerLiveActivity: View {
             Text(timerManager.formattedRemainingTime())
                 .font(.system(size: 13, weight: .semibold, design: .monospaced))
                 .foregroundColor(timerManager.isOvertime ? .red : .white)
+                .lineLimit(1)
+                .fixedSize(horizontal: true, vertical: false)
                 .contentTransition(.numericText())
                 .animation(.smooth(duration: 0.25), value: timerManager.remainingTime)
                 .frame(maxWidth: .infinity, alignment: .trailing)
-            
+
             if showsBarProgress {
                 Capsule()
                     .fill(Color.white.opacity(0.12))
@@ -483,7 +501,9 @@ struct TimerLiveActivity: View {
                     .frame(maxWidth: .infinity, alignment: .trailing)
             }
         }
-     .padding(.trailing, 8)
+     // Note: rightWingView already applies a trailing wing padding, so no extra
+     // trailing padding here — a second one pushes the digits left and clips the
+     // hour under the notch while wasting space on the right.
      .frame(width: countdownWidth,
          height: notchContentHeight, alignment: .center)
     }


### PR DESCRIPTION
## Description

Fixes two layout issues in the timer's Live Activity / notch UI:

1. **Hour-format overflow / clipping** — When the timer showed an hour component (e.g. `1:00:00`), the leading digit was clipped and could disappear under the notch. The countdown width was being measured with a *digit-only* monospaced font (`monospacedDigitSystemFont`), which under-measures the `:` separators used in the rendered `.monospaced` design. Both `TimerLiveActivity` and `MusicTimerSupplementView` now measure with a fully monospaced font so the measured width matches the rendered width. Added `.lineLimit(1)` + `.fixedSize` guards and removed a redundant trailing padding that double-padded (and clipped) the digits.

2. **Left gap** — The timer icon left an empty gap between itself and the notch body. `leftWingWidth` now reserves only the outer half of the wing padding so the icon sits flush against the notch, matching the album-art / Toggl layout.

## Motivation

Hour-length timers were visually broken (missing leading digit) and the leading icon was misaligned relative to the rest of the notch content.

## Changes

- `DynamicIsland/components/Timer/TimerLiveActivity.swift`
- `DynamicIsland/ContentView.swift` (`MusicTimerSupplementView`, `TimerSupplementMetrics`)


## Testing

- Built without errors or warnings.
- Verified hour-format times (`1:00:00`) render fully without clipping in both the standalone timer and the music-paired supplement view.
- Verified the timer icon sits flush against the notch.

## Screenshots

Per the contributing guidelines, screenshots are included for these UI changes.

### Before

| Timer Live Activity | Music-paired supplement |
| --- | --- |
| <img width="4032" height="3024" alt="IMG_9756" src="https://github.com/user-attachments/assets/f0401075-7378-4d73-a48f-e60af498d31b" /> |<img width="4032" height="3024" alt="IMG_9755" src="https://github.com/user-attachments/assets/f949657f-224f-497c-8ced-2d0d4c7759b7" />|



### After

| Timer Live Activity | Music-paired supplement |
| --- | --- |
| <img width="690" height="99" alt="Screenshot 2026-07-05 at 16 00 16" src="https://github.com/user-attachments/assets/03016f8f-17f7-4d15-97a4-7441df873e48" />|<img width="294" height="42" alt="Screenshot 2026-07-05 at 16 01 33" src="https://github.com/user-attachments/assets/76659e45-4589-48c5-805d-99430a97de01" />|


## Checklist

- [x] Branch is up to date with `main`
- [x] Code builds without errors or warnings
- [x] Screenshots added for UI changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved timer countdown rendering so text stays on one line and avoids clipping or width jitter.
  * Tightened spacing around the timer display for better visual alignment in the live view.
  * Updated width measurement for countdown text to handle hour-format times more consistently and prevent under-sizing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->