### PR TITLE
Fix: suppress island dismiss while scrolling a long note in NoteEditorView

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed the Shelf freezing for seconds on every drop, and dragging items out delivering the file name as plain text instead of the file itself. Four call sites bridged to `@MainActor` members of `ShelfItem` with a `Task.detached` plus `DispatchSemaphore.wait`, which deadlocks by construction when called from the main actor and always burned its full 5-second timeout: the deduplication pass in `add()` paid that cost once per existing *and* incoming item, and `createPasteboardItem` timed out to a `nil` URL and fell through to writing plain text. Resolved paths are now cached on the item at drop time (and backfilled off the main actor for items persisted earlier), so deduplication, drag-out, and the context menu need no main-actor disk I/O (#682).
 - Fixed Open, Open With, Show in Finder, Quick Look, Compress, Copy Path, and the image actions all missing from the Shelf file context menu, caused by `ShelfItem.fileURL` returning a hard-coded `nil` for files (#682).
 - Fixed the notch auto-closing in the middle of a drag and cancelling the session: dragging an item out necessarily takes the cursor off the panel, which tore down the view acting as the drag source (#682).
+- Fixed an issue where scrolling a long note inside the Dynamic Island reset the view to home instead of scrolling the note. (#637)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed the Shelf freezing for seconds on every drop, and dragging items out delivering the file name as plain text instead of the file itself. Four call sites bridged to `@MainActor` members of `ShelfItem` with a `Task.detached` plus `DispatchSemaphore.wait`, which deadlocks by construction when called from the main actor and always burned its full 5-second timeout: the deduplication pass in `add()` paid that cost once per existing *and* incoming item, and `createPasteboardItem` timed out to a `nil` URL and fell through to writing plain text. Resolved paths are now cached on the item at drop time (and backfilled off the main actor for items persisted earlier), so deduplication, drag-out, and the context menu need no main-actor disk I/O (#682).
 - Fixed Open, Open With, Show in Finder, Quick Look, Compress, Copy Path, and the image actions all missing from the Shelf file context menu, caused by `ShelfItem.fileURL` returning a hard-coded `nil` for files (#682).
 - Fixed the notch auto-closing in the middle of a drag and cancelling the session: dragging an item out necessarily takes the cursor off the panel, which tore down the view acting as the drag source (#682).
-- Fixed an issue where scrolling a long note inside the Dynamic Island reset the view to home instead of scrolling the note. (#636)
+- Fixed an issue where scrolling a long note inside the Dynamic Island returned the view to the home view instead of scrolling the note. (`#636`)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed the Shelf freezing for seconds on every drop, and dragging items out delivering the file name as plain text instead of the file itself. Four call sites bridged to `@MainActor` members of `ShelfItem` with a `Task.detached` plus `DispatchSemaphore.wait`, which deadlocks by construction when called from the main actor and always burned its full 5-second timeout: the deduplication pass in `add()` paid that cost once per existing *and* incoming item, and `createPasteboardItem` timed out to a `nil` URL and fell through to writing plain text. Resolved paths are now cached on the item at drop time (and backfilled off the main actor for items persisted earlier), so deduplication, drag-out, and the context menu need no main-actor disk I/O (#682).
 - Fixed Open, Open With, Show in Finder, Quick Look, Compress, Copy Path, and the image actions all missing from the Shelf file context menu, caused by `ShelfItem.fileURL` returning a hard-coded `nil` for files (#682).
 - Fixed the notch auto-closing in the middle of a drag and cancelling the session: dragging an item out necessarily takes the cursor off the panel, which tore down the view acting as the drag source (#682).
-- Fixed an issue where scrolling a long note inside the Dynamic Island reset the view to home instead of scrolling the note. (#637)
+- Fixed an issue where scrolling a long note inside the Dynamic Island reset the view to home instead of scrolling the note. (#636)
 
 ### Removed
 

--- a/DynamicIsland/components/Notch/NotchNotesView.swift
+++ b/DynamicIsland/components/Notch/NotchNotesView.swift
@@ -903,7 +903,11 @@ struct NoteEditorView: View {
     }
 
     @FocusState private var isContentFocused: Bool
-    
+
+    @EnvironmentObject var vm: DynamicIslandViewModel
+    private var suppressionToken = UUID()
+    @State private var isSuppressing = false
+
     var body: some View {
         VStack(spacing: 0) {
             // Toolbar
@@ -1047,10 +1051,22 @@ struct NoteEditorView: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity) // Ensure VStack takes full space
         .background(Color.black) // Ensure solid background
+        .onHover { hovering in
+            updateSuppression(for: hovering)
+        }
+        .onDisappear {
+            updateSuppression(for: false)
+        }
         .onAppear {
             if isNew {
                 isContentFocused = true
             }
         }
+    }
+
+    private func updateSuppression(for hovering: Bool) {
+        guard hovering != isSuppressing else { return }
+        isSuppressing = hovering
+        vm.setScrollGestureSuppression(hovering, token: suppressionToken)
     }
 }


### PR DESCRIPTION
Fixes #636

## Summary

`NoteEditorView` (the long-note editor shown inside the Dynamic Island) did not declare scroll-gesture suppression. As a result, scrolling a long note triggered the global scroll-to-dismiss handler, which **closed the Dynamic Island and reset the view back to home** instead of scrolling the note content.

This mirrors the existing pattern already used by the notes list / clipboard views via `vm.setScrollGestureSuppression(...)`, which were already guarded against the same issue — but the editor view was missed.

## Root cause

The Dynamic Island listens globally for `scrollWheel` events to support the "scroll to dismiss" gesture. Content views are expected to suppress that handler while the pointer is over scrollable content. `NoteListView` does this; `NoteEditorView` did not, so any scroll inside a long note was interpreted as a dismiss.

## Changes

`DynamicIsland/components/Notch/NotchNotesView.swift` — `NoteEditorView`:
- Add `@EnvironmentObject var vm: DynamicIslandViewModel`
- Add a `suppressionToken` and `isSuppressing` state
- On `.onHover`, call `vm.setScrollGestureSuppression(hovering, token:)`
- On `.onDisappear`, clear the suppression so it never leaks

## Steps to reproduce (before)

1. Open a long note (content taller than the island) inside the Dynamic Island.
2. Hover over the note content and scroll down with the mouse wheel.
3. The Dynamic Island dismisses; the note view is lost and must be re-entered.

## Expected (after)

Scrolling scrolls the note content; the island stays open. Re-hovering keeps you on the note.

## Tested

Built locally (Debug, Apple Development signing) and verified on macOS: scrolling a long note no longer dismisses the island; hovering still works; island re-opens to the note view as expected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented unintended scrolling while hovering over the note editor.
  * Restored normal scrolling when hover ends or the note editor closes or leaves the screen.
  * Fixed long-note scrolling unexpectedly returning to the home view.
  * Improved scrolling stability by avoiding duplicate interaction-state updates during hover transitions.
* **Documentation**
  * Added a changelog entry describing the long-note scrolling fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->