### PR TITLE
fix(audio): stop Spotify process-tap from hijacking AirPods media control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed an issue where `BluetoothHUDAnimations` (.mov files) were missing in release builds.
 - Improved the GitHub Actions release workflow to use a monotonic build number allocator and automated patch versioning for stable releases.
 - Fixed Cursor quota parsing and display to show the current Cursor Models and Other Models billing buckets with readable long reset durations.
+- Fixed the AirPods pause gesture opening Siri instead of pausing Spotify: the real-time waveform no longer process-taps Spotify while a Bluetooth output route is active, and the tap is rebuilt whenever the output route changes.
 
 ### Removed
 

--- a/DynamicIsland/DynamicIslandApp.swift
+++ b/DynamicIsland/DynamicIslandApp.swift
@@ -130,6 +130,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     
     // Debouncing mechanism for window size updates
     private var windowSizeUpdateWorkItem: DispatchWorkItem?
+
+    // Block-based AudioTap observers, kept with their center so they can be removed by token
+    private var audioTapObserverTokens: [(center: NotificationCenter, token: NSObjectProtocol)] = []
 //    let calendarManager = CalendarManager.shared
 //    let webcamManager = WebcamManager.shared
 //    var closeNotchWorkItem: DispatchWorkItem?
@@ -187,6 +190,12 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     
     /// Setup observers for music player state changes to restart AudioTap capture
     private func setupAudioTapMusicObservers() {
+        // Registration is additive and this runs again every time the waveform setting is
+        // switched back on, so drop the previous generation instead of stacking duplicates.
+        // Block-based observers are only removable through the token they return, which is
+        // why they are retained in `audioTapObserverTokens`.
+        tearDownAudioTapMusicObservers()
+
         // Listen for app launches to restart capture when music apps are opened
         let targetBundleIDs = [
             "com.apple.Music",
@@ -202,7 +211,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             "com.coppertino.Vox",
         ]
         
-        NSWorkspace.shared.notificationCenter.addObserver(
+        let launchToken = NSWorkspace.shared.notificationCenter.addObserver(
             forName: NSWorkspace.didLaunchApplicationNotification,
             object: nil,
             queue: .main
@@ -222,7 +231,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         }
         
         // Also observe app terminations to restart capture
-        NSWorkspace.shared.notificationCenter.addObserver(
+        let terminateToken = NSWorkspace.shared.notificationCenter.addObserver(
             forName: NSWorkspace.didTerminateApplicationNotification,
             object: nil,
             queue: .main
@@ -242,7 +251,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         // disconnect). AudioTap skips Spotify while a Bluetooth route is active to keep the
         // AirPods pause gesture working, so the tap must be rebuilt to re-include or exclude
         // Spotify whenever the route flips.
-        NotificationCenter.default.addObserver(
+        let routeToken = NotificationCenter.default.addObserver(
             forName: .systemAudioRouteDidChange,
             object: nil,
             queue: .main
@@ -252,8 +261,22 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                 AudioTap.shared.restartCapture()
             }
         }
+
+        audioTapObserverTokens = [
+            (NSWorkspace.shared.notificationCenter, launchToken),
+            (NSWorkspace.shared.notificationCenter, terminateToken),
+            (NotificationCenter.default, routeToken),
+        ]
     }
-    
+
+    /// Removes the AudioTap observers registered by `setupAudioTapMusicObservers()`.
+    private func tearDownAudioTapMusicObservers() {
+        for (center, token) in audioTapObserverTokens {
+            center.removeObserver(token)
+        }
+        audioTapObserverTokens.removeAll()
+    }
+
     func applicationWillTerminate(_ notification: Notification) {
         let userInfo: [String: Any] = [
             AtollDistributedNotifications.UserInfoKey.sourcePID: NSNumber(value: ProcessInfo.processInfo.processIdentifier)
@@ -680,6 +703,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                     self?.setupAudioTapMusicObservers()
                 } else {
                     AudioTap.shared.stopCapture()
+                    self?.tearDownAudioTapMusicObservers()
                 }
             }
             .store(in: &cancellables)

--- a/DynamicIsland/DynamicIslandApp.swift
+++ b/DynamicIsland/DynamicIslandApp.swift
@@ -237,6 +237,21 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                 AudioTap.shared.restartCapture()
             }
         }
+
+        // Restart capture when the audio output route changes (e.g. AirPods connect/
+        // disconnect). AudioTap skips Spotify while a Bluetooth route is active to keep the
+        // AirPods pause gesture working, so the tap must be rebuilt to re-include or exclude
+        // Spotify whenever the route flips.
+        NotificationCenter.default.addObserver(
+            forName: .systemAudioRouteDidChange,
+            object: nil,
+            queue: .main
+        ) { _ in
+            if Defaults[.enableRealTimeWaveform] {
+                print("🔀 [AudioTap] Audio route changed, restarting capture...")
+                AudioTap.shared.restartCapture()
+            }
+        }
     }
     
     func applicationWillTerminate(_ notification: Notification) {

--- a/DynamicIsland/audio/AudioTap.swift
+++ b/DynamicIsland/audio/AudioTap.swift
@@ -23,6 +23,7 @@
 import AppKit
 import AudioToolbox
 import CoreAudio
+import Defaults
 import simd
 import os.log
 
@@ -315,6 +316,13 @@ class AudioTap: NSObject {
                 self?.stopCaptureSync()
                 // Small delay to let CoreAudio fully release resources
                 Thread.sleep(forTimeInterval: 0.1)
+                // Re-read the setting instead of trusting the state at scheduling time: the
+                // waveform can be switched off during the debounce window, and a stale
+                // restart must not bring capture back up behind the user's back.
+                guard Defaults[.enableRealTimeWaveform] else {
+                    print("⏹️ [AudioTap] Waveform disabled during restart, staying stopped")
+                    return
+                }
                 self?.startCaptureSync()
             }
         }
