### PR TITLE
Update Chinese translation from '免费' to '空闲'（Free）

### DIFF
--- a/DynamicIsland/Localizable.xcstrings
+++ b/DynamicIsland/Localizable.xcstrings
@@ -29459,7 +29459,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "免费"
+            "value" : "空闲"
           }
         }
       }


### PR DESCRIPTION
This pull request updates the Simplified Chinese translation for a string in the DynamicIsland/Localizable.xcstrings file. The translation for the string has been changed from "免费" to "空闲".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Simplified Chinese localization for the empty/free state to display “空闲” for improved clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->