### PR TITLE
feat(shelf): add hover remove (×) button to shelf items (#461)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **AntiGravity Usage Tracking**: Track how much of Antigravity usage is left in the LLM Usage Monitor tab (both Gemini and Claude models)
+- **Shelf item removal**: Hovering a Shelf item now reveals a × button that removes just that item, with a VoiceOver-accessible "Remove from Shelf" action that works without hovering (#461).
 
 ### Changed
 - Improved the Dutch localization by adding missing translations, corrected terminology, and wording aligned with Apple's Dutch macOS conventions.

--- a/DynamicIsland/components/Shelf/Views/ShelfItemView.swift
+++ b/DynamicIsland/components/Shelf/Views/ShelfItemView.swift
@@ -77,6 +77,13 @@ struct ShelfItemView: View {
                         removeButton
                     }
                 }
+                // Keep removal reachable without hover (VoiceOver / keyboard):
+                // expose the item as one element with a named remove action.
+                .accessibilityElement(children: .combine)
+                .accessibilityLabel(viewModel.displayName.isEmpty ? Text("Shelf item") : Text(viewModel.displayName))
+                .accessibilityAction(named: Text("Remove from Shelf")) {
+                    ShelfActionService.remove(item)
+                }
 
                 DraggableClickHandler(
                     item: item,
@@ -160,21 +167,29 @@ struct ShelfItemView: View {
     /// Hover-revealed circular remove button in the top-trailing corner.
     /// Removes just this item from the shelf via the same path as the
     /// right-click "Remove" menu item (`ShelfActionService.remove`).
+    /// Uses a `Button` (not a bare tap gesture) so it carries button
+    /// semantics for VoiceOver; the item also exposes a hover-independent
+    /// "Remove from Shelf" accessibility action (see `body`).
     private var removeButton: some View {
-        Circle()
-            .fill(.white)
-            .frame(width: ShelfRemoveButton.size, height: ShelfRemoveButton.size)
-            .overlay(
-                Image(systemName: "xmark")
-                    .font(.system(size: 8, weight: .bold))
-                    .foregroundStyle(.black)
-            )
-            .shadow(color: .black.opacity(0.4), radius: 2)
-            .contentShape(Circle())
-            .onTapGesture { ShelfActionService.remove(item) }
-            .padding(ShelfRemoveButton.inset)
-            .help("Remove from Shelf")
-            .transition(.scale.combined(with: .opacity))
+        Button {
+            ShelfActionService.remove(item)
+        } label: {
+            Circle()
+                .fill(.white)
+                .frame(width: ShelfRemoveButton.size, height: ShelfRemoveButton.size)
+                .overlay(
+                    Image(systemName: "xmark")
+                        .font(.system(size: 8, weight: .bold))
+                        .foregroundStyle(.black)
+                )
+                .shadow(color: .black.opacity(0.4), radius: 2)
+        }
+        .buttonStyle(.plain)
+        .contentShape(Circle())
+        .padding(ShelfRemoveButton.inset)
+        .help("Remove from Shelf")
+        .accessibilityLabel("Remove from Shelf")
+        .transition(.scale.combined(with: .opacity))
     }
 
     private var backgroundView: some View {

--- a/DynamicIsland/components/Shelf/Views/ShelfItemView.swift
+++ b/DynamicIsland/components/Shelf/Views/ShelfItemView.swift
@@ -26,6 +26,19 @@ import Defaults
 
 import QuickLook
 
+/// Layout metrics for the hover-revealed remove (x) button on a shelf item.
+/// Shared between the SwiftUI overlay and the AppKit drag view's hit-testing so
+/// the corner the button occupies is excluded from the drag/click handler.
+private enum ShelfRemoveButton {
+    /// Diameter of the circular remove button.
+    static let size: CGFloat = 20
+    /// Inset of the button from the item's top-trailing corner.
+    static let inset: CGFloat = 2
+    /// Square corner region (top-trailing) reserved for the button while
+    /// hovering, so clicks there hit the button instead of the drag view.
+    static let hitRegion: CGFloat = 30
+}
+
 struct ShelfItemView: View {
     let item: ShelfItem
     @EnvironmentObject var vm: DynamicIslandViewModel
@@ -35,6 +48,7 @@ struct ShelfItemView: View {
     @State private var showStack = false
     @State private var cachedPreviewImage: NSImage?
     @State private var debouncedDropTarget = false
+    @State private var isHovering = false
 
     private var isSelected: Bool { viewModel.isSelected }
     private var shouldHideDuringDrag: Bool { selection.isDragging && selection.isSelected(item.id) && false }
@@ -58,10 +72,25 @@ struct ShelfItemView: View {
                 .contentShape(Rectangle())
                 .animation(.easeInOut(duration: 0.1), value: debouncedDropTarget)
                 .animation(.easeInOut(duration: 0.1), value: isSelected)
+                .overlay(alignment: .topTrailing) {
+                    if isHovering {
+                        removeButton
+                    }
+                }
 
                 DraggableClickHandler(
                     item: item,
                     viewModel: viewModel,
+                    isHovering: isHovering,
+                    // Hover is detected here (in the AppKit drag view via a
+                    // tracking area) rather than with SwiftUI's `.onHover`,
+                    // because this NSView sits on top of the cell and
+                    // intercepts the mouse-tracking `.onHover` would need.
+                    onHoverChange: { hovering in
+                        withAnimation(.smooth(duration: 0.15)) {
+                            isHovering = hovering
+                        }
+                    },
                     cachedPreviewImage: $cachedPreviewImage,
                     dragPreviewContent: {
                         DragPreviewView(thumbnail: viewModel.thumbnail ?? viewModel.icon, displayName: viewModel.displayName)
@@ -128,6 +157,26 @@ struct ShelfItemView: View {
             .frame(height: 30, alignment: .top)
     }
 
+    /// Hover-revealed circular remove button in the top-trailing corner.
+    /// Removes just this item from the shelf via the same path as the
+    /// right-click "Remove" menu item (`ShelfActionService.remove`).
+    private var removeButton: some View {
+        Circle()
+            .fill(.white)
+            .frame(width: ShelfRemoveButton.size, height: ShelfRemoveButton.size)
+            .overlay(
+                Image(systemName: "xmark")
+                    .font(.system(size: 8, weight: .bold))
+                    .foregroundStyle(.black)
+            )
+            .shadow(color: .black.opacity(0.4), radius: 2)
+            .contentShape(Circle())
+            .onTapGesture { ShelfActionService.remove(item) }
+            .padding(ShelfRemoveButton.inset)
+            .help("Remove from Shelf")
+            .transition(.scale.combined(with: .opacity))
+    }
+
     private var backgroundView: some View {
         RoundedRectangle(cornerRadius: 12, style: .continuous)
             .fill(backgroundColor)
@@ -187,24 +236,30 @@ struct ShelfItemView: View {
 private struct DraggableClickHandler<Content: View>: NSViewRepresentable {
     let item: ShelfItem
     let viewModel: ShelfItemViewModel
+    let isHovering: Bool
+    let onHoverChange: (Bool) -> Void
     @Binding var cachedPreviewImage: NSImage?
     @ViewBuilder let dragPreviewContent: () -> Content
     let onRightClick: (NSEvent, NSView) -> Void
     let onClick: (NSEvent, NSView) -> Void
-    
+
     func makeNSView(context: Context) -> DraggableClickView {
         let view = DraggableClickView()
         view.item = item
         view.viewModel = viewModel
+        view.isHovering = isHovering
+        view.onHoverChange = onHoverChange
         view.dragPreviewImage = cachedPreviewImage ?? renderDragPreview()
         view.onRightClick = onRightClick
         view.onClick = onClick
         return view
     }
-    
+
     func updateNSView(_ nsView: DraggableClickView, context: Context) {
         nsView.item = item
         nsView.viewModel = viewModel
+        nsView.isHovering = isHovering
+        nsView.onHoverChange = onHoverChange
         // Only update preview if cached version is available
         if let cached = cachedPreviewImage {
             nsView.dragPreviewImage = cached
@@ -232,13 +287,54 @@ private struct DraggableClickHandler<Content: View>: NSViewRepresentable {
         var dragPreviewImage: NSImage?
         var onRightClick: ((NSEvent, NSView) -> Void)?
         var onClick: ((NSEvent, NSView) -> Void)?
+        var onHoverChange: ((Bool) -> Void)?
+        var isHovering = false
 
         private var mouseDownEvent: NSEvent?
         private let dragThreshold: CGFloat = 3.0
         private var draggedURLs: [URL] = []
         private var draggedItems: [ShelfItem] = []
         private var didStartDragSession = false
-        
+
+        // Detect hover here (this NSView sits on top of the cell and would
+        // otherwise swallow the mouse tracking SwiftUI's `.onHover` relies on).
+        override func updateTrackingAreas() {
+            super.updateTrackingAreas()
+            for area in trackingAreas { removeTrackingArea(area) }
+            let area = NSTrackingArea(
+                rect: .zero,
+                options: [.mouseEnteredAndExited, .activeAlways, .inVisibleRect],
+                owner: self,
+                userInfo: nil
+            )
+            addTrackingArea(area)
+        }
+
+        override func mouseEntered(with event: NSEvent) {
+            onHoverChange?(true)
+        }
+
+        override func mouseExited(with event: NSEvent) {
+            onHoverChange?(false)
+        }
+
+        override func hitTest(_ point: NSPoint) -> NSView? {
+            // While hovering, yield the top-trailing corner to the SwiftUI
+            // remove (x) button drawn beneath this drag view, so tapping it
+            // removes the item instead of opening it or starting a drag.
+            if isHovering {
+                let local = convert(point, from: superview)
+                let corner = NSRect(
+                    x: bounds.maxX - ShelfRemoveButton.hitRegion,
+                    y: bounds.maxY - ShelfRemoveButton.hitRegion,
+                    width: ShelfRemoveButton.hitRegion,
+                    height: ShelfRemoveButton.hitRegion
+                )
+                if corner.contains(local) { return nil }
+            }
+            return super.hitTest(point)
+        }
+
         override func rightMouseDown(with event: NSEvent) {
             onRightClick?(event, self)
         }


### PR DESCRIPTION
Closes #461.

## Problem
Shelf items could only be removed via the right-click "Remove" menu, which the reporter found tedious. They asked for a visible × (remove) button on hover, like boring.notch.

## Change
- Adds a hover-revealed circular × button in each shelf item's top-trailing corner (`ShelfItemView`). Tapping it removes that item via the same path as the menu (`ShelfActionService.remove`).
- Hover is detected with an `NSTrackingArea` on the item's `DraggableClickView` — that AppKit view handles click/drag and sits on top of the cell, so it would otherwise swallow the mouse tracking SwiftUI's `.onHover` needs.
- While hovering, the button's top-trailing corner is excluded from `DraggableClickView.hitTest`, so a tap there reaches the SwiftUI button (remove) instead of opening/dragging the item.

## Testing (macOS 26.5.2)
- Hover a shelf item → × appears top-right; click it → item is removed.
- Regression checked: normal click (open / Quick Look), drag-out, and the right-click "Remove" menu still work; clicking just outside the × does not remove.

> Pairs with #648 (file-drop persistence fix): on macOS 26 that fix is needed to get items into the shelf to exercise this button.

_Screen recording (hover → × → delete) to be attached._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a hover-revealed “Remove” (×) button for shelf items.
  * Added a VoiceOver-accessible “Remove from Shelf” action without requiring hover.
* **User Experience**
  * Added smooth visibility and scale transitions for the removal button.
  * Improved top-right corner hit detection so removal clicks work reliably without triggering drag or open actions.
* **Documentation**
  * Documented the new shelf item removal options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

### Screenshots / Recording
<!-- Aşağıya dosyayı sürükle-bırak; GitHub otomatik yükler -->
_Screen recording: hover a shelf item → the × appears → click it → the item is removed._