@@ -323,6 +331,11 @@ class AudioTap: NSObject {
     }
 
     func stopCapture() {
+        // Drop a queued restart first, otherwise a debounced route/app change can resurrect
+        // capture right after the caller asked us to stop.
+        pendingRestartWorkItem?.cancel()
+        pendingRestartWorkItem = nil
+
         audioQueue.sync { [weak self] in
             self?.stopCaptureSync()
         }

--- a/DynamicIsland/audio/AudioTap.swift
+++ b/DynamicIsland/audio/AudioTap.swift
@@ -172,8 +172,21 @@ class AudioTap: NSObject {
         let runningApps = NSWorkspace.shared.runningApplications
         var targetPIDs: [AudioDeviceID] = []
 
+        // AirPods/Bluetooth output + Spotify don't mix: process-tapping Spotify into our
+        // private aggregate device disturbs the system Now Playing / AVRCP session, so the
+        // AirPods pause gesture finds no target and macOS falls back to Siri. Spotify is
+        // controlled via AppleScript and registers weakly with MediaRemote, which is why
+        // only it is affected (Apple Music etc. stay registered). While a Bluetooth route is
+        // active, skip tapping Spotify to preserve media control — the visualizer stays live
+        // for Spotify on wired/built-in output and for every other app on any output.
+        let bluetoothOutputActive = AudioRouteManager.shared.isDefaultOutputBluetooth()
+
         for app in runningApps {
             if let bundleID = app.bundleIdentifier, targetBundleIDs.contains(bundleID) {
+                if bundleID == SpotifyController.bundleIdentifier, bluetoothOutputActive {
+                    print("⏭️ [AudioTap] Bluetooth output active — skipping Spotify tap to preserve AirPods media control")
+                    continue
+                }
                 if let deviceID = getAudioObjectID(for: app.processIdentifier) {
                     targetPIDs.append(deviceID)
                     print("🎯 [AudioTap] Found \(app.localizedName ?? "App") with PID: \(app.processIdentifier), AudioObjectID: \(deviceID)")

--- a/DynamicIsland/managers/AudioRouteManager.swift
+++ b/DynamicIsland/managers/AudioRouteManager.swift
@@ -120,6 +120,20 @@ final class AudioRouteManager: ObservableObject {
         }
     }
 
+    /// Whether the current system default output device is a Bluetooth route (e.g. AirPods).
+    /// Queried synchronously against CoreAudio so callers on background queues get a fresh value
+    /// rather than the async-updated `activeDevice` snapshot.
+    func isDefaultOutputBluetooth() -> Bool {
+        let deviceID = fetchDefaultOutputDevice()
+        guard deviceID != 0 else { return false }
+        switch transportType(for: deviceID) {
+        case kAudioDeviceTransportTypeBluetooth, kAudioDeviceTransportTypeBluetoothLE:
+            return true
+        default:
+            return false
+        }
+    }
+
     // MARK: - Private
 
     @objc private func handleRouteChange() {


### PR DESCRIPTION
## Problem

When the real-time waveform visualizer is enabled and **Spotify** is playing through a **Bluetooth output route (e.g. AirPods)**, the AirPods pause gesture fails to pause the music and macOS falls back to invoking **Siri** instead.

## Root cause

`AudioTap` process-taps every target music app (including Spotify) into a private CoreAudio aggregate device (`Atoll_Virtual_Tap`) for the visualizer. On a Bluetooth route this disturbs the system Now Playing / AVRCP session, so the AirPods pause gesture finds no valid target and the system routes it to Siri.

Only Spotify is affected because it is controlled via AppleScript and registers only weakly with MediaRemote — unlike Apple Music, which stays properly registered and keeps working.

## Fix

- **`AudioRouteManager`** — add `isDefaultOutputBluetooth()`, querying CoreAudio directly (works from background queues, unlike the async `activeDevice` snapshot).
- **`AudioTap`** — skip tapping Spotify while a Bluetooth output route is active. The visualizer stays live for Spotify on wired/built-in output and for every other app on any output; only the Spotify-on-Bluetooth combination is skipped.
- **`DynamicIslandApp`** — restart capture on `.systemAudioRouteDidChange` so Spotify is re-included/excluded when AirPods connect or disconnect (previously the tap was only rebuilt on app launch/terminate).

## Testing

- Builds cleanly (`Debug`, `CODE_SIGNING_ALLOWED=NO`).
- Manual: with visualizer on + AirPods connected + Spotify playing → AirPods pause now pauses Spotify (no Siri). Switching output to built-in speakers restores the Spotify visualizer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved real-time waveform capture when switching audio routes, including Bluetooth devices such as AirPods.
  * Prevented Spotify audio capture from interfering with Bluetooth output while continuing to support other audio sources.
  * Automatically refreshes audio capture after audio-route changes for more reliable waveform behavior.
  * Prevented duplicate audio callbacks and ensured capture stops cleanly when waveform mode is disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->