### PR TITLE
fix(release): preserve app entitlements during signing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,9 @@ jobs:
         with:
           xcode-version: latest-stable
 
+      - name: Validate privacy configuration
+        run: python3 -m unittest tests.test_privacy_configuration
+
       - name: Download Metal Toolchain
         # The downloadable Metal Toolchain is an Xcode 26+ (macOS 26) component; older Xcode ships metal.
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -292,6 +292,12 @@ jobs:
       - name: Sign Sparkle XPC Services
         run: |
           APP_PATH="build/export/${APP_NAME}.app"
+          ENTITLEMENTS_PATH="$RUNNER_TEMP/${APP_NAME}.entitlements"
+
+          # Keep the capabilities Xcode applied to the archived app. Re-signing
+          # without this file strips TCC-gated capabilities such as Camera and
+          # Apple Events automation from the shipped app.
+          codesign -d --entitlements :- "$APP_PATH" > "$ENTITLEMENTS_PATH"
 
           # Sign Sparkle XPC services with hardened runtime
           find "$APP_PATH" -name "*.xpc" -print0 | while IFS= read -r -d '' xpc; do
@@ -310,11 +316,20 @@ jobs:
 
           # Re-sign the entire app
           codesign --force --options runtime \
+            --entitlements "$ENTITLEMENTS_PATH" \
             --sign "Developer ID Application: Hariharan Mudaliar ($TEAM_ID)" \
             "$APP_PATH"
 
           # Verify
           codesign --verify --deep --strict --verbose=2 "$APP_PATH"
+
+          # Confirm the shipped app still contains the privacy capabilities
+          # required by the features it exposes. This catches any future
+          # signing change that would silently strip the app's entitlements.
+          FINAL_ENTITLEMENTS_PATH="$RUNNER_TEMP/${APP_NAME}-final.entitlements"
+          codesign -d --entitlements :- "$APP_PATH" > "$FINAL_ENTITLEMENTS_PATH"
+          plutil -extract com.apple.security.device.camera raw "$FINAL_ENTITLEMENTS_PATH" | grep -qx "true"
+          plutil -extract com.apple.security.automation.apple-events raw "$FINAL_ENTITLEMENTS_PATH" | grep -qx "true"
 
       # ─────────────────────────────────────────────────────────────────
       # 14. Create DMG

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -328,8 +328,8 @@ jobs:
           # signing change that would silently strip the app's entitlements.
           FINAL_ENTITLEMENTS_PATH="$RUNNER_TEMP/${APP_NAME}-final.entitlements"
           codesign -d --entitlements :- "$APP_PATH" > "$FINAL_ENTITLEMENTS_PATH"
-          plutil -extract com.apple.security.device.camera raw "$FINAL_ENTITLEMENTS_PATH" | grep -qx "true"
-          plutil -extract com.apple.security.automation.apple-events raw "$FINAL_ENTITLEMENTS_PATH" | grep -qx "true"
+          /usr/libexec/PlistBuddy -c "Print :com.apple.security.device.camera" "$FINAL_ENTITLEMENTS_PATH" | grep -qx "true"
+          /usr/libexec/PlistBuddy -c "Print :com.apple.security.automation.apple-events" "$FINAL_ENTITLEMENTS_PATH" | grep -qx "true"
 
       # ─────────────────────────────────────────────────────────────────
       # 14. Create DMG

--- a/.gitignore
+++ b/.gitignore
@@ -139,6 +139,7 @@ referenceimages
 PrivateWorks
 
 *.py
+!tests/test_privacy_configuration.py
 *.sh
 comparison_report.json
 *.txt

--- a/DynamicIsland.xcodeproj/project.pbxproj
+++ b/DynamicIsland.xcodeproj/project.pbxproj
@@ -574,7 +574,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIconDev;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
-				AUTOMATION_APPLE_EVENTS = NO;
+				AUTOMATION_APPLE_EVENTS = YES;
 				CODE_SIGN_ENTITLEMENTS = DynamicIsland/DynamicIsland.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
@@ -604,7 +604,7 @@
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.utilities";
 				INFOPLIST_KEY_LSUIElement = YES;
 				INFOPLIST_KEY_MetalCaptureEnabled = YES;
-				INFOPLIST_KEY_NSAppleEventsUsageDescription = "Atoll uses AppleScripts to control Spotify and Apple Music";
+				INFOPLIST_KEY_NSAppleEventsUsageDescription = "Atoll uses AppleScripts to control Spotify, Apple Music, and Notes.";
 				INFOPLIST_KEY_NSBluetoothAlwaysUsageDescription = "Atoll needs Bluetooth access to detect when audio devices connect and display their battery status in the HUD.";
 				INFOPLIST_KEY_NSCalendarsFullAccessUsageDescription = "Show calender events inside the notch";
 				INFOPLIST_KEY_NSCalendarsUsageDescription = "Need for Calendar Mode";
