### PR TITLE
Update: CI for close and label events

### DIFF
--- a/.github/workflows/triage-slash-commands.yml
+++ b/.github/workflows/triage-slash-commands.yml
@@ -1,0 +1,41 @@
+name: Triage Slash Commands
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  slash_commands:
+    runs-on: ubuntu-latest
+    # Only run if the commenter is the repository owner or a trusted contributor
+    if: contains(fromJSON('["Ebullioscopic", "danfq", "Ruken16", "StudioKeys"]'), github.event.comment.user.login)
+    steps:
+      - name: Check for /close command
+        if: startsWith(github.event.comment.body, '/close')
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              state: 'closed'
+            });
+
+      - name: Check for /label command
+        if: startsWith(github.event.comment.body, '/label ')
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const label = context.payload.comment.body.replace('/label ', '').trim();
+            if (label) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                labels: [label]
+              });
+            }

--- a/.github/workflows/triage-slash-commands.yml
+++ b/.github/workflows/triage-slash-commands.yml
@@ -5,13 +5,12 @@ on:
 
 permissions:
   issues: write
-  pull-requests: write
 
 jobs:
   slash_commands:
     runs-on: ubuntu-latest
     # Only run if the commenter is the repository owner or a trusted contributor
-    if: contains(fromJSON('["Ebullioscopic", "danfq", "Ruken16", "StudioKeys"]'), github.event.comment.user.login)
+    if: contains(fromJSON(vars.TRUSTED_TRIAGE_USERS), github.event.comment.user.login)
     steps:
       - name: Check for /close command
         if: startsWith(github.event.comment.body, '/close')
@@ -30,12 +29,16 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const label = context.payload.comment.body.replace('/label ', '').trim();
-            if (label) {
-              await github.rest.issues.addLabels({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                labels: [label]
-              });
+            const firstLine = context.payload.comment.body.split(/\r?\n/)[0];
+            const labelStr = firstLine.replace('/label ', '').trim();
+            if (labelStr) {
+              const labelsToApply = labelStr.split(',').map(l => l.trim()).filter(Boolean);
+              if (labelsToApply.length > 0) {
+                await github.rest.issues.addLabels({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: context.issue.number,
+                  labels: labelsToApply
+                });
+              }
             }

--- a/.gitignore
+++ b/.gitignore
@@ -159,3 +159,4 @@ mew-notch/
 /builds/
 /appdmg.json
 COMPREHENSIVE_DOCUMENTATION.md
+implementation_plan.md


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a GitHub Actions workflow to automate triage from newly posted issue comments.
  * Supports `/close` to close the current issue and `/label <name>` to apply one or more labels parsed from the command text.
  * The workflow runs only for trusted commenters and uses restricted write access.
* **Chores**
  * Updated `.gitignore` to also exclude `implementation_plan.md`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->