### PR TITLE
Atoll: Refactor bookmark resolution to async with caching

### DIFF
--- a/DynamicIsland/components/Shelf/Models/Bookmark.swift
+++ b/DynamicIsland/components/Shelf/Models/Bookmark.swift
@@ -48,6 +48,33 @@ struct Bookmark: Sendable, Equatable, Codable {
         }
     }
 
+    func resolveAsync() async -> (url: URL?, refreshedData: Data?) {
+        guard !data.isEmpty else { return (nil, nil) }
+        return await Task.detached(priority: .userInitiated) { [data] in
+            var isStale = false
+            do {
+                let url = try URL(
+                    resolvingBookmarkData: data,
+                    options: [.withSecurityScope],
+                    relativeTo: nil,
+                    bookmarkDataIsStale: &isStale
+                )
+                if isStale, let newData = try? url.bookmarkData(options: [.withSecurityScope]) {
+                    NSLog("⚠️ Bookmark was stale for \(url.path), refreshed")
+                    return (url, newData)
+                }
+                return (url, nil)
+            } catch {
+                NSLog("❌ Failed to resolve bookmark asynchronously: \(error.localizedDescription)")
+                return (nil, nil)
+            }
+        }.value
+    }
+
+    func resolveURL() -> URL? {
+        return resolve().url
+    }
+
     func resolve() -> (url: URL?, refreshedData: Data?) {
         guard !data.isEmpty else { return (nil, nil) }
         var isStale = false
@@ -69,22 +96,8 @@ struct Bookmark: Sendable, Equatable, Codable {
         }
     }
 
-    func resolveURL() -> URL? {
-        return resolve().url
-    }
-
-    var refreshedData: Data? {
-        return resolve().refreshedData
-    }
-    
-    static func update(in items: inout [ShelfItem], for item: ShelfItem, newBookmark: Data) {
-        guard let idx = items.firstIndex(where: { $0.id == item.id }) else { return }
-        guard case .file = items[idx].kind else { return }
-        items[idx].kind = ShelfItemKind.file(bookmark: newBookmark)
-    }
-
     func validate() async -> Bool {
-        let (url, _) = resolve()
+        let (url, _) = await resolveAsync()
         guard let url = url else { return false }
         return url.accessSecurityScopedResource { url in
             FileManager.default.fileExists(atPath: url.path)
@@ -104,6 +117,12 @@ struct Bookmark: Sendable, Equatable, Codable {
         guard let url = url else { return nil }
         return try url.accessSecurityScopedResource { url in
             try block(url)
+        }
+    }
+
+    func invalidate() {
+        if let url = resolveURL() {
+            url.stopAccessingSecurityScopedResource()
         }
     }
 }

--- a/DynamicIsland/components/Shelf/Models/Bookmark.swift
+++ b/DynamicIsland/components/Shelf/Models/Bookmark.swift
@@ -119,10 +119,4 @@ struct Bookmark: Sendable, Equatable, Codable {
             try block(url)
         }
     }
-
-    func invalidate() {
-        if let url = resolveURL() {
-            url.stopAccessingSecurityScopedResource()
-        }
-    }
 }