@@ -616,6 +616,7 @@
 				INFOPLIST_KEY_NSLocationUsageDescription = "Atoll uses your location to display accurate lock screen weather.";
 				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "Atoll uses your location to display accurate lock screen weather.";
 				INFOPLIST_KEY_NSRemindersUsageDescription = "Atoll needs Reminders access to show your reminders";
+				INFOPLIST_KEY_NSRemindersFullAccessUsageDescription = "Atoll needs Reminders access to show your reminders";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",
@@ -646,7 +647,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
-				AUTOMATION_APPLE_EVENTS = NO;
+				AUTOMATION_APPLE_EVENTS = YES;
 				CODE_SIGN_ENTITLEMENTS = DynamicIsland/DynamicIsland.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Developer ID Application";
@@ -677,7 +678,7 @@
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.utilities";
 				INFOPLIST_KEY_LSUIElement = YES;
 				INFOPLIST_KEY_MetalCaptureEnabled = YES;
-				INFOPLIST_KEY_NSAppleEventsUsageDescription = "Atoll uses AppleScripts to control Spotify and Apple Music";
+				INFOPLIST_KEY_NSAppleEventsUsageDescription = "Atoll uses AppleScripts to control Spotify, Apple Music, and Notes.";
 				INFOPLIST_KEY_NSBluetoothAlwaysUsageDescription = "Atoll needs Bluetooth access to detect when audio devices connect and display their battery status in the HUD.";
 				INFOPLIST_KEY_NSCalendarsFullAccessUsageDescription = "Show calender events inside the notch";
 				INFOPLIST_KEY_NSCalendarsUsageDescription = "Need for Calendar Mode";
@@ -689,6 +690,7 @@
 				INFOPLIST_KEY_NSLocationUsageDescription = "Atoll uses your location to display accurate lock screen weather.";
 				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "Atoll uses your location to display accurate lock screen weather.";
 				INFOPLIST_KEY_NSRemindersUsageDescription = "Atoll needs Reminders access to show your reminders";
+				INFOPLIST_KEY_NSRemindersFullAccessUsageDescription = "Atoll needs Reminders access to show your reminders";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",

--- a/DynamicIsland/DynamicIsland.entitlements
+++ b/DynamicIsland/DynamicIsland.entitlements
@@ -2,19 +2,22 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-    <key>com.apple.security.cs.disable-library-validation</key>
-    <true/>
-    <key>com.apple.security.mach-services</key>
+	<key>com.apple.security.cs.disable-library-validation</key>
+	<true/>
+	<key>com.apple.security.device.camera</key>
+	<true/>
+	<key>com.apple.security.mach-services</key>
     <array>
         <string>com.ebullioscopic.Atoll.xpc</string>
     </array>
     <key>com.apple.security.automation.apple-events</key>
     <true/>
     <key>com.apple.security.temporary-exception.apple-events</key>
-    <array>
-        <string>com.spotify.client</string>
-        <string>com.apple.Music</string>
-    </array>
+	<array>
+		<string>com.spotify.client</string>
+		<string>com.apple.Music</string>
+		<string>com.apple.Notes</string>
+	</array>
     <key>com.apple.security.temporary-exception.mach-lookup.global-name</key>
     <array>
         <string>$(PRODUCT_BUNDLE_IDENTIFIER)-spks</string>

