### PR TITLE
fix: add Calendar entitlement for EventKit access

### DIFF
--- a/DynamicIsland/DynamicIsland.entitlements
+++ b/DynamicIsland/DynamicIsland.entitlements
@@ -10,6 +10,8 @@
     </array>
     <key>com.apple.security.automation.apple-events</key>
     <true/>
+    <key>com.apple.security.personal-information.calendars</key>
+    <true/>
     <key>com.apple.security.temporary-exception.apple-events</key>
     <array>
         <string>com.spotify.client</string>


### PR DESCRIPTION
## Summary

- Add `com.apple.security.personal-information.calendars` to the entitlements file used by both Debug and Release builds.
- Allow EventKit to present the macOS Calendar consent prompt instead of silently denying access.

## Root cause

The target enables Calendar resource access and already provides `NSCalendarsFullAccessUsageDescription`, but `DynamicIsland.entitlements` does not contain the Calendar entitlement. The shipped app therefore has no Calendar capability in its code signature, so requesting full EventKit access produces no system prompt and Atoll does not appear under Privacy & Security → Calendars.

Apple documents this entitlement as the capability that permits calendar access on macOS:
https://developer.apple.com/documentation/bundleresources/entitlements/com.apple.security.personal-information.calendars

## User impact

After macOS receives a correctly signed build, people can grant Calendar access and Atoll can display their selected events. The entitlement does not grant access automatically; the user still has to approve the system permission prompt.

## Validation

- `plutil -lint DynamicIsland/DynamicIsland.entitlements`
- `plutil -lint DynamicIsland.xcodeproj/project.pbxproj`
- Full Debug build succeeded with Xcode 26.6 (17F113) on macOS 26.5.2 (Apple Silicon): `xcodebuild build -project DynamicIsland.xcodeproj -scheme DynamicIsland -configuration Debug -destination 'platform=macOS'`
- `codesign --verify --deep --strict` passed for the generated `Atoll.app`
- The generated app's signed entitlements contain `com.apple.security.personal-information.calendars = true`
- The generated app's `Info.plist` contains `NSCalendarsFullAccessUsageDescription`
- Runtime diagnosis on macOS 26.5.2 (Apple Silicon): a locally signed diagnostic copy with this entitlement was able to request access and list calendars

The project does not currently define a unit test target, so validation focused on the full build, signature integrity, entitlement payload, and EventKit runtime behavior.

## Related

- Discussion #629
- Complements #628, which preserves archived entitlements when the release workflow re-signs the exported app. That release fix is also required for this entitlement to remain present in shipped builds.
