### PR TITLE
Fix stale timer cleanup hiding restarted timers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,9 @@ jobs:
       - name: Validate privacy configuration
         run: python3 -m unittest tests.test_privacy_configuration
 
+      - name: Validate timer lifecycle cleanup
+        run: python3 -m unittest tests.test_timer_lifecycle
+
       - name: Download Metal Toolchain
         # The downloadable Metal Toolchain is an Xcode 26+ (macOS 26) component; older Xcode ships metal.
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -140,6 +140,7 @@ PrivateWorks
 
 *.py
 !tests/test_privacy_configuration.py
+!tests/test_timer_lifecycle.py
 *.sh
 comparison_report.json
 *.txt

--- a/DynamicIsland/managers/SystemTimerBridge.swift
+++ b/DynamicIsland/managers/SystemTimerBridge.swift
@@ -822,12 +822,17 @@ final class SystemTimerBridge {
         DispatchQueue.main.async {
             guard TimerManager.shared.isExternalTimerActive else { return }
             if didComplete {
+                guard let completedSessionID = TimerManager.shared.activeSessionID else { return }
                 self.logDebug("Timer finished; scheduling delayed cleanup")
                 DispatchQueue.main.asyncAfter(deadline: .now() + 3.2) {
-                    if TimerManager.shared.isExternalTimerActive {
-                        self.logDebug("Delayed cleanup firing; ending external timer")
-                        TimerManager.shared.endExternalTimer(triggerSmoothClose: false)
+                    guard TimerManager.shared.activeSource == .external,
+                          TimerManager.shared.activeSessionID == completedSessionID else {
+                        self.logDebug("Skipping delayed cleanup because a newer timer session is active")
+                        return
                     }
+
+                    self.logDebug("Delayed cleanup firing; ending external timer")
+                    TimerManager.shared.endExternalTimer(triggerSmoothClose: false)
                 }
             } else {
                 self.logDebug("Ending external timer immediately")

--- a/DynamicIsland/managers/SystemTimerBridge.swift
+++ b/DynamicIsland/managers/SystemTimerBridge.swift
@@ -822,7 +822,7 @@ final class SystemTimerBridge {
         DispatchQueue.main.async {
             guard TimerManager.shared.isExternalTimerActive else { return }
             if didComplete {
-                guard let completedSessionID = TimerManager.shared.activeSessionID else { return }
+                guard let completedSessionID = TimerManager.shared.completedSessionID else { return }
                 self.logDebug("Timer finished; scheduling delayed cleanup")
                 DispatchQueue.main.asyncAfter(deadline: .now() + 3.2) {
                     guard TimerManager.shared.activeSource == .external,

--- a/DynamicIsland/managers/TimerLifecycle.swift
+++ b/DynamicIsland/managers/TimerLifecycle.swift
@@ -1,0 +1,32 @@
+/*
+ * Atoll (DynamicIsland)
+ * Copyright (C) 2024-2026 Atoll Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+import Foundation
+
+/// Gives each timer run its own identity so delayed work from an earlier run
+/// cannot mutate a timer that was started in the meantime.
+struct TimerLifecycle {
+    private(set) var sessionID: UUID?
+
+    @discardableResult
+    mutating func beginSession() -> UUID {
+        let sessionID = UUID()
+        self.sessionID = sessionID
+        return sessionID
+    }
+
+    mutating func endSession() {
+        sessionID = nil
+    }
+
+    func isCurrent(_ candidate: UUID) -> Bool {
+        sessionID == candidate
+    }
+}

--- a/DynamicIsland/managers/TimerLifecycle.swift
+++ b/DynamicIsland/managers/TimerLifecycle.swift
@@ -14,16 +14,25 @@ import Foundation
 /// cannot mutate a timer that was started in the meantime.
 struct TimerLifecycle {
     private(set) var sessionID: UUID?
+    private(set) var completedSessionID: UUID?
 
     @discardableResult
     mutating func beginSession() -> UUID {
         let sessionID = UUID()
         self.sessionID = sessionID
+        completedSessionID = nil
         return sessionID
+    }
+
+    @discardableResult
+    mutating func completeSession() -> UUID? {
+        completedSessionID = sessionID
+        return completedSessionID
     }
 
     mutating func endSession() {
         sessionID = nil
+        completedSessionID = nil
     }
 
     func isCurrent(_ candidate: UUID) -> Bool {

--- a/DynamicIsland/managers/TimerManager.swift
+++ b/DynamicIsland/managers/TimerManager.swift
@@ -125,6 +125,14 @@ class TimerManager: ObservableObject {
     private var timerInstance: Timer?
     private var cancellables = Set<AnyCancellable>()
     private var soundPlayer: AVAudioPlayer?
+    private var smoothCloseWorkItem: DispatchWorkItem?
+    private var lifecycle = TimerLifecycle()
+
+    /// Identifies the current timer run. Delayed cleanup must match this value
+    /// before changing presentation state.
+    var activeSessionID: UUID? {
+        lifecycle.sessionID
+    }
     // MARK: - Initialization
     private init() {
         // Simple initialization
@@ -132,6 +140,7 @@ class TimerManager: ObservableObject {
     
     deinit {
         timerInstance?.invalidate()
+        smoothCloseWorkItem?.cancel()
         soundPlayer?.stop()
         cancellables.removeAll()
     }
@@ -144,6 +153,8 @@ class TimerManager: ObservableObject {
 
         // Stop any existing timer
         timerInstance?.invalidate()
+        soundPlayer?.stop()
+        beginTimerSession()
         
         // Start new timer
         withAnimation(.smooth) {
@@ -275,6 +286,7 @@ class TimerManager: ObservableObject {
         timerInstance?.invalidate()
         timerInstance = nil
         soundPlayer?.stop()
+        beginTimerSession()
 
         activeSource = .external
 
@@ -297,6 +309,16 @@ class TimerManager: ObservableObject {
 
     func updateExternalTimer(remaining: TimeInterval, totalDuration: TimeInterval?, isPaused paused: Bool, name: String? = nil) {
         guard activeSource == .external else { return }
+
+        // Clock may reuse both the timer ID and duration. A positive update
+        // after completion is nevertheless a new run and must invalidate the
+        // previous run's delayed close.
+        if remaining > 0 && (isFinished || isOvertime || remainingTime <= 0) {
+            beginTimerSession()
+            withAnimation(.smooth) {
+                isTimerActive = true
+            }
+        }
 
         if let name, !name.isEmpty, name != timerName {
             timerName = name
@@ -342,6 +364,7 @@ class TimerManager: ObservableObject {
     }
     
     private func resetTimer() {
+        endTimerSession()
         withAnimation(.smooth) {
             isTimerActive = false
         }
@@ -381,12 +404,33 @@ class TimerManager: ObservableObject {
     }
 
     private func scheduleSmoothClose() {
+        guard let sessionID = activeSessionID else { return }
+
+        smoothCloseWorkItem?.cancel()
+
         // Wait 3 seconds then smoothly close the live activity
-        DispatchQueue.main.asyncAfter(deadline: .now() + 3.0) {
+        let workItem = DispatchWorkItem { [weak self] in
+            guard let self, self.lifecycle.isCurrent(sessionID) else { return }
+            self.smoothCloseWorkItem = nil
             withAnimation(.easeInOut(duration: 1.0)) {
                 self.isTimerActive = false
             }
         }
+
+        smoothCloseWorkItem = workItem
+        DispatchQueue.main.asyncAfter(deadline: .now() + 3.0, execute: workItem)
+    }
+
+    private func beginTimerSession() {
+        smoothCloseWorkItem?.cancel()
+        smoothCloseWorkItem = nil
+        lifecycle.beginSession()
+    }
+
+    private func endTimerSession() {
+        smoothCloseWorkItem?.cancel()
+        smoothCloseWorkItem = nil
+        lifecycle.endSession()
     }
     
     private func playTimerSound() {

--- a/DynamicIsland/managers/TimerManager.swift
+++ b/DynamicIsland/managers/TimerManager.swift
@@ -133,6 +133,12 @@ class TimerManager: ObservableObject {
     var activeSessionID: UUID? {
         lifecycle.sessionID
     }
+
+    /// Session that most recently reached completion. Starting a replacement
+    /// session clears this value before any delayed cleanup can capture it.
+    var completedSessionID: UUID? {
+        lifecycle.completedSessionID
+    }
     // MARK: - Initialization
     private init() {
         // Simple initialization
@@ -341,6 +347,7 @@ class TimerManager: ObservableObject {
     func completeExternalTimer() {
         guard activeSource == .external else { return }
 
+        lifecycle.completeSession()
         remainingTime = 0
         elapsedTime = totalDuration
         isOvertime = false

--- a/tests/TimerLifecycleRegression.swift
+++ b/tests/TimerLifecycleRegression.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+@main
+struct TimerLifecycleRegression {
+    static func main() {
+        var lifecycle = TimerLifecycle()
+
+        let completedTimer = lifecycle.beginSession()
+        precondition(lifecycle.isCurrent(completedTimer))
+        var islandIsVisible = true
+
+        // Reusing the same duration or external timer ID must still create a
+        // different run. Cleanup captured for completedTimer is now stale.
+        let replacementTimer = lifecycle.beginSession()
+        precondition(replacementTimer != completedTimer)
+        precondition(!lifecycle.isCurrent(completedTimer))
+        precondition(lifecycle.isCurrent(replacementTimer))
+
+        // This is the guard used by delayed Island cleanup. The stale closure
+        // must leave the replacement timer visible.
+        if lifecycle.isCurrent(completedTimer) {
+            islandIsVisible = false
+        }
+        precondition(islandIsVisible)
+
+        lifecycle.endSession()
+        precondition(!lifecycle.isCurrent(replacementTimer))
+    }
+}

--- a/tests/TimerLifecycleRegression.swift
+++ b/tests/TimerLifecycleRegression.swift
@@ -7,6 +7,8 @@ struct TimerLifecycleRegression {
 
         let completedTimer = lifecycle.beginSession()
         precondition(lifecycle.isCurrent(completedTimer))
+        precondition(lifecycle.completeSession() == completedTimer)
+        precondition(lifecycle.completedSessionID == completedTimer)
         var islandIsVisible = true
 
         // Reusing the same duration or external timer ID must still create a
@@ -15,6 +17,7 @@ struct TimerLifecycleRegression {
         precondition(replacementTimer != completedTimer)
         precondition(!lifecycle.isCurrent(completedTimer))
         precondition(lifecycle.isCurrent(replacementTimer))
+        precondition(lifecycle.completedSessionID == nil)
 
         // This is the guard used by delayed Island cleanup. The stale closure
         // must leave the replacement timer visible.

--- a/tests/test_timer_lifecycle.py
+++ b/tests/test_timer_lifecycle.py
@@ -1,0 +1,35 @@
+import os
+import pathlib
+import subprocess
+import tempfile
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+
+class TimerLifecycleTests(unittest.TestCase):
+    def test_replacement_session_invalidates_delayed_cleanup_token(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            temporary_path = pathlib.Path(temporary_directory)
+            executable = temporary_path / "timer-lifecycle-regression"
+            environment = os.environ.copy()
+            environment["CLANG_MODULE_CACHE_PATH"] = str(temporary_path / "module-cache")
+            environment["SWIFT_MODULECACHE_PATH"] = str(temporary_path / "module-cache")
+            subprocess.run(
+                [
+                    "swiftc",
+                    str(ROOT / "DynamicIsland/managers/TimerLifecycle.swift"),
+                    str(ROOT / "tests/TimerLifecycleRegression.swift"),
+                    "-o",
+                    str(executable),
+                ],
+                check=True,
+                cwd=ROOT,
+                env=environment,
+            )
+            subprocess.run([str(executable)], check=True, cwd=ROOT)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- prevent delayed cleanup from a completed timer from hiding a newly started timer
- give each timer run a unique session identity and cancel stale smooth-close work
- handle macOS Clock timers that reuse the same duration or identifier
- add a standalone lifecycle regression test and run it in CI

## Root cause

`TimerManager.scheduleSmoothClose()` scheduled an unconditional presentation update three seconds after a timer completed. If the user stopped that timer and immediately started another timer with the same duration, the old closure set `isTimerActive` to `false` for the replacement run. The countdown itself continued, so its alarm still fired without an Island stop control.

`SystemTimerBridge` also scheduled a 3.2-second external-timer cleanup that checked only whether some external timer was active. It could therefore clear a replacement Clock timer.

## Fix

Each manual or external timer run now receives a unique session token. Starting or resetting a timer cancels pending smooth-close work, and delayed cleanup verifies that its captured token still belongs to the current session. A positive external update after completion starts a new session even if Clock reused the previous timer ID and duration.

## Validation

- `python3 -m unittest tests.test_privacy_configuration tests.test_timer_lifecycle`
- Swift parser validation for the changed sources
- manual macOS verification: complete a timer, stop it, restart the same duration within three seconds, and confirm the replacement remains visible and stoppable after both delayed-cleanup boundaries


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented delayed “smooth close” cleanup from interfering with a newly started or replacement timer session, improving stability when restarting or resetting timers (including external timer updates).

* **Tests**
  * Added a Swift regression executable to validate timer session replacement behavior.
  * Added a Python unittest that compiles and runs the regression executable.
  * Updated macOS CI to include the new timer lifecycle regression test.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->