### PR TITLE
fix(shelf): use plain bookmarks so file drops persist on macOS 26 (Tahoe)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed an issue where `BluetoothHUDAnimations` (.mov files) were missing in release builds.
 - Improved the GitHub Actions release workflow to use a monotonic build number allocator and automated patch versioning for stable releases.
 - Fixed Cursor quota parsing and display to show the current Cursor Models and Other Models billing buckets with readable long reset durations.
+- Fixed files dropped onto the Shelf silently disappearing on macOS 26 (Tahoe) by storing plain bookmarks instead of security-scoped ones, which a non-sandboxed app cannot create (#646).
 
 ### Removed
 

--- a/DynamicIsland/components/Shelf/Models/Bookmark.swift
+++ b/DynamicIsland/components/Shelf/Models/Bookmark.swift
@@ -35,8 +35,13 @@ struct Bookmark: Sendable, Equatable, Codable {
             throw NSError(domain: "Bookmark", code: 1, userInfo: [NSLocalizedDescriptionKey: "Not a valid file URL or file does not exist at \(url.path)"])
         }
         do {
+            // Atoll is not sandboxed (ENABLE_APP_SANDBOX = NO), so it already has
+            // full file access and cannot create security-scoped bookmarks:
+            // `.withSecurityScope` requires the App Sandbox entitlement and throws
+            // on macOS 26 (Tahoe), which silently dropped every shelf drop (#461/#646).
+            // Plain bookmarks are sufficient and correct for a non-sandboxed app.
             let bookmark = try url.bookmarkData(
-                options: .withSecurityScope,
+                options: [],
                 includingResourceValuesForKeys: nil,
                 relativeTo: nil
             )
@@ -55,11 +60,11 @@ struct Bookmark: Sendable, Equatable, Codable {
             do {
                 let url = try URL(
                     resolvingBookmarkData: data,
-                    options: [.withSecurityScope],
+                    options: [],
                     relativeTo: nil,
                     bookmarkDataIsStale: &isStale
                 )
-                if isStale, let newData = try? url.bookmarkData(options: [.withSecurityScope]) {
+                if isStale, let newData = try? url.bookmarkData(options: []) {
                     NSLog("⚠️ Bookmark was stale for \(url.path), refreshed")
                     return (url, newData)
                 }
@@ -81,11 +86,11 @@ struct Bookmark: Sendable, Equatable, Codable {
         do {
             let url = try URL(
                 resolvingBookmarkData: data,
-                options: [.withSecurityScope],
+                options: [],
                 relativeTo: nil,
                 bookmarkDataIsStale: &isStale
             )
-            if isStale, let newData = try? url.bookmarkData(options: [.withSecurityScope]) {
+            if isStale, let newData = try? url.bookmarkData(options: []) {
                 NSLog("⚠️ Bookmark was stale for \(url.path), refreshed")
                 return (url, newData)
             }


### PR DESCRIPTION
## Problem
On macOS 26 (Tahoe), dragging a file onto the File Shelf did nothing — the dropped file never appeared/stayed.

## Root cause
`Bookmark.swift` creates bookmarks for dropped files with `.withSecurityScope`. Atoll is **not** sandboxed (`ENABLE_APP_SANDBOX = NO`), and `URL.bookmarkData(options: .withSecurityScope)` requires the App Sandbox entitlement — on macOS 26 it now throws for non-sandboxed apps (older macOS tolerated it). The throw is swallowed by `try?` in `ShelfDropService.createBookmark`, so every dropped file is silently discarded and never added to the shelf.

## Fix
Non-sandboxed apps already have full file access and don't need (nor qualify for) security-scoped bookmarks. Create and resolve **plain** bookmarks (`options: []`) in `Bookmark.swift` for both creation and resolution (including the stale-refresh paths).

## Testing
- Build & run in Xcode on macOS 26.
- Drag a file from Finder onto the shelf → the file now appears and persists (previously it vanished silently).
- Verified on macOS 26.5.2.

Relates to #646 / #545 (shelf drag-and-drop on newer macOS).

> Note: there is a **separate, pre-existing** ~10s drag stall on macOS 26 caused by the notch window resizing during an active drag (Core Drag reentrancy: `kDragIPCWithinWindow` / `kDragIPCEnterLeaveHandler`). That is an independent issue (#646) and is **not** addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue on macOS 26 that could cause Shelf files to disappear.
  * Improved bookmark handling so saved files remain accessible and are reliably restored when bookmark data becomes outdated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->