### PR TITLE
fix: update track metadata before lyrics lookup

### DIFF
--- a/DynamicIsland/managers/MusicManager.swift
+++ b/DynamicIsland/managers/MusicManager.swift
@@ -783,6 +783,18 @@ class MusicManager: ObservableObject {
             self.videoArtworkURL = state.liveArtworkURL
         }
 
+        if state.title != self.songTitle {
+            self.songTitle = state.title
+        }
+
+        if state.artist != self.artistName {
+            self.artistName = state.artist
+        }
+
+        if state.album != self.album {
+            self.album = state.album
+        }
+
         // Handle artwork and visual transitions for changed content
         let shouldAutoPeekOnTrackChange = Defaults[.showSneakPeekOnTrackChange]
 
@@ -831,18 +843,6 @@ class MusicManager: ObservableObject {
         let playbackRateChanged = state.playbackRate != self.playbackRate
         let shuffleChanged = state.isShuffled != self.isShuffled
         let repeatModeChanged = state.repeatMode != self.repeatMode
-
-        if state.title != self.songTitle {
-            self.songTitle = state.title
-        }
-
-        if state.artist != self.artistName {
-            self.artistName = state.artist
-        }
-
-        if state.album != self.album {
-            self.album = state.album
-        }
 
         if timeChanged {
             self.elapsedTime = state.currentTime

--- a/scripts/check_lyrics_metadata_order.rb
+++ b/scripts/check_lyrics_metadata_order.rb
@@ -18,7 +18,7 @@ album_idx = method.index("self.album = state.album")
 
 abort("missing expected snippets") unless [prepare_idx, title_idx, artist_idx, album_idx].all?
 
-if prepare_idx < [title_idx, artist_idx, album_idx].min
+if prepare_idx < [title_idx, artist_idx, album_idx].max
   abort("FAIL: lyrics lookup runs before track metadata is updated; rapid track changes can reuse stale lyrics.")
 end
 

--- a/scripts/check_lyrics_metadata_order.rb
+++ b/scripts/check_lyrics_metadata_order.rb
@@ -1,0 +1,25 @@
+#!/usr/bin/env ruby
+
+file = "DynamicIsland/managers/MusicManager.swift"
+source = File.read(file, encoding: "UTF-8")
+
+method_start = source.index("private func updateFromPlaybackState(")
+abort("could not locate updateFromPlaybackState") unless method_start
+
+method_end = source.index("\n    @MainActor", method_start)
+abort("could not locate end of updateFromPlaybackState") unless method_end
+
+method = source[method_start...method_end]
+
+prepare_idx = method.index("self.prepareLyricsForCurrentTrack()")
+title_idx = method.index("self.songTitle = state.title")
+artist_idx = method.index("self.artistName = state.artist")
+album_idx = method.index("self.album = state.album")
+
+abort("missing expected snippets") unless [prepare_idx, title_idx, artist_idx, album_idx].all?
+
+if prepare_idx < [title_idx, artist_idx, album_idx].min
+  abort("FAIL: lyrics lookup runs before track metadata is updated; rapid track changes can reuse stale lyrics.")
+end
+
+puts "PASS: track metadata is updated before lyrics lookup."


### PR DESCRIPTION
## Summary

- update track metadata before calling the lyrics lookup path
- add a small regression script that checks the ordering inside `updateFromPlaybackState`

## Root cause

`updateFromPlaybackState` called `prepareLyricsForCurrentTrack()` before copying the incoming `PlaybackState` title/artist/album onto `MusicManager`. During rapid track changes, lyrics lookup could still use the previous track metadata and keep showing stale lyrics.

## Impact

- reduces stale-lyrics carryover when switching tracks quickly
- keeps the fix narrowly scoped to the lyrics timing path

## Validation

- `ruby scripts/check_lyrics_metadata_order.rb`

## Notes

- I did not run the app/UI test target on this machine because network issues prevented downloading a complete Xcode installation.
- The added `scripts/check_lyrics_metadata_order.rb` file is only a lightweight regression/test script for this fix. It can be removed after verification or after merge if you prefer not to keep it in the repository.

Thank u : )


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved music playback updates so track metadata refreshes sooner, helping titles, artists, and albums stay accurate during fast song changes.
  * Reduced the chance of stale lyrics appearing when switching tracks quickly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->