### PR TITLE
Atoll: Fix YT Music API Server hang-ups and add M5 stats for freq/temp sensors

### DIFF
--- a/DynamicIsland/MediaControllers/YouTube Music Controller/YouTubeMusicController.swift
+++ b/DynamicIsland/MediaControllers/YouTube Music Controller/YouTubeMusicController.swift
@@ -185,6 +185,11 @@ final class YouTubeMusicController: MediaControllerProtocol {
             return
         }
         
+        // Disconnect existing client first to avoid stale callbacks
+        if let existingClient = webSocketClient {
+            await existingClient.disconnect()
+        }
+        
         let client = YouTubeMusicWebSocketClient(
             onMessage: { [weak self] data in
                 await self?.handleWebSocketMessage(data)

--- a/DynamicIsland/MediaControllers/YouTube Music Controller/YouTubeMusicController.swift
+++ b/DynamicIsland/MediaControllers/YouTube Music Controller/YouTubeMusicController.swift
@@ -180,7 +180,7 @@ final class YouTubeMusicController: MediaControllerProtocol {
     }
     
     private func setupWebSocketIfPossible(token: String) async {
-        guard let wsURL = WebSocketURLBuilder.buildURL(from: configuration.baseURL) else {
+        guard let wsURL = WebSocketURLBuilder.buildURL(from: configuration.baseURL, with: token) else {
             print("[YouTubeMusicController] Failed to build WebSocket URL")
             return
         }
@@ -189,8 +189,8 @@ final class YouTubeMusicController: MediaControllerProtocol {
             onMessage: { [weak self] data in
                 await self?.handleWebSocketMessage(data)
             },
-            onDisconnect: { [weak self] in
-                await self?.handleWebSocketDisconnect()
+            onDisconnect: { [weak self] closeCode, closeReason in
+                await self?.handleWebSocketDisconnect(closeCode: closeCode, closeReason: closeReason)
             }
         )
         
@@ -198,7 +198,7 @@ final class YouTubeMusicController: MediaControllerProtocol {
             try await client.connect(to: wsURL, with: token)
             webSocketClient = client
             stopPeriodicUpdates() // WebSocket will provide real-time updates
-            reconnectDelay = configuration.reconnectDelay.lowerBound
+            // Do NOT reset reconnectDelay here - wait for authenticated message
         } catch {
             print("[YouTubeMusicController] WebSocket connection failed: \(error)")
             await scheduleReconnect()
@@ -218,6 +218,8 @@ final class YouTubeMusicController: MediaControllerProtocol {
                let response = PlaybackResponse.from(websocketData: data) {
                 await updatePlaybackState(with: response)
             }
+            // Reset reconnect delay on successful authenticated message
+            reconnectDelay = configuration.reconnectDelay.lowerBound
 
         case .positionChanged:
             guard let data = message.extractData() else { return }
@@ -263,10 +265,20 @@ final class YouTubeMusicController: MediaControllerProtocol {
         }
     }
     
-    private func handleWebSocketDisconnect() async {
+    private func handleWebSocketDisconnect(closeCode: URLSessionWebSocketTask.CloseCode?, closeReason: Data?) async {
+        // Check if this was an auth failure (close code 1008)
+        let wasAuthFailure = closeCode?.rawValue == 1008
+        
         webSocketClient = nil
         await startPeriodicUpdates() // Fallback to polling
-        await scheduleReconnect()
+        
+        if wasAuthFailure {
+            // Token invalid, invalidate and re-authenticate
+            await authManager.invalidateToken()
+            await scheduleReconnect()
+        } else {
+            await scheduleReconnect()
+        }
     }
     
     private func scheduleReconnect() async {

--- a/DynamicIsland/MediaControllers/YouTube Music Controller/YouTubeMusicNetworking.swift
+++ b/DynamicIsland/MediaControllers/YouTube Music Controller/YouTubeMusicNetworking.swift
@@ -133,6 +133,7 @@ actor YouTubeMusicWebSocketClient {
     private let onMessage: @Sendable (Data) async -> Void
     private let onDisconnect: @Sendable (URLSessionWebSocketTask.CloseCode?, Data?) async -> Void
     private var authenticated = false
+    private var isIntentionalDisconnect = false
     private var lastCloseCode: URLSessionWebSocketTask.CloseCode?
     private var lastCloseReason: Data?
     
@@ -154,25 +155,21 @@ actor YouTubeMusicWebSocketClient {
     func connect(to url: URL, with token: String) async throws {
         await disconnect()
         
-        var components = URLComponents(url: url, resolvingAgainstBaseURL: false)
-        components?.queryItems = [URLQueryItem(name: "token", value: token)]
-        
-        guard let wsURL = components?.url else {
-            throw YouTubeMusicError.invalidURL
-        }
-        
-        var request = URLRequest(url: wsURL)
+        // URL already has token query param from WebSocketURLBuilder.buildURL
+        var request = URLRequest(url: url)
         request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
         
         let newTask = session.webSocketTask(with: request)
         task = newTask
         authenticated = false
+        isIntentionalDisconnect = false
         newTask.resume()
         
         Task { await listenForMessages() }
     }
     
     func disconnect() async {
+        isIntentionalDisconnect = true
         task?.cancel(with: .goingAway, reason: nil)
         task = nil
         authenticated = false
@@ -210,8 +207,15 @@ actor YouTubeMusicWebSocketClient {
         // Capture close code before clearing task
         lastCloseCode = task?.closeCode
         lastCloseReason = task?.closeReason
+        
+        let closeCode = lastCloseCode
+        let closeReason = lastCloseReason
         task = nil
-        await onDisconnect(lastCloseCode, lastCloseReason)
+        
+        // Only call onDisconnect for unexpected closures, not intentional disconnects
+        if !isIntentionalDisconnect {
+            await onDisconnect(closeCode, closeReason)
+        }
     }
 }
 

--- a/DynamicIsland/MediaControllers/YouTube Music Controller/YouTubeMusicNetworking.swift
+++ b/DynamicIsland/MediaControllers/YouTube Music Controller/YouTubeMusicNetworking.swift
@@ -131,13 +131,19 @@ actor YouTubeMusicWebSocketClient {
     private var task: URLSessionWebSocketTask?
     private let session: URLSession
     private let onMessage: @Sendable (Data) async -> Void
-    private let onDisconnect: @Sendable () async -> Void
+    private let onDisconnect: @Sendable (URLSessionWebSocketTask.CloseCode?, Data?) async -> Void
+    private var authenticated = false
+    private var lastCloseCode: URLSessionWebSocketTask.CloseCode?
+    private var lastCloseReason: Data?
     
-    var isConnected: Bool { task != nil }
+    var isConnected: Bool { task?.state == .running }
+    var isAuthenticated: Bool { authenticated }
+    var closeCode: URLSessionWebSocketTask.CloseCode? { lastCloseCode }
+    var closeReason: Data? { lastCloseReason }
     
     init(
         onMessage: @escaping @Sendable (Data) async -> Void,
-        onDisconnect: @escaping @Sendable () async -> Void,
+        onDisconnect: @escaping @Sendable (URLSessionWebSocketTask.CloseCode?, Data?) async -> Void,
         session: URLSession = .shared
     ) {
         self.onMessage = onMessage
@@ -148,11 +154,19 @@ actor YouTubeMusicWebSocketClient {
     func connect(to url: URL, with token: String) async throws {
         await disconnect()
         
-        var request = URLRequest(url: url)
+        var components = URLComponents(url: url, resolvingAgainstBaseURL: false)
+        components?.queryItems = [URLQueryItem(name: "token", value: token)]
+        
+        guard let wsURL = components?.url else {
+            throw YouTubeMusicError.invalidURL
+        }
+        
+        var request = URLRequest(url: wsURL)
         request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
         
         let newTask = session.webSocketTask(with: request)
         task = newTask
+        authenticated = false
         newTask.resume()
         
         Task { await listenForMessages() }
@@ -161,6 +175,7 @@ actor YouTubeMusicWebSocketClient {
     func disconnect() async {
         task?.cancel(with: .goingAway, reason: nil)
         task = nil
+        authenticated = false
     }
     
     private func listenForMessages() async {
@@ -180,19 +195,29 @@ actor YouTubeMusicWebSocketClient {
                     continue
                 }
                 
+                if let wsMessage = WebSocketMessage(from: data), !authenticated {
+                    if wsMessage.type == .playerInfo || wsMessage.type == .videoChanged || wsMessage.type == .playerStateChanged {
+                        authenticated = true
+                    }
+                }
+                
                 await onMessage(data)
             } catch {
                 break
             }
         }
+        
+        // Capture close code before clearing task
+        lastCloseCode = task?.closeCode
+        lastCloseReason = task?.closeReason
         task = nil
-        await onDisconnect()
+        await onDisconnect(lastCloseCode, lastCloseReason)
     }
 }
 
 // MARK: - WebSocket URL Helper
 struct WebSocketURLBuilder {
-    static func buildURL(from baseURL: String) -> URL? {
+    static func buildURL(from baseURL: String, with token: String? = nil) -> URL? {
         guard var components = URLComponents(string: baseURL) else { return nil }
 
         switch components.scheme {
@@ -205,6 +230,11 @@ struct WebSocketURLBuilder {
         }
 
         components.path = "/api/v1/ws"
+        
+        if let token = token {
+            components.queryItems = [URLQueryItem(name: "token", value: token)]
+        }
+        
         return components.url
     }
 }

--- a/DynamicIsland/utils/AppleHardwareInfo.swift
+++ b/DynamicIsland/utils/AppleHardwareInfo.swift
@@ -38,6 +38,10 @@ enum ApplePlatform: String {
     case m4Pro
     case m4Max
     case m4Ultra
+    case m5
+    case m5Pro
+    case m5Max
+    case m5Ultra
 }
 
 struct CPUClusterFrequencies {
@@ -111,6 +115,12 @@ final class AppleHardwareInfo {
             if name.contains("pro") { return .m4Pro }
             return .m4
         }
+        if name.contains("m5") {
+            if name.contains("ultra") { return .m5Ultra }
+            if name.contains("max") { return .m5Max }
+            if name.contains("pro") { return .m5Pro }
+            return .m5
+        }
         return nil
     }
 
@@ -153,6 +163,7 @@ final class AppleHardwareInfo {
 
         let lowerName = cpuName.lowercased()
         let isM4 = lowerName.contains("m4")
+        let isM5 = lowerName.contains("m5")
         var eFreq: [Int32] = []
         var pFreq: [Int32] = []
 
@@ -161,10 +172,10 @@ final class AppleHardwareInfo {
             guard let name = di_getIOName(service), name == "pmgr", let props = di_getIOProperties(service) else { continue }
 
             if let data = props["voltage-states1-sram"] as? Data {
-                eFreq = di_convertCFDataToFrequencies(data, isM4: isM4)
+                eFreq = di_convertCFDataToFrequencies(data, isM4: isM4 || isM5)
             }
             if let data = props["voltage-states5-sram"] as? Data {
-                pFreq = di_convertCFDataToFrequencies(data, isM4: isM4)
+                pFreq = di_convertCFDataToFrequencies(data, isM4: isM4 || isM5)
             }
         }
 

--- a/DynamicIsland/utils/CPUSensorCollector.swift
+++ b/DynamicIsland/utils/CPUSensorCollector.swift
@@ -246,6 +246,8 @@ final class CPUSensorCollector {
             return ["Te05", "Te0L", "Te0P", "Te0S", "Tf04", "Tf09", "Tf0A", "Tf0B", "Tf0D", "Tf0E", "Tf44", "Tf49", "Tf4A", "Tf4B", "Tf4D", "Tf4E"]
         case .m4, .m4Pro, .m4Max, .m4Ultra:
             return ["Te05", "Te09", "Te0H", "Te0S", "Tp01", "Tp05", "Tp09", "Tp0D", "Tp0V", "Tp0Y", "Tp0b", "Tp0e"]
+        case .m5, .m5Pro, .m5Max, .m5Ultra:
+            return ["Te05", "Te09", "Te0H", "Te0S", "Tp01", "Tp05", "Tp09", "Tp0D", "Tp0V", "Tp0Y", "Tp0b", "Tp0e"]
         default:
             return ["TC0P", "TC0E", "TC0F", "TC0H", "TC0D"]
         }


### PR DESCRIPTION
Closes https://github.com/Ebullioscopic/Atoll/issues/594 and https://github.com/Ebullioscopic/Atoll/issues/585

- Tested that it works fine on a MBP M4 with latest YT Music / Pear
- Also backwards compatible for those on older clients as well


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved YouTube Music WebSocket connection lifecycle with token-included URLs and more reliable disconnect handling.
  * Authentication failures are now detected from WebSocket close details and trigger token invalidation and fallback polling.
  * Reconnection timing now resets after successful authenticated messages, preventing stale retry backoff.
  * Connection status more accurately reflects whether the WebSocket task is actively running.
* **New Features**
  * Added support for Apple M5 CPU variants and updated related frequency/temperature sensor handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->