### PR TITLE
Change '光标' to 'Cursor' in Chinese localization

### DIFF
--- a/DynamicIsland/Localizable.xcstrings
+++ b/DynamicIsland/Localizable.xcstrings
@@ -19058,7 +19058,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "光标"
+            "value" : "Cursor"
           }
         }
       }


### PR DESCRIPTION
I think it  needn't to be translated.In Chinese, we also call it "cursor", not "光标".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the Simplified Chinese display text for “Cursor” to ensure consistent labeling across the app.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->