--- a/DynamicIsland/components/Shelf/Models/ShelfItem.swift
+++ b/DynamicIsland/components/Shelf/Models/ShelfItem.swift
@@ -207,7 +207,7 @@ struct ShelfItem: Identifiable, Codable, Equatable, Sendable {
     func cleanupStoredData() {
         // Only resolve bookmark for temporary items - persisted items don't need cleanup
         guard isTemporary, case let .file(bookmark) = kind,
-              let context = resolvedContext(for: bookmark) else { return }
+              let context = resolvedContextSync(for: bookmark) else { return }
         
         let url = context.url
         
@@ -253,7 +253,7 @@ extension ShelfItem {
     var identityKey: String {
         switch kind {
         case .file(let bookmark):
-            if let url = resolvedContext(for: bookmark)?.url {
+            if let url = resolvedContextSync(for: bookmark)?.url {
                 return "file://" + url.standardizedFileURL.path
             }
             return "file://missing/" + bookmark.base64EncodedString()
@@ -280,12 +280,24 @@ private extension ShelfItemKind {
 }
 
 private extension ShelfItem {
-    func resolvedContext(for bookmarkData: Data) -> (url: URL, bookmark: Data)? {
+    func resolvedContext(for bookmarkData: Data) async -> (url: URL, bookmark: Data)? {
         let bookmark = Bookmark(data: bookmarkData)
-        let result = bookmark.resolve()
+        let result = await bookmark.resolveAsync()
         if let url = result.url {
             return (url, result.refreshedData ?? bookmarkData)
         }
         return nil
+    }
+
+    // Sync wrapper for backward compatibility
+    func resolvedContextSync(for bookmarkData: Data) -> (url: URL, bookmark: Data)? {
+        let semaphore = DispatchSemaphore(value: 0)
+        var result: (url: URL, bookmark: Data)?
+        Task.detached {
+            result = await resolvedContext(for: bookmarkData)
+            semaphore.signal()
+        }
+        _ = semaphore.wait(timeout: .now() + 5.0)
+        return result
     }
 }

--- a/DynamicIsland/components/Shelf/Models/ShelfItem.swift
+++ b/DynamicIsland/components/Shelf/Models/ShelfItem.swift
@@ -142,44 +142,47 @@ struct ShelfItem: Identifiable, Codable, Equatable, Sendable {
         let (url, _) = await bookmark.resolveAsync()
         guard let resolvedURL = url else { return "" }
         
-        if resolvedURL.pathExtension.lowercased() == "json" && resolvedURL.path.contains("TextBlocks") {
-            do {
-                let data = try Data(contentsOf: resolvedURL)
-                let decoder = JSONDecoder()
-                decoder.dateDecodingStrategy = .iso8601
-                struct TextBlockData: Codable {
-                    let content: String
-                    let title: String?
-                    var displayTitle: String {
-                        if let title = title, !title.isEmpty {
-                            return title
+        // Perform file I/O off the main actor
+        return await Task.detached { [resolvedURL] in
+            if resolvedURL.pathExtension.lowercased() == "json" && resolvedURL.path.contains("TextBlocks") {
+                do {
+                    let data = try Data(contentsOf: resolvedURL)
+                    let decoder = JSONDecoder()
+                    decoder.dateDecodingStrategy = .iso8601
+                    struct TextBlockData: Codable {
+                        let content: String
+                        let title: String?
+                        var displayTitle: String {
+                            if let title = title, !title.isEmpty {
+                                return title
+                            }
+                            let firstLine = content.components(separatedBy: .newlines).first ?? content
+                            if firstLine.count > 50 {
+                                return String(firstLine.prefix(47)) + "..."
+                            }
+                            return firstLine
                         }
-                        let firstLine = content.components(separatedBy: .newlines).first ?? content
-                        if firstLine.count > 50 {
-                            return String(firstLine.prefix(47)) + "..."
-                        }
-                        return firstLine
                     }
+                    if let textData = try? decoder.decode(TextBlockData.self, from: data) {
+                        return textData.displayTitle
+                    }
+                } catch {
+                    // Fall through
                 }
-                if let textData = try? decoder.decode(TextBlockData.self, from: data) {
-                    return textData.displayTitle
+            } else if resolvedURL.pathExtension.lowercased() == "webloc" && resolvedURL.path.contains("WebLocs") {
+                do {
+                    let data = try Data(contentsOf: resolvedURL)
+                    if let plist = try PropertyListSerialization.propertyList(from: data, format: nil) as? [String: Any],
+                       let urlString = plist["URL"] as? String {
+                        let title = plist["Title"] as? String
+                        return title ?? urlString
+                    }
+                } catch {
+                    // Fall through
                 }
-            } catch {
-                // Fall through
             }
-        } else if resolvedURL.pathExtension.lowercased() == "webloc" && resolvedURL.path.contains("WebLocs") {
-            do {
-                let data = try Data(contentsOf: resolvedURL)
-                if let plist = try PropertyListSerialization.propertyList(from: data, format: nil) as? [String: Any],
-                   let urlString = plist["URL"] as? String {
-                    let title = plist["Title"] as? String
-                    return title ?? urlString
-                }
-            } catch {
-                // Fall through
-            }
-        }
-        return (try? resolvedURL.resourceValues(forKeys: [.localizedNameKey]).localizedName) ?? resolvedURL.lastPathComponent
+            return (try? resolvedURL.resourceValues(forKeys: [.localizedNameKey]).localizedName) ?? resolvedURL.lastPathComponent
+        }.value
     }
     
     func loadIcon() async -> NSImage {
@@ -191,23 +194,25 @@ struct ShelfItem: Identifiable, Codable, Equatable, Sendable {
         }
         let bookmark = Bookmark(data: bookmarkData)
         let (url, _) = await bookmark.resolveAsync()
-        if let resolvedURL = url {
-            return NSWorkspace.shared.icon(forFile: resolvedURL.path)
+        guard let resolvedURL = url else {
+            return NSWorkspace.shared.icon(forFileType: "public.item")
         }
-        return NSWorkspace.shared.icon(forFileType: "public.item")
+        
+        // Perform icon loading off the main actor
+        return await Task.detached { [resolvedURL] in
+            return NSWorkspace.shared.icon(forFile: resolvedURL.path)
+        }.value
     }
 
     func cleanupStoredData() {
-        guard case let .file(bookmark) = kind,
+        // Only resolve bookmark for temporary items - persisted items don't need cleanup
+        guard isTemporary, case let .file(bookmark) = kind,
               let context = resolvedContext(for: bookmark) else { return }
         
         let url = context.url
         
         // Handle temporary files
-        if isTemporary {
-            TemporaryFileStorageService.shared.removeTemporaryFileIfNeeded(at: url)
-            return
-        }
+        TemporaryFileStorageService.shared.removeTemporaryFileIfNeeded(at: url)
     }
 }
 

--- a/DynamicIsland/components/Shelf/Models/ShelfItem.swift
+++ b/DynamicIsland/components/Shelf/Models/ShelfItem.swift
@@ -68,57 +68,26 @@ struct ShelfItem: Identifiable, Codable, Equatable, Sendable {
     let id: UUID
     var kind: ShelfItemKind
     var isTemporary: Bool
-    init(id: UUID = UUID(), kind: ShelfItemKind, isTemporary: Bool = false) {
+    // Cached display name and icon to avoid blocking on bookmark resolution
+    var cachedDisplayName: String?
+    var cachedIconData: Data?
+    init(id: UUID = UUID(), kind: ShelfItemKind, isTemporary: Bool = false, cachedDisplayName: String? = nil, cachedIconData: Data? = nil) {
         self.id = id
         self.kind = kind
         self.isTemporary = isTemporary
+        self.cachedDisplayName = cachedDisplayName
+        self.cachedIconData = cachedIconData
     }
     
     var displayName: String {
         switch kind {
         case .file(let bookmarkData):
-            let bookmark = Bookmark(data: bookmarkData)
-            guard let resolvedURL = bookmark.resolveURL() else { return "" }
-            
-            // Check for stored data files (text blocks, weblocs, etc.) to provide friendly names
-            if resolvedURL.pathExtension.lowercased() == "json" && resolvedURL.path.contains("TextBlocks") {
-                do {
-                    let data = try Data(contentsOf: resolvedURL)
-                    let decoder = JSONDecoder()
-                    decoder.dateDecodingStrategy = .iso8601
-                    struct TextBlockData: Codable {
-                        let content: String
-                        let title: String?
-                        var displayTitle: String {
-                            if let title = title, !title.isEmpty {
-                                return title
-                            }
-                            let firstLine = content.components(separatedBy: .newlines).first ?? content
-                            if firstLine.count > 50 {
-                                return String(firstLine.prefix(47)) + "..."
-                            }
-                            return firstLine
-                        }
-                    }
-                    if let textData = try? decoder.decode(TextBlockData.self, from: data) {
-                        return textData.displayTitle
-                    }
-                } catch {
-                    // Fall through to default naming
-                }
-            } else if resolvedURL.pathExtension.lowercased() == "webloc" && resolvedURL.path.contains("WebLocs") {
-                do {
-                    let data = try Data(contentsOf: resolvedURL)
-                    if let plist = try PropertyListSerialization.propertyList(from: data, format: nil) as? [String: Any],
-                       let urlString = plist["URL"] as? String {
-                        let title = plist["Title"] as? String
-                        return title ?? urlString
-                    }
-                } catch {
-                    // Fall through to default naming
-                }
+            if let cached = cachedDisplayName, !cached.isEmpty {
+                return cached
             }
-            return (try? resolvedURL.resourceValues(forKeys: [.localizedNameKey]).localizedName) ?? resolvedURL.lastPathComponent
+            // No synchronous fallback - return empty string if not cached
+            // Async resolution should be done via loadDisplayName()
+            return ""
         case .text(let string):
             return string.trimmingCharacters(in: .whitespacesAndNewlines)
         case .link(let url):
@@ -135,25 +104,98 @@ struct ShelfItem: Identifiable, Codable, Equatable, Sendable {
     
     var fileURL: URL? {
         guard case .file = kind else { return nil }
-        return ShelfStateViewModel.shared.resolveFileURL(for: self)
+        // Don't resolve synchronously - use async method from ShelfStateViewModel
+        return nil
     }
     
     var URL: URL? {
-        if case let .file(bookmark) = kind { return resolvedContext(for: bookmark)?.url }
-        else if case let .link(url) = kind { return url }
-        else { return nil }
+        if case let .file(bookmark) = kind { 
+            // Don't resolve synchronously
+            return nil
+        } else if case let .link(url) = kind { 
+            return url 
+        } else { 
+            return nil 
+        }
     }
     
     var icon: NSImage {
+        if let cachedData = cachedIconData, let cachedImage = NSImage(data: cachedData) {
+            return cachedImage
+        }
         guard case .file = kind else {
             return Self.thumbnailSymbolImage(systemName: kind.iconSymbolName) ?? NSImage()
         }
-        if let resolvedURL = ShelfStateViewModel.shared.resolveFileURL(for: self) {
-            return NSWorkspace.shared.icon(forFile: resolvedURL.path)
-        }
-        return NSImage()
+        // Return generic file icon instead of blocking on bookmark resolution
+        return NSWorkspace.shared.icon(forFileType: "public.item")
     }
     
+    // Async methods to load display name and icon without blocking
+    func loadDisplayName() async -> String {
+        // If we have a cached name, return it
+        if let cached = cachedDisplayName, !cached.isEmpty {
+            return cached
+        }
+        // Otherwise try to resolve asynchronously
+        guard case .file(let bookmarkData) = kind else { return displayName }
+        let bookmark = Bookmark(data: bookmarkData)
+        let (url, _) = await bookmark.resolveAsync()
+        guard let resolvedURL = url else { return "" }
+        
+        if resolvedURL.pathExtension.lowercased() == "json" && resolvedURL.path.contains("TextBlocks") {
+            do {
+                let data = try Data(contentsOf: resolvedURL)
+                let decoder = JSONDecoder()
+                decoder.dateDecodingStrategy = .iso8601
+                struct TextBlockData: Codable {
+                    let content: String
+                    let title: String?
+                    var displayTitle: String {
+                        if let title = title, !title.isEmpty {
+                            return title
+                        }
+                        let firstLine = content.components(separatedBy: .newlines).first ?? content
+                        if firstLine.count > 50 {
+                            return String(firstLine.prefix(47)) + "..."
+                        }
+                        return firstLine
+                    }
+                }
+                if let textData = try? decoder.decode(TextBlockData.self, from: data) {
+                    return textData.displayTitle
+                }
+            } catch {
+                // Fall through
+            }
+        } else if resolvedURL.pathExtension.lowercased() == "webloc" && resolvedURL.path.contains("WebLocs") {
+            do {
+                let data = try Data(contentsOf: resolvedURL)
+                if let plist = try PropertyListSerialization.propertyList(from: data, format: nil) as? [String: Any],
+                   let urlString = plist["URL"] as? String {
+                    let title = plist["Title"] as? String
+                    return title ?? urlString
+                }
+            } catch {
+                // Fall through
+            }
+        }
+        return (try? resolvedURL.resourceValues(forKeys: [.localizedNameKey]).localizedName) ?? resolvedURL.lastPathComponent
+    }
+    
+    func loadIcon() async -> NSImage {
+        if let cachedData = cachedIconData, let cachedImage = NSImage(data: cachedData) {
+            return cachedImage
+        }
+        guard case .file(let bookmarkData) = kind else {
+            return Self.thumbnailSymbolImage(systemName: kind.iconSymbolName) ?? NSImage()
+        }
+        let bookmark = Bookmark(data: bookmarkData)
+        let (url, _) = await bookmark.resolveAsync()
+        if let resolvedURL = url {
+            return NSWorkspace.shared.icon(forFile: resolvedURL.path)
+        }
+        return NSWorkspace.shared.icon(forFileType: "public.item")
+    }
 
     func cleanupStoredData() {
         guard case let .file(bookmark) = kind,
@@ -235,8 +277,9 @@ private extension ShelfItemKind {
 private extension ShelfItem {
     func resolvedContext(for bookmarkData: Data) -> (url: URL, bookmark: Data)? {
         let bookmark = Bookmark(data: bookmarkData)
-        if let url = bookmark.resolveURL() {
-            return (url, bookmark.refreshedData ?? bookmarkData)
+        let result = bookmark.resolve()
+        if let url = result.url {
+            return (url, result.refreshedData ?? bookmarkData)
         }
         return nil
     }

--- a/DynamicIsland/components/Shelf/Services/QuickShareService.swift
+++ b/DynamicIsland/components/Shelf/Services/QuickShareService.swift
@@ -305,14 +305,8 @@ private class SharingServiceDelegate: NSObject {}
     }
 
     private func resolveShelfItemBookmark(for fileURL: URL) async -> URL? {
-        let items = await ShelfStateViewModel.shared.items
-
-        for itm in items {
-            if let resolved = await ShelfStateViewModel.shared.resolveAndUpdateBookmarkAsync(for: itm) {
-                if resolved.standardizedFileURL.path == fileURL.standardizedFileURL.path {
-                    return resolved
-                }
-            }
+        if let item = await ShelfStateViewModel.shared.findItem(by: fileURL) {
+            return await ShelfStateViewModel.shared.resolveAndUpdateBookmarkAsync(for: item)
         }
         print("❌ Failed to resolve bookmark for shelf item")
         return nil

--- a/DynamicIsland/components/Shelf/Services/QuickShareService.swift
+++ b/DynamicIsland/components/Shelf/Services/QuickShareService.swift
@@ -308,7 +308,7 @@ private class SharingServiceDelegate: NSObject {}
         let items = await ShelfStateViewModel.shared.items
 
         for itm in items {
-            if let resolved = await ShelfStateViewModel.shared.resolveAndUpdateBookmark(for: itm) {
+            if let resolved = await ShelfStateViewModel.shared.resolveAndUpdateBookmarkAsync(for: itm) {
                 if resolved.standardizedFileURL.path == fileURL.standardizedFileURL.path {
                     return resolved
                 }

--- a/DynamicIsland/components/Shelf/ViewModels/ShelfItemViewModel.swift
+++ b/DynamicIsland/components/Shelf/ViewModels/ShelfItemViewModel.swift
@@ -45,33 +45,87 @@ final class ShelfItemViewModel: ObservableObject {
 
     init(item: ShelfItem) {
         self.item = item
-        self.displayName = ""  // Will be loaded asynchronously
-        self.icon = nil        // Will be loaded asynchronously
-        Task { await loadThumbnail() }
-        Task { await loadDisplayName() }
-        Task { await loadIcon() }
+        self.displayName = ""
+        self.icon = nil
+        Task { await loadMetadata() }
     }
 
     var isSelected: Bool { selection.isSelected(item.id) }
 
-    func loadDisplayName() async {
-        let name = await item.loadDisplayName()
-        await MainActor.run { self.displayName = name }
-    }
-
-    func loadIcon() async {
-        let image = await item.loadIcon()
-        await MainActor.run { self.icon = image }
-    }
-
-    func loadThumbnail() async {
+    // Single coordinated load: resolves bookmark once, populates all metadata
+    func loadMetadata() async {
         guard case .file(let bookmarkData) = item.kind else { return }
         let bookmark = Bookmark(data: bookmarkData)
         let (url, _) = await bookmark.resolveAsync()
         guard let resolvedURL = url else { return }
-        if let image = await ThumbnailService.shared.thumbnail(for: resolvedURL, size: CGSize(width: 56, height: 56)) {
-            self.thumbnail = image
+        
+        // Load display name
+        let name = await loadDisplayNameFromURL(resolvedURL)
+        await MainActor.run { self.displayName = name }
+        
+        // Load icon
+        let image = await loadIconFromURL(resolvedURL)
+        await MainActor.run { self.icon = image }
+        
+        // Load thumbnail
+        if let thumbnailImage = await ThumbnailService.shared.thumbnail(for: resolvedURL, size: CGSize(width: 56, height: 56)) {
+            await MainActor.run { self.thumbnail = thumbnailImage }
         }
+    }
+
+    func loadDisplayName() async {
+        guard case .file(let bookmarkData) = item.kind else { return }
+        let bookmark = Bookmark(data: bookmarkData)
+        let (url, _) = await bookmark.resolveAsync()
+        guard let resolvedURL = url else { return }
+        let name = await loadDisplayNameFromURL(resolvedURL)
+        await MainActor.run { self.displayName = name }
+    }
+
+    private func loadDisplayNameFromURL(_ url: URL) async -> String {
+        if url.pathExtension.lowercased() == "json" && url.path.contains("TextBlocks") {
+            do {
+                let data = try Data(contentsOf: url)
+                let decoder = JSONDecoder()
+                decoder.dateDecodingStrategy = .iso8601
+                struct TextBlockData: Codable {
+                    let content: String
+                    let title: String?
+                    var displayTitle: String {
+                        if let title = title, !title.isEmpty { return title }
+                        let firstLine = content.components(separatedBy: .newlines).first ?? content
+                        if firstLine.count > 50 { return String(firstLine.prefix(47)) + "..." }
+                        return firstLine
+                    }
+                }
+                if let textData = try? decoder.decode(TextBlockData.self, from: data) {
+                    return textData.displayTitle
+                }
+            } catch { /* fall through */ }
+        } else if url.pathExtension.lowercased() == "webloc" && url.path.contains("WebLocs") {
+            do {
+                let data = try Data(contentsOf: url)
+                if let plist = try PropertyListSerialization.propertyList(from: data, format: nil) as? [String: Any],
+                   let urlString = plist["URL"] as? String {
+                    let title = plist["Title"] as? String
+                    return title ?? urlString
+                }
+            } catch { /* fall through */ }
+        }
+        return (try? url.resourceValues(forKeys: [.localizedNameKey]).localizedName) ?? url.lastPathComponent
+    }
+
+    func loadIcon() async {
+        guard case .file(let bookmarkData) = item.kind else { return }
+        let bookmark = Bookmark(data: bookmarkData)
+        let (url, _) = await bookmark.resolveAsync()
+        guard let resolvedURL = url else { return }
+        let image = await loadIconFromURL(resolvedURL)
+        await MainActor.run { self.icon = image }
+    }
+
+    private func loadIconFromURL(_ url: URL) async -> NSImage {
+        return NSWorkspace.shared.icon(forFile: url.path)
     }
 
     // Async version to resolve file URL without blocking main thread
@@ -95,7 +149,16 @@ final class ShelfItemViewModel: ObservableObject {
         switch item.kind {
         case .file:
             let provider = NSItemProvider()
-            if let url = ShelfStateViewModel.shared.resolveAndUpdateBookmark(for: item) {
+            // Drag initiation needs synchronous URL - resolve on background thread with timeout
+            let semaphore = DispatchSemaphore(value: 0)
+            var resolvedURL: URL?
+            Task.detached { [item] in
+                resolvedURL = await ShelfStateViewModel.shared.resolveAndUpdateBookmarkAsync(for: item)
+                semaphore.signal()
+            }
+            _ = semaphore.wait(timeout: .now() + 5.0)
+            let url = resolvedURL
+            if let url = url {
                 provider.registerObject(url as NSURL, visibility: .all)
             } else {
                 provider.registerObject(item.displayName as NSString, visibility: .all)
@@ -115,7 +178,15 @@ final class ShelfItemViewModel: ObservableObject {
         for item in items {
             switch item.kind {
             case .file:
-                if let url = ShelfStateViewModel.shared.resolveAndUpdateBookmark(for: item) {
+                let semaphore = DispatchSemaphore(value: 0)
+                var resolvedURL: URL?
+                Task.detached { [item] in
+                    resolvedURL = await ShelfStateViewModel.shared.resolveAndUpdateBookmarkAsync(for: item)
+                    semaphore.signal()
+                }
+                _ = semaphore.wait(timeout: .now() + 5.0)
+                let url = resolvedURL
+                if let url = url {
                     urls.append(url)
                 } else {
                     textItems.append(item.displayName)
@@ -172,8 +243,8 @@ final class ShelfItemViewModel: ObservableObject {
                 for item in ShelfSelectionModel.shared.selectedItems(in: ShelfStateViewModel.shared.items) {
                     switch item.kind {
                     case .file:
-                        // Use immediate update for user-initiated share action
-                        if let url = ShelfStateViewModel.shared.resolveAndUpdateBookmark(for: item) {
+                        // Use async resolution for user-initiated share action
+                        if let url = await ShelfStateViewModel.shared.resolveAndUpdateBookmarkAsync(for: item) {
                             itemsToShare.append(url)
                             fileURLs.append(url)
                         }
@@ -528,8 +599,8 @@ final class ShelfItemViewModel: ObservableObject {
                 Task {
                     let urls = await selected.asyncCompactMap { item -> URL? in
                         if case .file = item.kind {
-                            // Use immediate update for user-initiated menu action
-                            return await ShelfStateViewModel.shared.resolveAndUpdateBookmark(for: item)
+                            // Use async resolution for user-initiated menu action
+                            return await ShelfStateViewModel.shared.resolveAndUpdateBookmarkAsync(for: item)
                         }
                         return nil
                     }
@@ -542,10 +613,20 @@ final class ShelfItemViewModel: ObservableObject {
 
             case "Copy Path":
                 let selected = ShelfSelectionModel.shared.selectedItems(in: ShelfStateViewModel.shared.items)
-                let paths = selected.compactMap { $0.fileURL?.path }
-                if !paths.isEmpty {
-                    NSPasteboard.general.clearContents()
-                    NSPasteboard.general.setString(paths.joined(separator: "\n"), forType: .string)
+                Task {
+                    let paths = await selected.asyncCompactMap { item -> String? in
+                        if case .file = item.kind,
+                           let url = await ShelfStateViewModel.shared.resolveFileURLAsync(for: item) {
+                            return url.path
+                        }
+                        return nil
+                    }
+                    if !paths.isEmpty {
+                        await MainActor.run {
+                            NSPasteboard.general.clearContents()
+                            NSPasteboard.general.setString(paths.joined(separator: "\n"), forType: .string)
+                        }
+                    }
                 }
 
             case "Copy":
@@ -562,7 +643,7 @@ final class ShelfItemViewModel: ObservableObject {
                 Task {
                     let fileURLs = await selected.asyncCompactMap { item -> URL? in
                         if case .file = item.kind {
-                            return ShelfStateViewModel.shared.resolveAndUpdateBookmark(for: item)
+                            return await ShelfStateViewModel.shared.resolveAndUpdateBookmarkAsync(for: item)
                         }
                         return nil
                     }

--- a/DynamicIsland/components/Shelf/ViewModels/ShelfItemViewModel.swift
+++ b/DynamicIsland/components/Shelf/ViewModels/ShelfItemViewModel.swift
@@ -138,7 +138,7 @@ final class ShelfItemViewModel: ObservableObject {
 
     // MARK: - Drag & Drop helpers
     func dragItemProvider() -> NSItemProvider {
-    let selectedItems = selection.selectedItems(in: ShelfStateViewModel.shared.items)
+        let selectedItems = selection.selectedItems(in: ShelfStateViewModel.shared.items)
         if selectedItems.count > 1 && selectedItems.contains(where: { $0.id == item.id }) {
             return createMultiItemProvider(for: selectedItems)
         }
@@ -149,20 +149,23 @@ final class ShelfItemViewModel: ObservableObject {
         switch item.kind {
         case .file:
             let provider = NSItemProvider()
-            // Drag initiation needs synchronous URL - resolve on background thread with timeout
-            let semaphore = DispatchSemaphore(value: 0)
-            var resolvedURL: URL?
-            Task.detached { [item] in
-                resolvedURL = await ShelfStateViewModel.shared.resolveAndUpdateBookmarkAsync(for: item)
-                semaphore.signal()
+            // Use registerFileRepresentation with async load handler
+            provider.registerFileRepresentation(forTypeIdentifier: UTType.fileURL.identifier, fileOptions: [], visibility: .all) { completion in
+                // This is called on a background thread - we can do async work
+                Task {
+                    let url = await ShelfStateViewModel.shared.resolveAndUpdateBookmarkAsync(for: item)
+                    if let url = url {
+                        _ = url.startAccessingSecurityScopedResource()
+                        completion(url, true, nil)
+                    } else {
+                        completion(nil, false, nil)
+                    }
+                }
+                // Return nil progress - completion will be called async
+                return nil
             }
-            _ = semaphore.wait(timeout: .now() + 5.0)
-            let url = resolvedURL
-            if let url = url {
-                provider.registerObject(url as NSURL, visibility: .all)
-            } else {
-                provider.registerObject(item.displayName as NSString, visibility: .all)
-            }
+            // Fallback: also register display name as plain text
+            provider.registerObject(item.displayName as NSString, visibility: .all)
             return provider
         case .text(let string):
             return NSItemProvider(object: string as NSString)
@@ -173,35 +176,38 @@ final class ShelfItemViewModel: ObservableObject {
 
     private func createMultiItemProvider(for items: [ShelfItem]) -> NSItemProvider {
         let provider = NSItemProvider()
-        var urls: [URL] = []
         var textItems: [String] = []
+        var fileItems: [ShelfItem] = []
+        
         for item in items {
             switch item.kind {
             case .file:
-                let semaphore = DispatchSemaphore(value: 0)
-                var resolvedURL: URL?
-                Task.detached { [item] in
-                    resolvedURL = await ShelfStateViewModel.shared.resolveAndUpdateBookmarkAsync(for: item)
-                    semaphore.signal()
-                }
-                _ = semaphore.wait(timeout: .now() + 5.0)
-                let url = resolvedURL
-                if let url = url {
-                    urls.append(url)
-                } else {
-                    textItems.append(item.displayName)
-                }
+                fileItems.append(item)
             case .text(let string):
                 textItems.append(string)
             case .link:
                 break
             }
         }
-        if !urls.isEmpty {
-            for url in urls {
-                provider.registerObject(url as NSURL, visibility: .all)
+        
+        // Register file representations with lazy loading
+        if !fileItems.isEmpty {
+            for fileItem in fileItems {
+                provider.registerFileRepresentation(forTypeIdentifier: UTType.fileURL.identifier, fileOptions: [], visibility: .all) { completion in
+                    Task {
+                        let url = await ShelfStateViewModel.shared.resolveAndUpdateBookmarkAsync(for: fileItem)
+                        if let url = url {
+                            _ = url.startAccessingSecurityScopedResource()
+                            completion(url, true, nil)
+                        } else {
+                            completion(nil, false, nil)
+                        }
+                    }
+                    return nil
+                }
             }
         }
+        
         if !textItems.isEmpty {
             provider.registerObject(textItems.joined(separator: "\n") as NSString, visibility: .all)
         }

--- a/DynamicIsland/components/Shelf/ViewModels/ShelfItemViewModel.swift
+++ b/DynamicIsland/components/Shelf/ViewModels/ShelfItemViewModel.swift
@@ -31,6 +31,8 @@ import ObjectiveC
 final class ShelfItemViewModel: ObservableObject {
     @Published private(set) var item: ShelfItem
     @Published var thumbnail: NSImage?
+    @Published var displayName: String = ""
+    @Published var icon: NSImage?
     @Published var isDropTargeted: Bool = false
     @Published var isRenaming: Bool = false
     @Published var draftTitle: String = ""
@@ -43,17 +45,41 @@ final class ShelfItemViewModel: ObservableObject {
 
     init(item: ShelfItem) {
         self.item = item
-        self.draftTitle = item.displayName
+        self.displayName = ""  // Will be loaded asynchronously
+        self.icon = nil        // Will be loaded asynchronously
         Task { await loadThumbnail() }
+        Task { await loadDisplayName() }
+        Task { await loadIcon() }
     }
 
     var isSelected: Bool { selection.isSelected(item.id) }
 
+    func loadDisplayName() async {
+        let name = await item.loadDisplayName()
+        await MainActor.run { self.displayName = name }
+    }
+
+    func loadIcon() async {
+        let image = await item.loadIcon()
+        await MainActor.run { self.icon = image }
+    }
+
     func loadThumbnail() async {
-        guard let url = item.fileURL else { return }
-        if let image = await ThumbnailService.shared.thumbnail(for: url, size: CGSize(width: 56, height: 56)) {
+        guard case .file(let bookmarkData) = item.kind else { return }
+        let bookmark = Bookmark(data: bookmarkData)
+        let (url, _) = await bookmark.resolveAsync()
+        guard let resolvedURL = url else { return }
+        if let image = await ThumbnailService.shared.thumbnail(for: resolvedURL, size: CGSize(width: 56, height: 56)) {
             self.thumbnail = image
         }
+    }
+
+    // Async version to resolve file URL without blocking main thread
+    func resolveFileURL() async -> URL? {
+        guard case .file(let bookmarkData) = item.kind else { return nil }
+        let bookmark = Bookmark(data: bookmarkData)
+        let (url, _) = await bookmark.resolveAsync()
+        return url
     }
 
     // MARK: - Drag & Drop helpers

--- a/DynamicIsland/components/Shelf/ViewModels/ShelfStateViewModel.swift
+++ b/DynamicIsland/components/Shelf/ViewModels/ShelfStateViewModel.swift
@@ -167,30 +167,46 @@ final class ShelfStateViewModel: ObservableObject {
     }
 
     // Find item by URL using cached mapping (avoids resolving all bookmarks)
-    func findItem(by url: URL) -> ShelfItem? {
+    func findItem(by url: URL) async -> ShelfItem? {
         let path = url.standardizedFileURL.path
         if urlCacheInvalidated {
-            rebuildURLCache()
+            await rebuildURLCache()
         }
         if let itemID = urlToItemCache[path],
            let idx = items.firstIndex(where: { $0.id == itemID }) {
             return items[idx]
         }
-        // Fallback: sync resolution for cache miss
-        return items.first { itm in
+        // Fallback: async resolution for cache miss
+        for itm in items {
             if case .file = itm.kind {
-                return resolveFileURL(for: itm)?.standardizedFileURL.path == path
+                if let resolved = await resolveFileURLAsync(for: itm),
+                   resolved.standardizedFileURL.path == path {
+                    return itm
+                }
             }
-            return false
         }
+        return nil
+    }
+
+    // Sync wrapper for backward compatibility
+    func findItemSync(by url: URL) -> ShelfItem? {
+        let semaphore = DispatchSemaphore(value: 0)
+        var result: ShelfItem?
+        Task.detached { [weak self] in
+            guard let self = self else { return }
+            result = await self.findItem(by: url)
+            semaphore.signal()
+        }
+        _ = semaphore.wait(timeout: .now() + 5.0)
+        return result
     }
     
-    private func rebuildURLCache() {
+    private func rebuildURLCache() async {
         urlToItemCache.removeAll()
         for item in items {
             if case .file(let bookmarkData) = item.kind {
                 let bookmark = Bookmark(data: bookmarkData)
-                let result = bookmark.resolve()
+                let result = await bookmark.resolveAsync()
                 if let url = result.url {
                     urlToItemCache[url.standardizedFileURL.path] = item.id
                 }
@@ -203,23 +219,25 @@ final class ShelfStateViewModel: ObservableObject {
         urlCacheInvalidated = true
     }
 
-    // Sync version for backward compatibility - uses synchronous bookmark resolution
-    func resolveFileURL(for item: ShelfItem) -> URL? {
-        guard case .file(let bookmarkData) = item.kind else { return nil }
-        let bookmark = Bookmark(data: bookmarkData)
-        let result = bookmark.resolve()
-        if let refreshed = result.refreshedData, refreshed != bookmarkData {
-            NSLog("Bookmark for \(item) stale; refreshing")
-            updateBookmark(for: item, bookmark: refreshed)
-        }
-        return result.url
-    }
-
-    func resolveFileURLs(for items: [ShelfItem]) -> [URL] {
+    // Async version - resolves file URLs without blocking
+    func resolveFileURLsAsync(for items: [ShelfItem]) async -> [URL] {
         var urls: [URL] = []
         for it in items {
-            if let u = resolveFileURL(for: it) { urls.append(u) }
+            if let u = await resolveFileURLAsync(for: it) { urls.append(u) }
         }
         return urls
+    }
+
+    // Sync wrapper for backward compatibility - resolves on background thread with timeout
+    func resolveFileURLs(for items: [ShelfItem]) -> [URL] {
+        let semaphore = DispatchSemaphore(value: 0)
+        var result: [URL] = []
+        Task.detached { [weak self] in
+            guard let self = self else { return }
+            result = await self.resolveFileURLsAsync(for: items)
+            semaphore.signal()
+        }
+        _ = semaphore.wait(timeout: .now() + 10.0)
+        return result
     }
 }

--- a/DynamicIsland/components/Shelf/ViewModels/ShelfStateViewModel.swift
+++ b/DynamicIsland/components/Shelf/ViewModels/ShelfStateViewModel.swift
@@ -135,7 +135,31 @@ final class ShelfStateViewModel: ObservableObject {
         }
     }
 
+    // Async version that resolves bookmark on background thread
+    func resolveFileURLAsync(for item: ShelfItem) async -> URL? {
+        guard case .file(let bookmarkData) = item.kind else { return nil }
+        let bookmark = Bookmark(data: bookmarkData)
+        let result = await bookmark.resolveAsync()
+        if let refreshed = result.refreshedData, refreshed != bookmarkData {
+            NSLog("Bookmark for \(item) stale; refreshing")
+            await MainActor.run { scheduleDeferredBookmarkUpdate(for: item, bookmark: refreshed) }
+        }
+        return result.url
+    }
 
+    // Async version for user-initiated actions
+    func resolveAndUpdateBookmarkAsync(for item: ShelfItem) async -> URL? {
+        guard case .file(let bookmarkData) = item.kind else { return nil }
+        let bookmark = Bookmark(data: bookmarkData)
+        let result = await bookmark.resolveAsync()
+        if let refreshed = result.refreshedData, refreshed != bookmarkData {
+            NSLog("Bookmark for \(item) stale; refreshing")
+            await MainActor.run { updateBookmark(for: item, bookmark: refreshed) }
+        }
+        return result.url
+    }
+
+    // Sync version for backward compatibility (used in drag operations, etc.) - but uses background resolution
     func resolveFileURL(for item: ShelfItem) -> URL? {
         guard case .file(let bookmarkData) = item.kind else { return nil }
         let bookmark = Bookmark(data: bookmarkData)

--- a/DynamicIsland/components/Shelf/ViewModels/ShelfStateViewModel.swift
+++ b/DynamicIsland/components/Shelf/ViewModels/ShelfStateViewModel.swift
@@ -159,7 +159,7 @@ final class ShelfStateViewModel: ObservableObject {
         return result.url
     }
 
-    // Sync version for backward compatibility (used in drag operations, etc.) - but uses background resolution
+    // Sync version for backward compatibility - uses synchronous bookmark resolution (blocks calling thread)
     func resolveFileURL(for item: ShelfItem) -> URL? {
         guard case .file(let bookmarkData) = item.kind else { return nil }
         let bookmark = Bookmark(data: bookmarkData)

--- a/DynamicIsland/components/Shelf/ViewModels/ShelfStateViewModel.swift
+++ b/DynamicIsland/components/Shelf/ViewModels/ShelfStateViewModel.swift
@@ -41,6 +41,10 @@ final class ShelfStateViewModel: ObservableObject {
     // Queue for deferred bookmark updates to avoid publishing during view updates
     private var pendingBookmarkUpdates: [ShelfItem.ID: Data] = [:]
     private var updateTask: Task<Void, Never>?
+    
+    // Cache for URL-to-item mapping to avoid resolving all bookmarks for lookup
+    private var urlToItemCache: [String: ShelfItem.ID] = [:]
+    private var urlCacheInvalidated = true
 
     private init() {
         items = ShelfPersistenceService.shared.load()
@@ -62,6 +66,7 @@ final class ShelfStateViewModel: ObservableObject {
             }
         }
         items = merged
+        invalidateURLCache()
         if !addedIDs.isEmpty {
             ExtensionRPCServer.shared.notifyShelfItemsChanged(itemIDs: addedIDs, action: "added")
         }
@@ -70,6 +75,7 @@ final class ShelfStateViewModel: ObservableObject {
     func remove(_ item: ShelfItem) {
         item.cleanupStoredData()
         items.removeAll { $0.id == item.id }
+        invalidateURLCache()
         ExtensionRPCServer.shared.notifyShelfItemsChanged(itemIDs: [item.id.uuidString], action: "removed")
     }
 
@@ -78,6 +84,7 @@ final class ShelfStateViewModel: ObservableObject {
         if case .file = items[idx].kind {
             items[idx].kind = .file(bookmark: bookmark)
         }
+        invalidateURLCache()
     }
 
     private func scheduleDeferredBookmarkUpdate(for item: ShelfItem, bookmark: Data) {
@@ -159,19 +166,45 @@ final class ShelfStateViewModel: ObservableObject {
         return result.url
     }
 
-    // Sync version for backward compatibility - uses synchronous bookmark resolution (blocks calling thread)
-    func resolveFileURL(for item: ShelfItem) -> URL? {
-        guard case .file(let bookmarkData) = item.kind else { return nil }
-        let bookmark = Bookmark(data: bookmarkData)
-        let result = bookmark.resolve()
-        if let refreshed = result.refreshedData, refreshed != bookmarkData {
-            NSLog("Bookmark for \(item) stale; refreshing")
-            scheduleDeferredBookmarkUpdate(for: item, bookmark: refreshed)
+    // Find item by URL using cached mapping (avoids resolving all bookmarks)
+    func findItem(by url: URL) -> ShelfItem? {
+        let path = url.standardizedFileURL.path
+        if urlCacheInvalidated {
+            rebuildURLCache()
         }
-        return result.url
+        if let itemID = urlToItemCache[path],
+           let idx = items.firstIndex(where: { $0.id == itemID }) {
+            return items[idx]
+        }
+        // Fallback: sync resolution for cache miss
+        return items.first { itm in
+            if case .file = itm.kind {
+                return resolveFileURL(for: itm)?.standardizedFileURL.path == path
+            }
+            return false
+        }
+    }
+    
+    private func rebuildURLCache() {
+        urlToItemCache.removeAll()
+        for item in items {
+            if case .file(let bookmarkData) = item.kind {
+                let bookmark = Bookmark(data: bookmarkData)
+                let result = bookmark.resolve()
+                if let url = result.url {
+                    urlToItemCache[url.standardizedFileURL.path] = item.id
+                }
+            }
+        }
+        urlCacheInvalidated = false
+    }
+    
+    private func invalidateURLCache() {
+        urlCacheInvalidated = true
     }
 
-    func resolveAndUpdateBookmark(for item: ShelfItem) -> URL? {
+    // Sync version for backward compatibility - uses synchronous bookmark resolution
+    func resolveFileURL(for item: ShelfItem) -> URL? {
         guard case .file(let bookmarkData) = item.kind else { return nil }
         let bookmark = Bookmark(data: bookmarkData)
         let result = bookmark.resolve()

--- a/DynamicIsland/components/Shelf/Views/ShelfItemView.swift
+++ b/DynamicIsland/components/Shelf/Views/ShelfItemView.swift
@@ -87,11 +87,9 @@ struct ShelfItemView: View {
             }
         }
         .onAppear {
-            Task { 
-                await viewModel.loadThumbnail()
-                await viewModel.loadDisplayName()
-                await viewModel.loadIcon()
-                // Pre-render drag preview once on appear
+            // Metadata loading is now done in ViewModel.init via loadMetadata()
+            // Pre-render drag preview once on appear
+            Task {
                 if cachedPreviewImage == nil {
                     cachedPreviewImage = await renderDragPreview()
                 }
@@ -342,7 +340,16 @@ private struct DraggableClickHandler<Content: View>: NSViewRepresentable {
 
             switch item.kind {
             case .file:
-                guard let url = ShelfStateViewModel.shared.resolveAndUpdateBookmark(for: item) else {
+                // Resolve bookmark on background thread with timeout for drag initiation
+                let semaphore = DispatchSemaphore(value: 0)
+                var resolvedURL: URL?
+                Task.detached { [item] in
+                    resolvedURL = await ShelfStateViewModel.shared.resolveAndUpdateBookmarkAsync(for: item)
+                    semaphore.signal()
+                }
+                _ = semaphore.wait(timeout: .now() + 5.0)
+                
+                guard let url = resolvedURL else {
                     pasteboardItem.setString(item.displayName, forType: .string)
                     return pasteboardItem
                 }

--- a/DynamicIsland/components/Shelf/Views/ShelfItemView.swift
+++ b/DynamicIsland/components/Shelf/Views/ShelfItemView.swift
@@ -64,7 +64,7 @@ struct ShelfItemView: View {
                     viewModel: viewModel,
                     cachedPreviewImage: $cachedPreviewImage,
                     dragPreviewContent: {
-                        DragPreviewView(thumbnail: viewModel.thumbnail ?? item.icon, displayName: item.displayName)
+                        DragPreviewView(thumbnail: viewModel.thumbnail ?? viewModel.icon, displayName: viewModel.displayName)
                     },
                     onRightClick: viewModel.handleRightClick,
                     onClick: { event, nsview in
@@ -89,6 +89,8 @@ struct ShelfItemView: View {
         .onAppear {
             Task { 
                 await viewModel.loadThumbnail()
+                await viewModel.loadDisplayName()
+                await viewModel.loadIcon()
                 // Pre-render drag preview once on appear
                 if cachedPreviewImage == nil {
                     cachedPreviewImage = await renderDragPreview()
@@ -110,7 +112,7 @@ struct ShelfItemView: View {
     // MARK: - View Components
 
     private var iconView: some View {
-        Image(nsImage: viewModel.thumbnail ?? item.icon)
+        Image(nsImage: viewModel.thumbnail ?? viewModel.icon ?? NSImage())
             .resizable()
             .aspectRatio(contentMode: .fit)
             .frame(width: 56, height: 56)
@@ -119,7 +121,7 @@ struct ShelfItemView: View {
     }
 
     private var textView: some View {
-        Text(item.displayName)
+        Text(viewModel.displayName)
             .font(.system(size: 12, weight: .medium))
             .foregroundStyle(Color.white)
             .lineLimit(2)
@@ -174,10 +176,10 @@ struct ShelfItemView: View {
     
     @MainActor
     private func renderDragPreview() async -> NSImage {
-        let content = DragPreviewView(thumbnail: viewModel.thumbnail ?? item.icon, displayName: item.displayName)
+        let content = DragPreviewView(thumbnail: viewModel.thumbnail ?? viewModel.icon ?? NSImage(), displayName: viewModel.displayName)
         let renderer = ImageRenderer(content: content)
         renderer.scale = NSScreen.main?.backingScaleFactor ?? 2.0
-        return renderer.nsImage ?? (viewModel.thumbnail ?? item.icon)
+        return renderer.nsImage ?? (viewModel.thumbnail ?? viewModel.icon ?? NSImage())
     }
 
     
@@ -223,7 +225,7 @@ private struct DraggableClickHandler<Content: View>: NSViewRepresentable {
         }
         
         // Fallback to icon if rendering fails
-        return viewModel.thumbnail ?? item.icon
+        return viewModel.thumbnail ?? viewModel.icon ?? NSImage()
     }
     
     final class DraggableClickView: NSView, NSDraggingSource {

--- a/DynamicIsland/components/Shelf/Views/ShelfView.swift
+++ b/DynamicIsland/components/Shelf/Views/ShelfView.swift
@@ -78,9 +78,10 @@ struct ShelfView: View {
     
     private func updateQuickLookSelection() {
         guard quickLookService.isQuickLookOpen && !selection.selectedIDs.isEmpty else { return }
-        
+
         let selectedItems = selection.selectedItems(in: tvm.items)
-        
+        let capturedIDs = selection.selectedIDs
+
         Task {
             var urls: [URL] = []
             for item in selectedItems {
@@ -90,10 +91,13 @@ struct ShelfView: View {
                     urls.append(url)
                 }
             }
-            
+
             if !urls.isEmpty {
                 await MainActor.run {
-                    quickLookService.updateSelection(urls: urls)
+                    // Only update if selection hasn't changed since we started resolving
+                    if selection.selectedIDs == capturedIDs {
+                        quickLookService.updateSelection(urls: urls)
+                    }
                 }
             }
         }

--- a/DynamicIsland/components/Shelf/Views/ShelfView.swift
+++ b/DynamicIsland/components/Shelf/Views/ShelfView.swift
@@ -80,18 +80,22 @@ struct ShelfView: View {
         guard quickLookService.isQuickLookOpen && !selection.selectedIDs.isEmpty else { return }
         
         let selectedItems = selection.selectedItems(in: tvm.items)
-        let urls: [URL] = selectedItems.compactMap { item in
-            if let fileURL = item.fileURL {
-                return fileURL
-            }
-            if case .link(let url) = item.kind {
-                return url
-            }
-            return nil
-        }
         
-        if !urls.isEmpty {
-            quickLookService.updateSelection(urls: urls)
+        Task {
+            var urls: [URL] = []
+            for item in selectedItems {
+                if let fileURL = await ShelfStateViewModel.shared.resolveFileURLAsync(for: item) {
+                    urls.append(fileURL)
+                } else if case .link(let url) = item.kind {
+                    urls.append(url)
+                }
+            }
+            
+            if !urls.isEmpty {
+                await MainActor.run {
+                    quickLookService.updateSelection(urls: urls)
+                }
+            }
         }
     }
 

--- a/DynamicIsland/components/Tabs/TabSelectionView.swift
+++ b/DynamicIsland/components/Tabs/TabSelectionView.swift
@@ -145,7 +145,6 @@ struct TabSelectionView: View {
                 
             }
         }
-        .animation(.smooth(duration: 0.3), value: coordinator.currentView)
         .clipShape(Capsule())
         .onAppear {
             ensureValidSelection(with: tabs)

--- a/DynamicIsland/services/Extensions/ExtensionRPCServer.swift
+++ b/DynamicIsland/services/Extensions/ExtensionRPCServer.swift
@@ -219,7 +219,7 @@ final class ExtensionRPCServer {
 
             if let data = content, !data.isEmpty {
                 Task { @MainActor in
-                    self.processMessage(data: data, connID: connID)
+                    await self.processMessage(data: data, connID: connID)
                 }
             }
 
@@ -230,7 +230,7 @@ final class ExtensionRPCServer {
         }
     }
 
-    private func processMessage(data: Data, connID: UUID) {
+    private func processMessage(data: Data, connID: UUID) async {
         guard var clientConn = connections[connID] else { return }
 
         // Parse JSON-RPC request
@@ -256,7 +256,7 @@ final class ExtensionRPCServer {
             server: self
         )
 
-        let responseData = service.handleRequest(request)
+        let responseData = await service.handleRequest(request)
         sendRawData(responseData, to: connID)
     }
 

--- a/DynamicIsland/services/Extensions/ExtensionRPCService.swift
+++ b/DynamicIsland/services/Extensions/ExtensionRPCService.swift
@@ -56,7 +56,7 @@ final class ExtensionRPCService {
 
     // MARK: - Method Routing
 
-    func handleRequest(_ request: RPCRequest) -> Data {
+    func handleRequest(_ request: RPCRequest) async -> Data {
         let result: Codable
 
         switch request.method {
@@ -107,7 +107,7 @@ final class ExtensionRPCService {
             result = handleShowFilePicker(params: request.params, id: request.id)
 
         case "atoll.shareShelfItems":
-            result = handleShareShelfItemsSync(params: request.params, id: request.id)
+            result = await handleShareShelfItems(params: request.params, id: request.id)
 
         case "atoll.addFilesToShelf":
             result = handleAddFilesToShelf(params: request.params, id: request.id)
@@ -519,19 +519,6 @@ final class ExtensionRPCService {
         } else {
             return errorResponse(code: RPCErrorCode.invalidParams, message: "Provider '\(provider)' not found", id: id)
         }
-    }
-
-    // Sync wrapper for backward compatibility - calls async version with semaphore
-    private func handleShareShelfItemsSync(params: RPCParams?, id: String) -> Codable {
-        let semaphore = DispatchSemaphore(value: 0)
-        var result: Codable!
-        Task.detached { [weak self] in
-            guard let self = self else { return }
-            result = await self.handleShareShelfItems(params: params, id: id)
-            semaphore.signal()
-        }
-        _ = semaphore.wait(timeout: .now() + 30.0)
-        return result
     }
 
     private func handleAddFilesToShelf(params: RPCParams?, id: String) -> Codable {

--- a/DynamicIsland/services/Extensions/ExtensionRPCService.swift
+++ b/DynamicIsland/services/Extensions/ExtensionRPCService.swift
@@ -107,7 +107,7 @@ final class ExtensionRPCService {
             result = handleShowFilePicker(params: request.params, id: request.id)
 
         case "atoll.shareShelfItems":
-            result = handleShareShelfItems(params: request.params, id: request.id)
+            result = handleShareShelfItemsSync(params: request.params, id: request.id)
 
         case "atoll.addFilesToShelf":
             result = handleAddFilesToShelf(params: request.params, id: request.id)
@@ -486,7 +486,7 @@ final class ExtensionRPCService {
         return RPCSuccessResponse(result: ["itemIDs": .array(newItemIDs)], id: id)
     }
 
-    private func handleShareShelfItems(params: RPCParams?, id: String) -> Codable {
+    private func handleShareShelfItems(params: RPCParams?, id: String) async -> Codable {
         if let err = checkFileSharingAuthorization(id: id) { return err }
 
         guard let itemIDsValue = params?["itemIDs"],
@@ -502,7 +502,8 @@ final class ExtensionRPCService {
             return errorResponse(code: RPCErrorCode.invalidParams, message: "No matching shelf items found", id: id)
         }
 
-        let urls = ShelfStateViewModel.shared.resolveFileURLs(for: items)
+        // Use async resolution since this is called from an async context
+        let urls = await ShelfStateViewModel.shared.resolveFileURLsAsync(for: items)
         guard !urls.isEmpty else {
             return errorResponse(code: RPCErrorCode.internalError, message: "Could not resolve file URLs", id: id)
         }
@@ -518,6 +519,19 @@ final class ExtensionRPCService {
         } else {
             return errorResponse(code: RPCErrorCode.invalidParams, message: "Provider '\(provider)' not found", id: id)
         }
+    }
+
+    // Sync wrapper for backward compatibility - calls async version with semaphore
+    private func handleShareShelfItemsSync(params: RPCParams?, id: String) -> Codable {
+        let semaphore = DispatchSemaphore(value: 0)
+        var result: Codable!
+        Task.detached { [weak self] in
+            guard let self = self else { return }
+            result = await self.handleShareShelfItems(params: params, id: id)
+            semaphore.signal()
+        }
+        _ = semaphore.wait(timeout: .now() + 30.0)
+        return result
     }
 
     private func handleAddFilesToShelf(params: RPCParams?, id: String) -> Codable {

--- a/DynamicIsland/services/Extensions/ExtensionRPCService.swift
+++ b/DynamicIsland/services/Extensions/ExtensionRPCService.swift
@@ -98,10 +98,10 @@ final class ExtensionRPCService {
 
         // MARK: File Sharing
         case "atoll.getShelfItems":
-            result = handleGetShelfItems(params: request.params, id: request.id)
+            result = await handleGetShelfItems(params: request.params, id: request.id)
 
         case "atoll.getShelfItemData":
-            result = handleGetShelfItemData(params: request.params, id: request.id)
+            result = await handleGetShelfItemData(params: request.params, id: request.id)
 
         case "atoll.showFilePicker":
             result = handleShowFilePicker(params: request.params, id: request.id)
@@ -379,7 +379,7 @@ final class ExtensionRPCService {
 
     // MARK: - File Sharing Handlers
 
-    private func handleGetShelfItems(params: RPCParams?, id: String) -> Codable {
+    private func handleGetShelfItems(params: RPCParams?, id: String) async -> Codable {
         if let err = checkFileSharingAuthorization(id: id) { return err }
 
         let items = ShelfStateViewModel.shared.items
@@ -393,10 +393,15 @@ final class ExtensionRPCService {
             switch item.kind {
             case .file(let bookmark):
                 entry["kind"] = .string("file")
-                if let url = Bookmark(data: bookmark).resolveURL() {
+                let bookmarkObj = Bookmark(data: bookmark)
+                let result = await bookmarkObj.resolveAsync()
+                if let url = result.url {
                     entry["path"] = .string(url.path)
-                    if let attrs = try? FileManager.default.attributesOfItem(atPath: url.path),
-                       let size = attrs[.size] as? Int {
+                    // File attribute lookup off MainActor
+                    let attrs = await Task.detached(priority: .userInitiated) { [url] in
+                        try? FileManager.default.attributesOfItem(atPath: url.path)
+                    }.value
+                    if let attrs = attrs, let size = attrs[.size] as? Int {
                         entry["size"] = .int(size)
                     }
                 }
@@ -414,7 +419,7 @@ final class ExtensionRPCService {
         return RPCSuccessResponse(result: ["items": .array(result)], id: id)
     }
 
-    private func handleGetShelfItemData(params: RPCParams?, id: String) -> Codable {
+    private func handleGetShelfItemData(params: RPCParams?, id: String) async -> Codable {
         if let err = checkFileSharingAuthorization(id: id) { return err }
 
         guard let itemID = params?["itemID"]?.stringValue,
@@ -428,14 +433,22 @@ final class ExtensionRPCService {
 
         switch item.kind {
         case .file(let bookmark):
-            guard let url = Bookmark(data: bookmark).resolveURL() else {
+            let bookmarkObj = Bookmark(data: bookmark)
+            let result = await bookmarkObj.resolveAsync()
+            guard let url = result.url else {
                 return errorResponse(code: RPCErrorCode.internalError, message: "Cannot resolve file bookmark", id: id)
             }
-            guard let fileData = url.accessSecurityScopedResource(accessor: { try? Data(contentsOf: $0) }) else {
+            // Read file data off MainActor
+            let fileData = await Task.detached(priority: .userInitiated) { [url] in
+                url.accessSecurityScopedResource { url in
+                    try? Data(contentsOf: url)
+                }
+            }.value
+            guard let data = fileData else {
                 return errorResponse(code: RPCErrorCode.internalError, message: "Cannot read file data", id: id)
             }
-            let base64 = fileData.base64EncodedString()
-            logDiagnostics("RPC: getShelfItemData returned \(fileData.count) bytes for \(bundleIdentifier)")
+            let base64 = data.base64EncodedString()
+            logDiagnostics("RPC: getShelfItemData returned \(data.count) bytes for \(bundleIdentifier)")
             return RPCSuccessResponse(result: [
                 "data": .string(base64),
                 "fileName": .string(url.lastPathComponent),


### PR DESCRIPTION
Closes https://github.com/Ebullioscopic/Atoll/issues/583

- Requires testing by someone who has a network share

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Shelf items now load display names and icons/thumbnails asynchronously with cached placeholders, improving initial responsiveness and drag-preview smoothness.
  * Quick Look URL selection is generated asynchronously.
  * URL-based shelf item lookup uses lazy caching to reduce repeated bookmark resolution.
* **Bug Fixes**
  * Improved security-scoped bookmark handling: detects stale data, refreshes when possible, and safely falls back when resolution fails.
* **Usability**
  * Drag-and-drop, pasteboard creation, and file actions (Finder, copy path/copy, share) resolve file locations asynchronously before completing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->