### PR TITLE
fix(hud): keep all AirPods listening modes visible in the notch HUD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improved the GitHub Actions release workflow to use a monotonic build number allocator and automated patch versioning for stable releases.
 - Fixed Cursor quota parsing and display to show the current Cursor Models and Other Models billing buckets with readable long reset durations.
 - Fixed the AirPods pause gesture opening Siri instead of pausing Spotify: the real-time waveform no longer process-taps Spotify while a Bluetooth output route is active, and the tap is rebuilt whenever the output route changes.
+- Fixed Noise Cancellation, Adaptive Audio, and Conversation Awareness labels being clipped behind the notch in the AirPods listening-mode HUD; every mode is now trailing-aligned and scales down instead of scrolling.
 
 ### Removed
 

--- a/DynamicIsland/components/Live activities/InlineHUD.swift
+++ b/DynamicIsland/components/Live activities/InlineHUD.swift
@@ -364,30 +364,25 @@ struct InlineHUD: View {
                     if let listeningMode {
                         let listeningModeTextWidth: CGFloat = enableMinimalisticUI ? 96 : 124
 
-                        HStack(spacing: 0) {
-                            Spacer(minLength: 0)
-                            if listeningMode == .off || listeningMode == .transparency {
-                                Text(listeningMode.displayName)
-                                    .font(.caption.weight(.medium))
-                                    .foregroundStyle(.white)
-                                    .lineLimit(1)
-                                    .allowsTightening(true)
-                                    .frame(
-                                        width: min(max(trailingWidth - 44, 64), listeningModeTextWidth),
-                                        alignment: .trailing
-                                    )
-                            } else {
-                                MarqueeText(
-                                    .constant(listeningMode.displayName),
-                                    font: .caption.weight(.medium),
-                                    nsFont: .caption1,
-                                    textColor: .white,
-                                    minDuration: 0.6,
-                                    frameWidth: min(max(trailingWidth - 44, 64), listeningModeTextWidth)
-                                )
-                            }
-                        }
-                        .frame(maxWidth: .infinity, alignment: .trailing)
+                        // Render every mode label with a trailing-aligned Text.
+                        // The previous MarqueeText path is `.leading`-aligned
+                        // internally, so the longer modes (Noise Cancellation /
+                        // Adaptive Audio / Conversation Awareness) hugged the notch
+                        // edge and were clipped behind it — only the short,
+                        // trailing-aligned modes (Transparency / Off) stayed
+                        // visible. A scaling Text keeps every mode on screen.
+                        Text(listeningMode.displayName)
+                            .font(.caption.weight(.medium))
+                            .foregroundStyle(.white)
+                            .lineLimit(1)
+                            .minimumScaleFactor(0.6)
+                            .truncationMode(.tail)
+                            .allowsTightening(true)
+                            .frame(
+                                width: min(max(trailingWidth - 44, 64), listeningModeTextWidth),
+                                alignment: .trailing
+                            )
+                            .frame(maxWidth: .infinity, alignment: .trailing)
                     } else if hasBatteryLevel {
                         let indicatorSpacing: CGFloat = {
                             if useCircularIndicator {


### PR DESCRIPTION
## Problem
When the AirPods listening mode changes, only **Transparency** (and Off) showed in the notch HUD; **Noise Cancellation**, **Adaptive Audio**, and **Conversation Awareness** stayed hidden behind the notch.

## Root cause
In `InlineHUD.swift`, the trailing mode label used a trailing-aligned `Text` **only** for `.transparency`/`.off`, and a `MarqueeText` for the longer modes. `MarqueeText` is `.leading`-aligned internally, so those labels hugged the notch edge and were clipped behind it — while the trailing-aligned `Text` modes stayed visible.

## Fix
Render every listening mode with a single **trailing-aligned, scaling `Text`** (`minimumScaleFactor(0.6)`, `truncationMode(.tail)`). All modes now stay visible; long names shrink/truncate instead of scrolling.

Tested on macOS 26.5.2.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Bluetooth listening-mode labels in the Dynamic Island display.
  * Long labels now fit more reliably through adaptive sizing, width constraints, and tail truncation.
  * Aligned labels to the trailing edge for clearer presentation.
  * Removed scrolling text behavior that could cause labels to clip near the notch.
* **Documentation**
  * Added a changelog entry describing the listening-mode label display improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->