--- a/tests/test_privacy_configuration.py
+++ b/tests/test_privacy_configuration.py
@@ -1,0 +1,79 @@
+import plistlib
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+ENTITLEMENTS = ROOT / "DynamicIsland" / "DynamicIsland.entitlements"
+PROJECT = ROOT / "DynamicIsland.xcodeproj" / "project.pbxproj"
+RELEASE_WORKFLOW = ROOT / ".github" / "workflows" / "release.yml"
+CI_WORKFLOW = ROOT / ".github" / "workflows" / "ci.yml"
+
+
+class PrivacyConfigurationTests(unittest.TestCase):
+    def test_camera_capture_is_explicitly_entitled(self):
+        entitlements = plistlib.loads(ENTITLEMENTS.read_bytes())
+
+        self.assertTrue(entitlements.get("com.apple.security.device.camera"))
+
+    def test_notes_sync_is_authorized_for_apple_events(self):
+        project = PROJECT.read_text()
+        entitlements = plistlib.loads(ENTITLEMENTS.read_bytes())
+
+        self.assertNotIn("AUTOMATION_APPLE_EVENTS = NO;", project)
+        self.assertIn(
+            "com.apple.Notes",
+            entitlements["com.apple.security.temporary-exception.apple-events"],
+        )
+
+    def test_automation_usage_text_names_notes(self):
+        project = PROJECT.read_text()
+
+        self.assertEqual(
+            2,
+            project.count(
+                'INFOPLIST_KEY_NSAppleEventsUsageDescription = "Atoll uses AppleScripts to control Spotify, Apple Music, and Notes.";'
+            ),
+        )
+
+    def test_full_access_reminder_api_has_matching_usage_text(self):
+        project = PROJECT.read_text()
+
+        self.assertEqual(
+            2,
+            project.count("INFOPLIST_KEY_NSRemindersFullAccessUsageDescription ="),
+        )
+
+    def test_release_resigning_preserves_archived_entitlements(self):
+        workflow = RELEASE_WORKFLOW.read_text()
+
+        self.assertIn(
+            'codesign -d --entitlements :- "$APP_PATH" > "$ENTITLEMENTS_PATH"',
+            workflow,
+        )
+        self.assertIn('--entitlements "$ENTITLEMENTS_PATH"', workflow)
+        self.assertIn(
+            'FINAL_ENTITLEMENTS_PATH="$RUNNER_TEMP/${APP_NAME}-final.entitlements"',
+            workflow,
+        )
+        self.assertIn(
+            'codesign -d --entitlements :- "$APP_PATH" > "$FINAL_ENTITLEMENTS_PATH"',
+            workflow,
+        )
+        self.assertIn(
+            'plutil -extract com.apple.security.device.camera raw "$FINAL_ENTITLEMENTS_PATH" | grep -qx "true"',
+            workflow,
+        )
+        self.assertIn(
+            'plutil -extract com.apple.security.automation.apple-events raw "$FINAL_ENTITLEMENTS_PATH" | grep -qx "true"',
+            workflow,
+        )
+
+    def test_ci_checks_the_privacy_configuration(self):
+        workflow = CI_WORKFLOW.read_text()
+
+        self.assertIn("python3 -m unittest tests.test_privacy_configuration", workflow)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_privacy_configuration.py
+++ b/tests/test_privacy_configuration.py
@@ -61,11 +61,11 @@ class PrivacyConfigurationTests(unittest.TestCase):
             workflow,
         )
         self.assertIn(
-            'plutil -extract com.apple.security.device.camera raw "$FINAL_ENTITLEMENTS_PATH" | grep -qx "true"',
+            '/usr/libexec/PlistBuddy -c "Print :com.apple.security.device.camera" "$FINAL_ENTITLEMENTS_PATH" | grep -qx "true"',
             workflow,
         )
         self.assertIn(
-            'plutil -extract com.apple.security.automation.apple-events raw "$FINAL_ENTITLEMENTS_PATH" | grep -qx "true"',
+            '/usr/libexec/PlistBuddy -c "Print :com.apple.security.automation.apple-events" "$FINAL_ENTITLEMENTS_PATH" | grep -qx "true"',
             workflow,
         )
 


### PR DESCRIPTION
## Summary
- Preserve the archive's entitlements when the release workflow re-signs the app bundle.
- Explicitly authorize Camera and Notes Apple Events automation, with accurate user-facing automation text.
- Validate the configuration in CI and verify the shipped release retains its Camera and Automation entitlements.

## Root cause
The release workflow force re-signed the exported app without passing its existing entitlements. That strips TCC-gated capabilities from the shipped bundle, so macOS never receives Camera or Apple Events authorization requests.

## Privacy and security
This preserves Xcode's exact archived entitlement set; it does not use broad recursive signing. Camera is limited to the live-mirror feature, and the Apple Events exception adds only `com.apple.Notes` alongside the existing Spotify and Music targets.

## Validation
- `python3 -m unittest tests.test_privacy_configuration`
- `plutil -lint DynamicIsland/DynamicIsland.entitlements`
- release-workflow YAML parse
- local code-sign/re-sign round-trip confirming Camera and Automation entitlements survive

A full Xcode build was not run locally because Xcode is unavailable on this machine; GitHub Actions remains required before merge.

## Related
Related to #626.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Privacy & Permissions**
  * Enabled camera access and ensured the required entitlements are included in releases.
  * Expanded Apple Events automation support to include Notes (in addition to Spotify and Apple Music).
  * Updated permission text for Apple Events/automation and Reminders full-access.

* **Reliability**
  * Improved signing/re-signing to preserve existing entitlements during the macOS release process.

* **Quality Improvements**
  * Added automated CI validation to confirm privacy entitlements and release-signing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->