### PR TITLE
fix: resume OSDUIHelper synchronously on quit

### DIFF
--- a/DynamicIsland/DynamicIslandApp.swift
+++ b/DynamicIsland/DynamicIslandApp.swift
@@ -244,6 +244,12 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             deliverImmediately: true
         )
 
+        // Guarantee the native OSD is usable after we exit: if we were
+        // suppressing it, OSDUIHelper is SIGSTOP-frozen and the async restore in
+        // enableSystemHUD() would not finish before the process dies. Resume it
+        // synchronously here so it is never left frozen. (See issue #568.)
+        SystemOSDManager.resumeOSDUIHelperForTermination()
+
         // Cancel any pending window size updates
         windowSizeUpdateWorkItem?.cancel()
         NotificationCenter.default.removeObserver(self)

--- a/DynamicIsland/managers/SystemOSDManager.swift
+++ b/DynamicIsland/managers/SystemOSDManager.swift
@@ -150,8 +150,16 @@ class SystemOSDManager {
     /// termination handler.
     public static func resumeOSDUIHelperForTermination() {
         suppressionState.withLock { $0.active = false }
-        // Cancel the watcher first so it cannot re-SIGSTOP the helper we resume.
-        stopSuppressionWatcher()
+
+        // Cancel the watcher and wait for it to fully exit before resuming. A
+        // bare cancel is cooperative, so an in-flight suspendOSDUIHelper() could
+        // otherwise land its SIGSTOP after our SIGCONT and re-freeze the helper.
+        // Bridge the async drain to this synchronous path with a bounded wait.
+        if let watcher = stopSuppressionWatcher() {
+            let drained = DispatchSemaphore(value: 0)
+            Task { await watcher.value; drained.signal() }
+            _ = drained.wait(timeout: .now() + 1.0)
+        }
 
         let resume = Process()
         resume.executableURL = URL(fileURLWithPath: "/usr/bin/killall")
@@ -297,7 +305,10 @@ class SystemOSDManager {
         previous?.cancel()
     }
 
-    private static func stopSuppressionWatcher() {
+    /// Cancels the suppression watcher. Returns the cancelled task so callers
+    /// that must not race it (e.g. termination) can wait for it to fully exit.
+    @discardableResult
+    private static func stopSuppressionWatcher() -> Task<Void, Never>? {
         let previous = suppressionState.withLock { state -> Task<Void, Never>? in
             let prior = state.task
             state.task = nil
@@ -305,6 +316,7 @@ class SystemOSDManager {
             return prior
         }
         previous?.cancel()
+        return previous
     }
 
     /// Returns the newest OSDUIHelper PID, or nil if none.

--- a/DynamicIsland/managers/SystemOSDManager.swift
+++ b/DynamicIsland/managers/SystemOSDManager.swift
@@ -138,6 +138,33 @@ class SystemOSDManager {
         }
     }
 
+    /// Synchronously resumes OSDUIHelper for app termination.
+    ///
+    /// `enableSystemHUD()` restarts the helper on a detached background `Task`,
+    /// which never runs to completion when the process is already terminating —
+    /// so a SIGSTOP-frozen OSDUIHelper stays frozen after Atoll quits, breaking
+    /// every native OSD Atoll does not replace (keyboard backlight,
+    /// external-display brightness, …) and leaving a stuck HUD on screen. This
+    /// sends SIGCONT inline and blocks until it lands, guaranteeing the helper
+    /// is resumed before Atoll exits. Idempotent; safe to call from a
+    /// termination handler.
+    public static func resumeOSDUIHelperForTermination() {
+        suppressionState.withLock { $0.active = false }
+        // Cancel the watcher first so it cannot re-SIGSTOP the helper we resume.
+        stopSuppressionWatcher()
+
+        let resume = Process()
+        resume.executableURL = URL(fileURLWithPath: "/usr/bin/killall")
+        resume.arguments = ["-CONT", "OSDUIHelper"]
+        resume.standardError = Pipe() // silence "no such process" stderr
+        do {
+            try resume.run()
+            resume.waitUntilExit()
+        } catch {
+            NSLog("Failed to SIGCONT OSDUIHelper on termination: \(error)")
+        }
+    }
+
     /// Disables the system HUD by stopping OSDUIHelper, and starts a
     /// background watcher that re-suspends any future incarnation launchd
     /// spawns (macOS auto-exits OSDUIHelper on idle).


### PR DESCRIPTION
Fixes #568.

## Problem

When Atoll suppresses the native OSD it SIGSTOP-freezes `OSDUIHelper`. On quit, `enableSystemHUD()` is the only path that restores it, and it does the work on a detached background `Task` (`killall -9` + `launchctl kickstart`). When the process is already terminating that `Task` never runs to completion, so `OSDUIHelper` is left frozen (`T`) after Atoll exits. Every native OSD Atoll does not replace (keyboard backlight, external-display brightness, …) then breaks, and a stuck HUD window is left on screen. It only recovers with a manual `kill -CONT`.

## Fix

Add `SystemOSDManager.resumeOSDUIHelperForTermination()`, which clears the suppression flag, cancels the re-suspend watcher (so it cannot immediately re-`SIGSTOP` the helper), then sends `SIGCONT` inline via `killall -CONT OSDUIHelper` and blocks until it lands. It is called from `applicationWillTerminate`, so the helper is guaranteed to be resumed before Atoll exits.

This mirrors the existing synchronous `killall -STOP` in `suspendOSDUIHelper()`; it is idempotent and a no-op when no `OSDUIHelper` is running.

## Verifying (process state, per #568)

1. Launch Atoll -> `OSDUIHelper` becomes `T` (SIGSTOP-frozen).
2. Quit Atoll -> with this change it returns to `S`; keyboard-backlight / external-display brightness OSD works again and no HUD is left on screen.

`ps -o stat= -p $(pgrep -n OSDUIHelper)` before/after quitting shows the state going `T -> S`.

## Scope

This covers the normal quit path (the reported repro). Crash / `SIGKILL` paths are inherently uncatchable and out of scope here; a watchdog could cover those as a follow-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved app shutdown behavior so system UI elements recover cleanly instead of remaining frozen during termination.
  * Added termination-safe handling to ensure paused system UI helpers can resume reliably as the app exits.  
  * Reduced the chance of stalled or incomplete restore behavior when the app exits while background UI processes are paused.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->