### PR TITLE
ci: stop pricing workflow from running on org mirror

### DIFF
--- a/.github/workflows/update-pricing.yml
+++ b/.github/workflows/update-pricing.yml
@@ -11,6 +11,7 @@ permissions:
 jobs:
   update-pricing:
     runs-on: ubuntu-latest
+    if: github.repository == 'Ebullioscopic/Atoll'
 
     steps:
       - name: Generate GitHub App token


### PR DESCRIPTION
The `Update LLM Pricing Data` workflow commits directly to `main`, which diverges the org mirror (`Atoll-Labs/Atoll`) and causes the mirror-release push to be rejected with `fetch first`.

This adds a `github.repository == 'Ebullioscopic/Atoll'` guard so the pricing job only runs on the source repo and never on forks/mirrors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Restricted the pricing update workflow to run only in the intended repository.
  * No changes were made to pricing update steps or commit behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->