### PR TITLE
Atoll: Fix Readability Issues in Light Mode

### DIFF
--- a/DynamicIsland/components/Live activities/DynamicIslandBattery.swift
+++ b/DynamicIsland/components/Live activities/DynamicIslandBattery.swift
@@ -227,7 +227,6 @@ struct BatteryMenuView: View {
     var onDismiss: () -> Void
 
     @Environment(\.openURL) private var openURL
-    @Environment(\.colorScheme) private var colorScheme
 
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {

--- a/DynamicIsland/components/Live activities/DynamicIslandBattery.swift
+++ b/DynamicIsland/components/Live activities/DynamicIslandBattery.swift
@@ -227,6 +227,7 @@ struct BatteryMenuView: View {
     var onDismiss: () -> Void
 
     @Environment(\.openURL) private var openURL
+    @Environment(\.colorScheme) private var colorScheme
 
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
@@ -274,7 +275,7 @@ struct BatteryMenuView: View {
             }
             .padding(.vertical, 8)
 
-            Divider().background(Color.white)
+            Divider()
 
             Button(action: openBatteryPreferences) {
                 Label("Battery Settings", systemImage: "gearshape")
@@ -286,7 +287,7 @@ struct BatteryMenuView: View {
         }
         .padding()
         .frame(width: 280)
-        .foregroundColor(.white)
+        .foregroundStyle(.primary)
     }
 
     private func openBatteryPreferences() {

--- a/DynamicIsland/components/Notch/NotchLLMUsageView.swift
+++ b/DynamicIsland/components/Notch/NotchLLMUsageView.swift
@@ -31,6 +31,7 @@ struct NotchLLMUsageView: View {
             }
         }
         .padding(.horizontal, 8)
+        .environment(\.colorScheme, .dark)
         .onAppear { manager.refreshAll() }
     }
 

--- a/DynamicIsland/components/Notch/NotchNotesView.swift
+++ b/DynamicIsland/components/Notch/NotchNotesView.swift
@@ -773,6 +773,7 @@ struct NoteListView: View {
                             TextField("Search notes...", text: $searchText)
                                 .textFieldStyle(.plain)
                                 .font(.system(size: 12))
+                                .foregroundStyle(.white)
                             if !searchText.isEmpty {
                                 Button(action: { searchText = "" }) {
                                     Image(systemName: "xmark.circle.fill")
@@ -1112,6 +1113,7 @@ struct NoteEditorView: View {
                 TextField("Title", text: $title)
                     .font(.system(size: 17, weight: .bold, design: .rounded))
                     .textFieldStyle(.plain)
+                    .foregroundStyle(.white)
                 
                 Spacer()
                 
@@ -1153,7 +1155,7 @@ struct NoteEditorView: View {
                 if content.isEmpty { // Placeholder
                     Text("Start typing...")
                         .font(.system(size: 13, design: .rounded)) // Reduced from 14
-                        .foregroundStyle(.secondary.opacity(0.5))
+                        .foregroundStyle(.white.opacity(0.5))
                         .padding(.top, 10)
                         .padding(.leading, 12)
                         .allowsHitTesting(false)

--- a/DynamicIsland/components/Notch/NotchTerminalView.swift
+++ b/DynamicIsland/components/Notch/NotchTerminalView.swift
@@ -88,6 +88,7 @@ struct NotchTerminalView: View {
     @Default(.enableTerminalFeature) var enableTerminalFeature
     @Default(.cornerRadiusScaling) var cornerRadiusScaling
     @Default(.enableMinimalisticUI) var enableMinimalisticUI
+    @Default(.terminalForegroundColor) var terminalForegroundColor
     @State private var suppressionToken = UUID()
     @State private var isSuppressing = false
 
@@ -125,12 +126,12 @@ struct NotchTerminalView: View {
                 // Terminal header bar
                 HStack {
                     Image(systemName: "apple.terminal")
-                        .foregroundStyle(.secondary)
+                        .foregroundStyle(terminalForegroundColor)
                         .font(.system(size: 11))
 
                     Text(terminalManager.terminalTitle)
                         .font(.system(size: 11, weight: .medium))
-                        .foregroundStyle(.secondary)
+                        .foregroundStyle(terminalForegroundColor)
                         .lineLimit(1)
 
                     Spacer()
@@ -141,7 +142,7 @@ struct NotchTerminalView: View {
                     } label: {
                         Image(systemName: "arrow.counterclockwise")
                             .font(.system(size: 10))
-                            .foregroundStyle(.secondary)
+                            .foregroundStyle(terminalForegroundColor)
                     }
                     .buttonStyle(.plain)
                     .help("Restart shell")


### PR DESCRIPTION
- Fixes refresh button in light theme going invisible

Closes https://github.com/Ebullioscopic/Atoll/issues/571

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the terminal header (icon, title, and restart button) to reflect the configured terminal foreground color.
  * Improved battery menu theming by using theme-aware foreground colors and removing a hard-coded divider background.
  * Standardized the LLM usage view appearance by forcing a dark color scheme.
  * Refined notes UI text and placeholder colors with clearer white-based foreground styling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->