### PR TITLE
feat(i18n): add Traditional Chinese (zh-Hant) localization

### DIFF
--- a/DynamicIsland/Localizable.xcstrings
+++ b/DynamicIsland/Localizable.xcstrings
@@ -110,6 +110,12 @@
             "state" : "needs_review",
             "value" : ""
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : ""
+          }
         }
       }
     },
@@ -222,6 +228,12 @@
             "state" : "translated",
             "value" : " – %lld"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : " – %lld"
+          }
         }
       }
     },
@@ -266,6 +278,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : " %@"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : " %@"
@@ -315,6 +333,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "-%@"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "-%@"
@@ -373,6 +397,12 @@
             "state" : "translated",
             "value" : "—"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "—"
+          }
         }
       }
     },
@@ -417,6 +447,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "："
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "："
@@ -534,6 +570,12 @@
             "state" : "needs_review",
             "value" : "“当前播放”是以前版本中唯一的选项，并适用于所有媒体应用。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "「正在播放」是以前版本中唯一的選項，並適用於所有媒體 App。"
+          }
         }
       }
     },
@@ -642,6 +684,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "(%@)"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "(%@)"
@@ -759,6 +807,12 @@
             "state" : "needs_review",
             "value" : "%.0f 秒"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%.0f 秒"
+          }
         }
       }
     },
@@ -868,6 +922,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%.1f秒"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%.1f秒"
@@ -985,6 +1045,12 @@
             "state" : "needs_review",
             "value" : "%@"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%@"
+          }
         }
       }
     },
@@ -1039,6 +1105,12 @@
             "state" : "translated",
             "value" : "%@ · %@"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ · %@"
+          }
         }
       }
     },
@@ -1050,6 +1122,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@-kanaal"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ 通道"
           }
         }
       }
@@ -1080,6 +1158,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "剩余 %@"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "剩餘 %@"
           }
         }
       }
@@ -1134,6 +1218,12 @@
             "state" : "translated",
             "value" : "%@ 模型"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ 模型"
+          }
         }
       }
     },
@@ -1178,6 +1268,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ 偏移"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ 偏移"
@@ -1230,6 +1326,12 @@
             "state" : "translated",
             "value" : "%@ pt"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ pt"
+          }
         }
       }
     },
@@ -1274,6 +1376,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@："
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@："
@@ -1326,6 +1434,12 @@
             "state" : "translated",
             "value" : "%@。专注模式已激活：%@"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@。專注模式已啟用：%@"
+          }
         }
       }
     },
@@ -1374,6 +1488,12 @@
             "state" : "translated",
             "value" : "%@°"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@°"
+          }
         }
       }
     },
@@ -1404,6 +1524,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%0.1f"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%0.1f"
@@ -1520,6 +1646,12 @@
             "state" : "needs_review",
             "value" : "%d%%"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%d%%"
+          }
         }
       }
     },
@@ -1550,6 +1682,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%lld"
@@ -1593,6 +1731,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld %@"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%lld %@"
@@ -1658,6 +1802,12 @@
             "state" : "translated",
             "value" : "%lld 个动画"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld 個動畫"
+          }
         }
       }
     },
@@ -1705,6 +1855,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%lld 字符"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld 字元"
           }
         }
       }
@@ -1759,6 +1915,12 @@
             "state" : "translated",
             "value" : "%lld 种颜色"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld 種顏色"
+          }
         }
       }
     },
@@ -1803,6 +1965,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld 天%@前"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%lld 天%@前"
@@ -1855,6 +2023,12 @@
             "state" : "translated",
             "value" : "%lld 小时%@前"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld 小時%@前"
+          }
         }
       }
     },
@@ -1890,6 +2064,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%lld 分钟"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld 分鐘"
           }
         }
       },
@@ -1940,6 +2120,12 @@
             "state" : "translated",
             "value" : "%lld 分钟%@前"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld 分鐘%@前"
+          }
         }
       }
     },
@@ -1982,6 +2168,12 @@
             "state" : "translated",
             "value" : "%lld pt"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld pt"
+          }
         }
       }
     },
@@ -2018,6 +2210,12 @@
             "state" : "translated",
             "value" : "%lld 像素"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld 畫素"
+          }
         }
       },
       "shouldTranslate" : false
@@ -2051,6 +2249,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld 秒"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%lld 秒"
@@ -2103,6 +2307,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "已启用 %lld 个标签页%@ · 最小 %lld 像素"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已啟用 %lld 個分頁%@ · 最小 %lld 畫素"
           }
         }
       }
@@ -2216,6 +2426,12 @@
             "state" : "needs_review",
             "value" : "%lld%%"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%lld%%"
+          }
         }
       },
       "shouldTranslate" : false
@@ -2229,6 +2445,12 @@
             "state" : "translated",
             "value" : "%lld%% over"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "剩餘 %lld%%"
+          }
         }
       }
     },
@@ -2240,6 +2462,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%lld%% gebruikt"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已使用 %lld%%"
           }
         }
       }
@@ -2283,6 +2511,12 @@
             "state" : "translated",
             "value" : "%lld天前"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld天前"
+          }
         }
       }
     },
@@ -2305,6 +2539,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%lld дн. назад"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld 天前"
           }
         }
       }
@@ -2348,6 +2588,12 @@
             "state" : "translated",
             "value" : "%lld小时"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld小時"
+          }
         }
       }
     },
@@ -2390,6 +2636,12 @@
             "state" : "translated",
             "value" : "%lld小时前"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld小時前"
+          }
         }
       }
     },
@@ -2412,6 +2664,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%lld ч. назад"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld 小時前"
           }
         }
       }
@@ -2455,6 +2713,12 @@
             "state" : "translated",
             "value" : "%lld分钟"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld分鐘"
+          }
         }
       }
     },
@@ -2497,6 +2761,12 @@
             "state" : "translated",
             "value" : "%lld分钟前"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld分鐘前"
+          }
         }
       }
     },
@@ -2519,6 +2789,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%lld мин. назад"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld 分鐘前"
           }
         }
       }
@@ -2544,6 +2820,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld秒"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%lld秒"
@@ -2588,6 +2870,12 @@
             "state" : "translated",
             "value" : "%lldx"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lldx"
+          }
         }
       },
       "shouldTranslate" : false
@@ -2627,6 +2915,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "•"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "•"
@@ -2745,6 +3039,12 @@
             "state" : "needs_review",
             "value" : "• Bug 修复"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "• Bug 修復"
+          }
         }
       }
     },
@@ -2795,6 +3095,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "• 磨砂玻璃：半透明模糊效果"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "• 磨砂玻璃：半透明模糊效果"
@@ -2911,6 +3217,12 @@
             "state" : "needs_review",
             "value" : "• 提升性能"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "• 提升效能"
+          }
         }
       }
     },
@@ -2964,6 +3276,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "• 液态玻璃：现代玻璃效果（macOS 26+）"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "• 液態玻璃：現代玻璃效果（macOS 26+）"
           }
         }
       }
@@ -3077,6 +3395,12 @@
             "state" : "needs_review",
             "value" : "• 新功能1"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "• 新功能1"
+          }
         }
       }
     },
@@ -3131,6 +3455,12 @@
             "state" : "translated",
             "value" : "• 纯色深色/浅色/自动：不透明背景"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "• 純色深色/淺色/自動：不透明背景"
+          }
         }
       }
     },
@@ -3184,6 +3514,12 @@
             "state" : "translated",
             "value" : "• 思考中"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "• 思考中"
+          }
         }
       }
     },
@@ -3231,6 +3567,12 @@
             "state" : "translated",
             "value" : "• 更新于 %@"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "• 更新於 %@"
+          }
         }
       }
     },
@@ -3261,6 +3603,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "••••••••"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "••••••••"
@@ -3318,6 +3666,12 @@
             "state" : "translated",
             "value" : "+%lld 更多"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "+%lld 更多"
+          }
         }
       }
     },
@@ -3361,6 +3715,12 @@
             "state" : "translated",
             "value" : "±10 秒"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "±10 秒"
+          }
         }
       }
     },
@@ -3393,6 +3753,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "0"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "0"
@@ -3434,6 +3800,12 @@
             "state" : "translated",
             "value" : "00"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "00"
+          }
         }
       },
       "shouldTranslate" : false
@@ -3467,6 +3839,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "00:05:00"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "00:05:00"
@@ -3512,6 +3890,12 @@
             "state" : "translated",
             "value" : "1 小时"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1 小時"
+          }
         }
       }
     },
@@ -3552,6 +3936,12 @@
             "state" : "translated",
             "value" : "1 分钟"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1 分鐘"
+          }
         }
       }
     },
@@ -3581,6 +3971,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "1. 在浏览器中打开 Spotify 并登录"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1. 在瀏覽器中開啟 Spotify 並登入"
           }
         }
       }
@@ -3621,6 +4017,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "1分钟"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1分鐘"
           }
         }
       }
@@ -3669,6 +4071,12 @@
             "state" : "translated",
             "value" : "1x"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1x"
+          }
         }
       }
     },
@@ -3709,6 +4117,12 @@
             "state" : "translated",
             "value" : "2 小时"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "2 小時"
+          }
         }
       }
     },
@@ -3738,6 +4152,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "2. 开发者工具 -> Application/Storage -> Cookies -> https://open.spotify.com"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "2. 開發者工具 -> Application/Storage -> Cookies -> https://open.spotify.com"
           }
         }
       }
@@ -3792,6 +4212,12 @@
             "state" : "translated",
             "value" : "3 个项目"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "3 個項目"
+          }
         }
       }
     },
@@ -3821,6 +4247,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "3. 复制 `sp_dc` 的值并将其粘贴到此处"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "3. 複製 `sp_dc` 的值並將其貼上到此處"
           }
         }
       }
@@ -3912,6 +4344,12 @@
             "state" : "translated",
             "value" : "5 种颜色"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "5 種顏色"
+          }
         }
       }
     },
@@ -3965,6 +4403,12 @@
             "state" : "translated",
             "value" : "5 个项目"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "5 個項目"
+          }
         }
       }
     },
@@ -4005,6 +4449,12 @@
             "state" : "translated",
             "value" : "5 分钟"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "5 分鐘"
+          }
         }
       }
     },
@@ -4044,6 +4494,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "5分钟"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "5分鐘"
           }
         }
       }
@@ -4108,6 +4564,12 @@
             "state" : "translated",
             "value" : "7 个项目"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "7 個項目"
+          }
         }
       }
     },
@@ -4160,6 +4622,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "10 种颜色"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "10 種顏色"
           }
         }
       }
@@ -4214,6 +4682,12 @@
             "state" : "translated",
             "value" : "10 个项目"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "10 個項目"
+          }
         }
       }
     },
@@ -4253,6 +4727,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "10 分钟"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "10 分鐘"
           }
         }
       }
@@ -4307,6 +4787,12 @@
             "state" : "translated",
             "value" : "15 种颜色"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "15 種顏色"
+          }
         }
       }
     },
@@ -4346,6 +4832,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "15 分钟"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "15 分鐘"
           }
         }
       }
@@ -4387,6 +4879,12 @@
             "state" : "translated",
             "value" : "15分钟"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "15分鐘"
+          }
         }
       }
     },
@@ -4424,6 +4922,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "20"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "20"
@@ -4482,6 +4986,12 @@
             "state" : "translated",
             "value" : "20 种颜色"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "20 種顏色"
+          }
         }
       }
     },
@@ -4519,6 +5029,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "30"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "30"
@@ -4564,6 +5080,12 @@
             "state" : "translated",
             "value" : "30 分钟"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "30 分鐘"
+          }
         }
       }
     },
@@ -4604,6 +5126,12 @@
             "state" : "translated",
             "value" : "45 分钟"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "45 分鐘"
+          }
         }
       }
     },
@@ -4636,6 +5164,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "100"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "100"
@@ -4681,6 +5215,12 @@
             "state" : "translated",
             "value" : "100%"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "100%"
+          }
         }
       },
       "shouldTranslate" : false
@@ -4693,6 +5233,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Er is een nieuwe versie van Atoll beschikbaar!"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Atoll 有新版本可用！"
           }
         }
       }
@@ -4807,6 +5353,12 @@
             "state" : "needs_review",
             "value" : "关于"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "關於"
+          }
         }
       }
     },
@@ -4849,6 +5401,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "强调色"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "強調色"
           }
         }
       }
@@ -4962,6 +5520,12 @@
             "state" : "translated",
             "value" : "强调色"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "強調色"
+          }
         }
       }
     },
@@ -5009,6 +5573,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "强调色"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "強調色"
           }
         }
       }
@@ -5123,6 +5693,12 @@
             "state" : "needs_review",
             "value" : "被拒绝访问"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "被拒絕存取"
+          }
         }
       }
     },
@@ -5170,6 +5746,12 @@
             "state" : "translated",
             "value" : "辅助功能"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "輔助使用"
+          }
         }
       }
     },
@@ -5193,6 +5775,12 @@
             "state" : "translated",
             "value" : "Разрешение «Универсальный доступ» позволяет Dynamic Island заменять системные индикаторы громкости, яркости и клавиатуры."
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "輔助使用權限可讓動態島取代原生的音量、亮度和鍵盤 HUD。"
+          }
         }
       }
     },
@@ -5215,6 +5803,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Требуется разрешение «Универсальный доступ»"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "需要輔助使用權限"
           }
         }
       }
@@ -5264,6 +5858,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "操作"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "操作"
@@ -5321,6 +5921,12 @@
             "state" : "translated",
             "value" : "激活"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "啟用"
+          }
         }
       }
     },
@@ -5374,6 +5980,12 @@
             "state" : "translated",
             "value" : "激活您的许可证"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "啟用你的許可證"
+          }
         }
       }
     },
@@ -5426,6 +6038,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "激活"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "啟用"
           }
         }
       }
@@ -5485,6 +6103,12 @@
             "state" : "translated",
             "value" : "活跃"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "活躍"
+          }
         }
       }
     },
@@ -5536,6 +6160,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "活跃 - 无专注模式"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "活躍 - 無專注模式"
           }
         }
       }
@@ -5591,6 +6221,12 @@
             "state" : "translated",
             "value" : "活跃 - 未录制"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "活躍 - 未錄製"
+          }
         }
       }
     },
@@ -5632,6 +6268,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "活跃 GPU"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "活躍 GPU"
           }
         }
       }
@@ -5675,6 +6317,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "自适应渐变"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自適應漸變"
           }
         }
       }
@@ -5788,6 +6436,12 @@
             "state" : "needs_review",
             "value" : "添加"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "新增"
+          }
         }
       }
     },
@@ -5841,6 +6495,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "从 URL 添加动画"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "從 URL 新增動畫"
           }
         }
       }
@@ -5900,6 +6560,12 @@
             "state" : "translated",
             "value" : "添加文件"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "新增檔案"
+          }
         }
       }
     },
@@ -5954,6 +6620,12 @@
             "state" : "translated",
             "value" : "从 URL 添加..."
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "從 URL 新增..."
+          }
         }
       }
     },
@@ -5993,6 +6665,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "添加图标"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "新增圖示"
           }
         }
       }
@@ -6107,6 +6785,12 @@
             "state" : "needs_review",
             "value" : "手动添加"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "手動新增"
+          }
         }
       }
     },
@@ -6157,6 +6841,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "新增"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "新增"
@@ -6274,6 +6964,12 @@
             "state" : "needs_review",
             "value" : "添加新的可视化器"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "新增新的視覺化器"
+          }
         }
       }
     },
@@ -6321,6 +7017,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "添加预设"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "新增預設組合"
           }
         }
       }
@@ -6435,6 +7137,12 @@
             "state" : "needs_review",
             "value" : "其他功能"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "其他功能"
+          }
         }
       }
     },
@@ -6474,6 +7182,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "添加 Guake 风格的下拉终端标签页。终端会话在刘海开关周期间保持。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "新增 Guake 風格的下拉終端機分頁。終端機工作階段在瀏海開關週期間保持。"
           }
         }
       }
@@ -6520,6 +7234,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "启用 Caps Lock 时添加刘海 HUD，可选标签和着色控制。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "啟用 Caps Lock 時新增瀏海 HUD，可選標籤和著色控制。"
           }
         }
       }
@@ -6572,6 +7292,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "将隔空播放/路由选择按钮添加回可自定义的控制面板。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "將 AirPlay/路由選擇按鈕新增回可自訂的控制面板。"
           }
         }
       }
@@ -6627,6 +7353,12 @@
             "state" : "translated",
             "value" : "调整上方设置即可实时查看变化。实际 OSD 显示在屏幕底部中央。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "調整上方設定即可即時檢視變化。實際 OSD 顯示在螢幕底部中央。"
+          }
         }
       }
     },
@@ -6666,6 +7398,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "调整锁屏计时器小组件宽度，不影响按钮大小。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "調整鎖定畫面計時器小工具寬度，不影響按鈕大小。"
           }
         }
       }
@@ -6719,6 +7457,12 @@
             "state" : "translated",
             "value" : "AI 助手"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "AI 助理"
+          }
         }
       }
     },
@@ -6767,6 +7511,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "AI 正在思考..."
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "AI 正在思考..."
@@ -6823,6 +7573,12 @@
             "state" : "translated",
             "value" : "AI 模型选择"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "AI 模型選擇"
+          }
         }
       }
     },
@@ -6874,6 +7630,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "AI 服务商"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "AI 服務商"
           }
         }
       }
@@ -6933,6 +7695,12 @@
             "state" : "translated",
             "value" : "AI 驱动的助手，可分析文件和图像并提供对话式帮助。使用 Cmd+Shift+A 快速访问。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "AI 驅動的助理，可分析檔案和影像並提供對話式幫助。使用 Cmd+Shift+A 快速存取。"
+          }
         }
       }
     },
@@ -6986,6 +7754,12 @@
             "state" : "translated",
             "value" : "空气质量指数 %1$d，%2$@"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "空氣品質指數 %1$d，%2$@"
+          }
         }
       }
     },
@@ -7032,6 +7806,12 @@
             "state" : "translated",
             "value" : "空气质量需要 Open Meteo 数据源。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "空氣品質需要 Open Meteo 資料來源。"
+          }
         }
       }
     },
@@ -7077,6 +7857,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "空气质量量表"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "空氣品質量表"
           }
         }
       }
@@ -7186,6 +7972,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "AirDrop"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "AirDrop"
@@ -7304,6 +8096,12 @@
             "state" : "needs_review",
             "value" : "AirDrop 服务不可用"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "AirDrop 服務不可用"
+          }
         }
       }
     },
@@ -7346,6 +8144,12 @@
             "state" : "translated",
             "value" : "隔空播放"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "AirPlay"
+          }
         }
       }
     },
@@ -7385,6 +8189,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "对齐"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "對齊"
           }
         }
       }
@@ -7428,6 +8238,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "全部"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "全部"
@@ -7544,6 +8360,12 @@
             "state" : "needs_review",
             "value" : "全天"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "全天"
+          }
         }
       }
     },
@@ -7588,6 +8410,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "全天事件"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "全天事件"
@@ -7704,6 +8532,12 @@
             "state" : "needs_review",
             "value" : "允许访问"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "允許存取"
+          }
         }
       }
     },
@@ -7727,6 +8561,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "请在“系统设置”→“隐私与安全性”→“自动化”中允许 Atoll 控制“备忘录”。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "請在「系統設定」→「隱私與安全性」→「自動化」中允許 Atoll 控制「備忘錄」。"
           }
         }
       }
@@ -7770,6 +8610,12 @@
             "state" : "translated",
             "value" : "允许扩展实时活动"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "允許延伸功能即時動態"
+          }
         }
       }
     },
@@ -7811,6 +8657,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "允许扩展锁屏小组件"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "允許延伸功能鎖定畫面小工具"
           }
         }
       }
@@ -7854,6 +8706,12 @@
             "state" : "translated",
             "value" : "允许扩展刘海体验"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "允許延伸功能瀏海體驗"
+          }
         }
       }
     },
@@ -7895,6 +8753,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "允许交互式网页内容"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "允許互動式網頁內容"
           }
         }
       }
@@ -7938,6 +8802,12 @@
             "state" : "translated",
             "value" : "允许简约模式覆盖"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "允許簡約模式覆蓋"
+          }
         }
       }
     },
@@ -7977,6 +8847,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "允许鼠标报告"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "允許滑鼠報告"
           }
         }
       }
@@ -8026,6 +8902,12 @@
             "state" : "translated",
             "value" : "允许的功能"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "允許的功能"
+          }
         }
       }
     },
@@ -8061,6 +8943,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "测试版"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "測試版"
           }
         }
       },
@@ -8175,6 +9063,12 @@
             "state" : "needs_review",
             "value" : "总是隐藏在全屏"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "總是隱藏在全螢幕"
+          }
         }
       }
     },
@@ -8288,6 +9182,12 @@
             "state" : "needs_review",
             "value" : "总是显示标签页"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "總是顯示分頁"
+          }
         }
       }
     },
@@ -8370,6 +9270,12 @@
             "state" : "translated",
             "value" : "动画"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "動畫"
+          }
         }
       }
     },
@@ -8424,6 +9330,12 @@
             "state" : "translated",
             "value" : "动画名称"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "動畫名稱"
+          }
         }
       }
     },
@@ -8472,6 +9384,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "API 配置"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "API 配置"
@@ -8528,6 +9446,12 @@
             "state" : "translated",
             "value" : "需要 API 密钥"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "需要 API 金鑰"
+          }
         }
       }
     },
@@ -8567,6 +9491,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "应用"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "App"
           }
         }
       }
@@ -8680,6 +9610,12 @@
             "state" : "needs_review",
             "value" : "应用图标"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "App 圖示"
+          }
         }
       }
     },
@@ -8727,6 +9663,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "应用权限"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "App 權限"
           }
         }
       }
@@ -8840,6 +9782,12 @@
             "state" : "needs_review",
             "value" : "外观"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "外觀"
+          }
         }
       }
     },
@@ -8883,6 +9831,12 @@
             "state" : "translated",
             "value" : "Apple Music"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Apple Music"
+          }
         }
       }
     },
@@ -8906,6 +9860,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Apple 备忘录"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Apple 備忘錄"
           }
         }
       }
@@ -8953,6 +9913,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "将刘海风格的视差效果应用于锁屏媒体小组件的专辑封面。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "將瀏海風格的視差效果套用於鎖定畫面媒體小工具的專輯封面。"
           }
         }
       }
@@ -9002,6 +9968,12 @@
             "state" : "translated",
             "value" : "使用 AtollExtensionKit 的应用在请求权限后将显示在此处"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "使用 AtollExtensionKit 的 App 在請求權限後將顯示在此處"
+          }
         }
       }
     },
@@ -9042,6 +10014,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "空气质量指数"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "空氣品質指數"
           }
         }
       }
@@ -9102,6 +10080,12 @@
             "state" : "translated",
             "value" : "您确定要删除「%@」吗？"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "你確定要刪除「%@」嗎？"
+          }
         }
       }
     },
@@ -9153,6 +10137,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "您确定要从历史记录中删除此颜色吗？"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "你確定要從歷史記錄中刪除此顏色嗎？"
           }
         }
       }
@@ -9206,6 +10196,12 @@
             "state" : "translated",
             "value" : "随便问我..."
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "隨便問我..."
+          }
         }
       }
     },
@@ -9242,6 +10238,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Atoll"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Atoll"
@@ -9301,6 +10303,12 @@
             "state" : "translated",
             "value" : "Atoll 始终监听所选提供商的亮度事件，仅在启用外部音量监听器时监听提供商的音量事件。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Atoll 始終監聽所選提供商的亮度事件，僅在啟用外部音量監聽器時監聽提供商的音量事件。"
+          }
         }
       }
     },
@@ -9346,6 +10354,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Atoll 可以在一处显示您所有即将到来的事件。需要访问您的日历才能显示您的日程。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Atoll 可以在一處顯示你所有即將到來的事件。需要存取你的行事曆才能顯示你的日程。"
           }
         }
       }
@@ -9393,6 +10407,12 @@
             "state" : "translated",
             "value" : "Atoll 包含镜像功能，让您可以直接从刘海处使用相机快速检查外观。相机访问仅用于显示实时预览。您可以随时在应用中开启或关闭镜像功能。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Atoll 包含鏡像功能，讓你可以直接從瀏海處使用相機快速檢查外觀。相機存取僅用於顯示即時預覽。你可以隨時在 App 中開啟或關閉鏡像功能。"
+          }
         }
       }
     },
@@ -9434,6 +10454,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Atoll 保持原生音量键拦截。关闭此项时将忽略外部提供商的音量数据。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Atoll 保持原生音量鍵攔截。關閉此項時將忽略外部提供商的音量資料。"
           }
         }
       }
@@ -9482,6 +10508,12 @@
             "state" : "translated",
             "value" : "Atoll 需要完全磁盘访问权限来读取系统通知数据库。如果 Atoll 未出现在列表中，请使用「在 Finder 中显示应用」并将其拖入设置窗口。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Atoll 需要完整磁碟取用權來讀取系統通知資料庫。如果 Atoll 未出現在列表中，請使用「在 Finder 中顯示 App」並將其拖入設定視窗。"
+          }
         }
       }
     },
@@ -9512,6 +10544,12 @@
             "state" : "translated",
             "value" : "Atoll 仅使用本地 `sp_dc` cookie 来请求 Spotify 内部的 web-player 令牌，并获取当前曲目匹配的 Canvas。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Atoll 僅使用本機 `sp_dc` cookie 來請求 Spotify 內部的 web-player 權杖，並取得目前曲目匹配的 Canvas。"
+          }
         }
       }
     },
@@ -9523,6 +10561,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Atoll controleert regelmatig automatisch op updates."
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Atoll 會定期自動檢查更新。"
           }
         }
       }
@@ -9565,6 +10609,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "启用外部音量监听时，Atoll 的内置音量键拦截已禁用。音量 HUD/OSD 将跟随 %@ 的数据。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "啟用外部音量監聽時，Atoll 的內建音量鍵攔截已停用。音量 HUD/OSD 將跟隨 %@ 的資料。"
           }
         }
       }
@@ -9618,6 +10668,12 @@
             "state" : "translated",
             "value" : "附件"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "附件"
+          }
         }
       }
     },
@@ -9665,6 +10721,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "音频反馈"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "音訊回饋"
           }
         }
       }
@@ -9714,6 +10776,12 @@
             "state" : "translated",
             "value" : "授权"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "授權"
+          }
         }
       }
     },
@@ -9762,6 +10830,12 @@
             "state" : "translated",
             "value" : "已授权"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已授權"
+          }
         }
       }
     },
@@ -9801,6 +10875,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "自动隐藏不活跃的刘海媒体播放器"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自動隱藏不活躍的瀏海媒體播放器"
           }
         }
       }
@@ -9849,6 +10929,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "自动滚动到下一个事件"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自動滾動到下一個事件"
           }
         }
       }
@@ -9962,6 +11048,12 @@
             "state" : "needs_review",
             "value" : "自动检查更新"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "自動檢查更新"
+          }
         }
       }
     },
@@ -10074,6 +11166,12 @@
             "state" : "needs_review",
             "value" : "自动下载更新"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "自動下載更新"
+          }
         }
       }
     },
@@ -10114,6 +11212,12 @@
             "state" : "translated",
             "value" : "自动切换显示器"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自動切換顯示器"
+          }
         }
       }
     },
@@ -10150,6 +11254,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "平均"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "平均"
@@ -10208,6 +11318,12 @@
             "state" : "translated",
             "value" : "平均值"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "平均值"
+          }
         }
       }
     },
@@ -10244,6 +11360,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "背景"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "背景"
@@ -10296,6 +11418,12 @@
             "state" : "translated",
             "value" : "背光"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "背光"
+          }
         }
       }
     },
@@ -10338,6 +11466,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "条形"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "條形"
           }
         }
       }
@@ -10451,6 +11585,12 @@
             "state" : "needs_review",
             "value" : "电池"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "電池"
+          }
         }
       }
     },
@@ -10498,6 +11638,12 @@
             "state" : "translated",
             "value" : "电池电量 %d%%"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "電池電量 %d%%"
+          }
         }
       }
     },
@@ -10526,6 +11672,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "电池电量 %d%%，暂停充电"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "電池電量 %d%%，暫停充電"
           }
         }
       }
@@ -10574,6 +11726,12 @@
             "state" : "translated",
             "value" : "电池充电中"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "電池充電中"
+          }
         }
       }
     },
@@ -10620,6 +11778,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "电池充电中，剩余 %@"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "電池充電中，剩餘 %@"
           }
         }
       }
@@ -10668,6 +11832,12 @@
             "state" : "translated",
             "value" : "电池已充满"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "電池已充滿"
+          }
         }
       }
     },
@@ -10695,6 +11865,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "电池提示框"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "電池提示框"
           }
         }
       }
@@ -10749,6 +11925,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "电池指示器样式"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "電池指示器樣式"
           }
         }
       }
@@ -10862,6 +12044,12 @@
             "state" : "needs_review",
             "value" : "电池信息"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "電池資訊"
+          }
         }
       }
     },
@@ -10974,6 +12162,12 @@
             "state" : "needs_review",
             "value" : "电池设置"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "電池設定"
+          }
         }
       }
     },
@@ -11019,6 +12213,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "电池设置和信息仅在 MacBook 上可用"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "電池設定和資訊僅在 MacBook 上可用"
           }
         }
       }
@@ -11132,6 +12332,12 @@
             "state" : "needs_review",
             "value" : "电池状态"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "電池狀態"
+          }
         }
       }
     },
@@ -11177,6 +12383,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "电池小组件"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "電池小工具"
           }
         }
       }
@@ -11224,6 +12436,12 @@
             "state" : "translated",
             "value" : "行为与样式"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "行為與樣式"
+          }
         }
       }
     },
@@ -11259,6 +12477,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "测试版"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "測試版"
           }
         }
       },
@@ -11314,6 +12538,12 @@
             "state" : "translated",
             "value" : "蓝色虚线框显示 Atoll 中的实际大小"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "藍色虛線框顯示 Atoll 中的實際大小"
+          }
         }
       }
     },
@@ -11361,6 +12591,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "蓝色轮廓匹配刘海画布"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "藍色輪廓匹配瀏海畫布"
           }
         }
       }
@@ -11416,6 +12652,12 @@
             "state" : "translated",
             "value" : "蓝牙音频设备"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "藍牙音訊裝置"
+          }
         }
       }
     },
@@ -11469,6 +12711,12 @@
             "state" : "translated",
             "value" : "蓝牙设备 %1$@ 电量 %2$d%%"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "藍牙裝置 %1$@ 電量 %2$d%%"
+          }
         }
       }
     },
@@ -11508,6 +12756,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "粗体文本显示为亮色"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "粗體文字顯示為亮色"
           }
         }
       }
@@ -11621,6 +12875,12 @@
             "state" : "needs_review",
             "value" : "使用剪贴板管理器提升你的效率"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "使用剪貼簿管理程式提升你的效率"
+          }
         }
       }
     },
@@ -11680,6 +12940,12 @@
             "state" : "translated",
             "value" : "两者"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "兩者"
+          }
         }
       }
     },
@@ -11714,6 +12980,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "İkisi de etkin"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "兩者皆使用中"
           }
         }
       }
@@ -11753,6 +13025,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "休息"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "休息"
@@ -11817,6 +13095,12 @@
             "state" : "translated",
             "value" : "详细信息"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "詳細資訊"
+          }
         }
       }
     },
@@ -11865,6 +13149,12 @@
             "state" : "translated",
             "value" : "亮度"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "亮度"
+          }
         }
       }
     },
@@ -11892,6 +13182,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "亮度微调步长"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "亮度微調步長"
           }
         }
       }
@@ -11945,6 +13241,12 @@
             "state" : "translated",
             "value" : "亮度 HUD"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "亮度 HUD"
+          }
         }
       }
     },
@@ -11993,6 +13295,12 @@
             "state" : "translated",
             "value" : "亮度 OSD"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "亮度 OSD"
+          }
         }
       }
     },
@@ -12020,6 +13328,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "亮度步长"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "亮度步長"
           }
         }
       }
@@ -12075,6 +13389,12 @@
             "state" : "translated",
             "value" : "内置"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "內建"
+          }
         }
       }
     },
@@ -12121,6 +13441,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "内置系统监控"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "內建系統監控"
           }
         }
       }
@@ -12175,6 +13501,12 @@
             "state" : "translated",
             "value" : "内置系统监控直接检测音量、亮度和键盘背光变化，无需外部应用。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "內建系統監控直接偵測音量、亮度和鍵盤背光變化，無需外部 App。"
+          }
         }
       }
     },
@@ -12227,6 +13559,12 @@
             "state" : "translated",
             "value" : "请我们喝杯咖啡"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "請我們喝杯咖啡"
+          }
         }
       }
     },
@@ -12266,6 +13604,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "已缓存"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已快取"
           }
         }
       }
@@ -12378,6 +13722,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "日历"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "行事曆"
           }
         }
       }
@@ -12492,6 +13842,12 @@
             "state" : "needs_review",
             "value" : "日历访问被拒绝。请在系统设置中启用它。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "行事曆存取被拒絕。請在系統設定中啟用它。"
+          }
         }
       }
     },
@@ -12531,6 +13887,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "日历应用"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "行事曆 App"
           }
         }
       }
@@ -12586,6 +13948,12 @@
             "state" : "translated",
             "value" : "日历或提醒事项访问被拒绝。请在系统设置中启用。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "行事曆或提醒事項存取被拒絕。請在系統設定中啟用。"
+          }
         }
       }
     },
@@ -12625,6 +13993,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "日历小组件"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "行事曆小工具"
           }
         }
       }
@@ -12683,6 +14057,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "日历"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "行事曆"
           }
         }
       }
@@ -12744,6 +14124,12 @@
             "state" : "translated",
             "value" : "相机"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "相機"
+          }
         }
       }
     },
@@ -12802,6 +14188,12 @@
             "state" : "translated",
             "value" : "相机已激活"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "相機已啟用"
+          }
         }
       }
     },
@@ -12836,6 +14228,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Yalnızca kamera"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "僅相機"
           }
         }
       }
@@ -12894,6 +14292,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "相机状态"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "相機狀態"
           }
         }
       }
@@ -13007,6 +14411,12 @@
             "state" : "needs_review",
             "value" : "取消"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "取消"
+          }
         }
       }
     },
@@ -13037,6 +14447,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Caps Lock"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Caps Lock"
@@ -13088,6 +14504,12 @@
             "state" : "translated",
             "value" : "Caps Lock 颜色"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Caps Lock 顏色"
+          }
         }
       }
     },
@@ -13134,6 +14556,12 @@
             "state" : "translated",
             "value" : "Caps Lock 指示器"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Caps Lock 指示器"
+          }
         }
       }
     },
@@ -13155,6 +14583,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "摄氏度"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "攝氏度"
           }
         }
       }
@@ -13215,6 +14649,12 @@
             "state" : "translated",
             "value" : "居中"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "居中"
+          }
         }
       }
     },
@@ -13267,6 +14707,12 @@
             "state" : "translated",
             "value" : "更改"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "更改"
+          }
         }
       }
     },
@@ -13306,6 +14752,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "更改媒体输出"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "更改媒體輸出"
           }
         }
       }
@@ -13420,6 +14872,12 @@
             "state" : "needs_review",
             "value" : "充电中"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "充電中"
+          }
         }
       }
     },
@@ -13462,6 +14920,12 @@
             "state" : "translated",
             "value" : "电池充电中"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "電池充電中"
+          }
         }
       }
     },
@@ -13489,6 +14953,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "充电提示持续时间"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "充電提示持續時間"
           }
         }
       }
@@ -13518,6 +14988,12 @@
             "state" : "translated",
             "value" : "充电提示框"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "充電提示框"
+          }
         }
       }
     },
@@ -13546,6 +15022,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "暂停充电"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "暫停充電"
           }
         }
       }
@@ -13659,6 +15141,12 @@
             "state" : "needs_review",
             "value" : "暂停充电：桌面模式"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "暫停充電：桌面模式"
+          }
         }
       }
     },
@@ -13771,6 +15259,12 @@
             "state" : "needs_review",
             "value" : "检查更新…"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "檢查更新…"
+          }
         }
       }
     },
@@ -13782,6 +15276,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Zoeken naar updates…"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在檢查更新…"
           }
         }
       }
@@ -13830,6 +15330,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "芯片颜色"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "晶片顏色"
           }
         }
       }
@@ -13889,6 +15395,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "选择计时器完成时播放的自定义声音文件。支持格式：MP3、M4A、WAV、AIFF。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選擇計時器完成時播放的自訂聲音檔案。支援格式：MP3、M4A、WAV、AIFF。"
           }
         }
       }
@@ -14002,6 +15514,12 @@
             "state" : "needs_review",
             "value" : "选择音乐来源"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "選擇音樂來源"
+          }
         }
       }
     },
@@ -14053,6 +15571,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "选择 AI 模型"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選擇 AI 模型"
           }
         }
       }
@@ -14120,6 +15644,12 @@
             "state" : "translated",
             "value" : "选择 Atoll 空闲时显示的动画。点击选择，长按删除自定义动画。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選擇 Atoll 閒置時顯示的動畫。點按選擇，長按刪除自訂動畫。"
+          }
         }
       }
     },
@@ -14165,6 +15695,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "直接选择垂直条在屏幕的哪一侧显示。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "直接選擇垂直條在螢幕的哪一側顯示。"
           }
         }
       }
@@ -14217,6 +15753,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "选择文件"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選擇檔案"
           }
         }
       }
@@ -14271,6 +15813,12 @@
             "state" : "translated",
             "value" : "选择锁屏小组件的全局材质模式。自定义液态解锁每个小组件的变体滑块，标准则使用经典磨砂/液态选项。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選擇鎖定畫面小工具的全域材質模式。自訂液態解鎖每個小工具的變體滑桿，標準則使用經典磨砂/液態選項。"
+          }
         }
       }
     },
@@ -14280,6 +15828,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Kies welke AI-aanbieders op het tabblad Gebruik worden weergegeven."
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選擇要顯示在用量分頁中的 AI 服務供應商。"
           }
         }
       }
@@ -14328,6 +15882,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "选择从架子共享文件时使用的服务。将文件拖到架子上或点击架子按钮选择文件。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選擇從架子共享檔案時使用的服務。將檔案拖到架子上或點按架子按鈕選擇檔案。"
           }
         }
       }
@@ -14383,6 +15943,12 @@
             "state" : "translated",
             "value" : "选择哪些系统控制应显示自定义 OSD 窗口。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選擇哪些系統控制應顯示自訂 OSD 視窗。"
+          }
         }
       }
     },
@@ -14430,6 +15996,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "选择哪些系统控制应显示 HUD 通知。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選擇哪些系統控制應顯示 HUD 通知。"
           }
         }
       }
@@ -14482,6 +16054,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "选择您偏好的 AI 模型和配置"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選擇你偏好的 AI 模型和配置"
           }
         }
       }
@@ -14536,6 +16114,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "选择您的配置文件"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選擇你的配置檔案"
           }
         }
       }
@@ -14649,6 +16233,12 @@
             "state" : "needs_review",
             "value" : "圆形"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "圓形"
+          }
         }
       }
     },
@@ -14691,6 +16281,12 @@
             "state" : "translated",
             "value" : "圆形"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "圓形"
+          }
         }
       }
     },
@@ -14732,6 +16328,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "经典"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "經典"
           }
         }
       }
@@ -14781,6 +16383,12 @@
             "state" : "translated",
             "value" : "经典模式保持原始半透明黑色背景。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "經典模式保持原始半透明黑色背景。"
+          }
         }
       }
     },
@@ -14822,6 +16430,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "与屏幕顶部边缘融合的经典刘海形状"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "與螢幕頂部邊緣融合的經典瀏海形狀"
           }
         }
       }
@@ -14885,6 +16499,12 @@
             "state" : "translated",
             "value" : "清除"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "清除"
+          }
         }
       }
     },
@@ -14936,6 +16556,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "清除所有文件"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "清除所有檔案"
           }
         }
       }
@@ -14995,6 +16621,12 @@
             "state" : "translated",
             "value" : "清除所有文件将移除所有附件和音频录制。此操作不可撤销。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "清除所有檔案將移除所有附件和音訊錄製。此操作不可撤銷。"
+          }
         }
       }
     },
@@ -15046,6 +16678,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "清除剪贴板历史"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "清除剪貼簿歷史"
           }
         }
       }
@@ -15105,6 +16743,12 @@
             "state" : "translated",
             "value" : "清除剪贴板历史将移除最近的复制内容。清除固定项将移除您的收藏。两项操作均不可撤销。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "清除剪貼簿歷史將移除最近的複製內容。清除固定項將移除你的收藏。兩項操作均不可撤銷。"
+          }
         }
       }
     },
@@ -15152,6 +16796,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "清除剪贴板历史？"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "清除剪貼簿歷史？"
           }
         }
       }
@@ -15204,6 +16854,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "清除颜色历史"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "清除顏色歷史"
           }
         }
       }
@@ -15263,6 +16919,12 @@
             "state" : "translated",
             "value" : "清除颜色历史将移除所有取色记录。开始取色将进入屏幕取色模式。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "清除顏色歷史將移除所有取色記錄。開始取色將進入螢幕取色模式。"
+          }
         }
       }
     },
@@ -15304,6 +16966,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "清除对话和附件"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "清除對話和附件"
           }
         }
       }
@@ -15357,6 +17025,12 @@
             "state" : "translated",
             "value" : "清除数据"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "清除資料"
+          }
         }
       }
     },
@@ -15404,6 +17078,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "清除历史"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "清除歷史"
           }
         }
       }
@@ -15457,6 +17137,12 @@
             "state" : "translated",
             "value" : "清除固定项"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "清除固定項"
+          }
         }
       }
     },
@@ -15505,6 +17191,12 @@
             "state" : "translated",
             "value" : "清除搜索"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "清除搜尋"
+          }
         }
       }
     },
@@ -15549,6 +17241,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "清除插槽"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "清除插槽"
@@ -15605,6 +17303,12 @@
             "state" : "translated",
             "value" : "点击「取色」或使用 Cmd+Shift+P 开始取色"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "點按「取色」或使用 Cmd+Shift+P 開始取色"
+          }
         }
       }
     },
@@ -15659,6 +17363,12 @@
             "state" : "translated",
             "value" : "点击查看详情"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "點按檢視詳情"
+          }
         }
       }
     },
@@ -15710,6 +17420,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "剪贴板"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "剪貼簿"
           }
         }
       }
@@ -15763,6 +17479,12 @@
             "state" : "translated",
             "value" : "剪贴板功能已禁用"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "剪貼簿功能已停用"
+          }
         }
       }
     },
@@ -15814,6 +17536,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "剪贴板历史"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "剪貼簿歷史"
           }
         }
       }
@@ -15867,6 +17595,12 @@
             "state" : "translated",
             "value" : "剪贴板历史："
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "剪貼簿歷史："
+          }
         }
       }
     },
@@ -15918,6 +17652,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "剪贴板管理器"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "剪貼簿管理程式"
           }
         }
       }
@@ -16031,6 +17771,12 @@
             "state" : "needs_review",
             "value" : "关闭"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "關閉"
+          }
         }
       }
     },
@@ -16083,6 +17829,12 @@
             "state" : "translated",
             "value" : "关闭助手"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "關閉助理"
+          }
         }
       }
     },
@@ -16123,6 +17875,12 @@
             "state" : "translated",
             "value" : "关闭手势"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "關閉手勢"
+          }
         }
       }
     },
@@ -16144,6 +17902,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "收起时的刘海/胶囊宽度"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "收起時的瀏海/膠囊寬度"
           }
         }
       }
@@ -16186,6 +17950,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "使用取色器、系统监控和屏幕助手进行编码和调试。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "使用取色器、系統監控和螢幕助理進行編碼和除錯。"
           }
         }
       }
@@ -16245,6 +18015,12 @@
             "state" : "translated",
             "value" : "收集最新崩溃报告以便向开发者报告锁屏或覆盖层问题时分享。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "收集最新崩潰報告以便向開發者報告鎖定畫面或覆蓋層問題時分享。"
+          }
         }
       }
     },
@@ -16297,6 +18073,12 @@
             "state" : "translated",
             "value" : "颜色详情"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "顏色詳情"
+          }
         }
       }
     },
@@ -16318,6 +18100,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Извлечение цвета"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "色彩擷取"
           }
         }
       }
@@ -16371,6 +18159,12 @@
             "state" : "translated",
             "value" : "颜色格式"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "顏色格式"
+          }
         }
       }
     },
@@ -16422,6 +18216,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "颜色历史"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "顏色歷史"
           }
         }
       }
@@ -16477,6 +18277,12 @@
             "state" : "translated",
             "value" : "颜色选项控制图标和进度条外观。自动适应系统主题。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "顏色選項控制圖示和進度條外觀。自動適應系統主題。"
+          }
         }
       }
     },
@@ -16525,6 +18331,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已取色！"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "已取色！"
@@ -16581,6 +18393,12 @@
             "state" : "translated",
             "value" : "取色器"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "取色器"
+          }
         }
       }
     },
@@ -16632,6 +18450,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "取色器功能已禁用"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "取色器功能已停用"
           }
         }
       }
@@ -16685,6 +18509,12 @@
             "state" : "translated",
             "value" : "取色器面板："
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "取色器面板："
+          }
         }
       }
     },
@@ -16724,6 +18554,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "彩色电池显示"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "彩色電池顯示"
           }
         }
       }
@@ -16773,6 +18609,12 @@
             "state" : "translated",
             "value" : "分段模式下不支持彩色填充和平滑渐变。切换到层级或渐变模式来调整这些选项。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "分段模式下不支援彩色填充和平滑漸變。切換到層級或漸變模式來調整這些選項。"
+          }
         }
       }
     },
@@ -16821,6 +18663,12 @@
             "state" : "translated",
             "value" : "分段模式下不支持彩色填充。切换到控制 › 灵动岛中的层级或渐变模式来调整高级选项。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "分段模式下不支援彩色填充。切換到控制 › 動態島中的層級或漸變模式來調整進階選項。"
+          }
         }
       }
     },
@@ -16857,6 +18705,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "彩色音量"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "彩色音量"
@@ -16900,6 +18754,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "彩色音量显示"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "彩色音量顯示"
           }
         }
       }
@@ -16953,6 +18813,12 @@
             "state" : "translated",
             "value" : "取色器已禁用"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "取色器已停用"
+          }
         }
       }
     },
@@ -16992,6 +18858,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "颜色"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "顏色"
           }
         }
       }
@@ -17106,6 +18978,12 @@
             "state" : "translated",
             "value" : "即将推出"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "即將推出"
+          }
         }
       }
     },
@@ -17128,6 +19006,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Компактный"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "精簡"
           }
         }
       }
@@ -17157,6 +19041,12 @@
             "state" : "translated",
             "value" : "“紧凑”将保持提示内联。“标准”则使用带有充电动画的较高全尺寸提示框。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "「緊湊」將保持提示內聯。「標準」則使用帶有充電動畫的較高全尺寸提示框。"
+          }
         }
       }
     },
@@ -17184,6 +19074,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "“紧凑”与充电提示框匹配。“标准”则使用展开的 DynamicNotch 风格卡片。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "「緊湊」與充電提示框匹配。「標準」則使用展開的 DynamicNotch 風格卡片。"
           }
         }
       }
@@ -17225,6 +19121,12 @@
             "state" : "translated",
             "value" : "已压缩"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已壓縮"
+          }
         }
       }
     },
@@ -17264,6 +19166,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "计算"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "計算"
           }
         }
       }
@@ -17317,6 +19225,12 @@
             "state" : "translated",
             "value" : "配置"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "配置"
+          }
         }
       }
     },
@@ -17365,6 +19279,12 @@
             "state" : "translated",
             "value" : "在日历标签页中配置倒计时样式和锁屏小组件。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在行事曆分頁中配置倒數計時樣式和鎖定畫面小工具。"
+          }
         }
       }
     },
@@ -17410,6 +19330,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "配置计时器在关闭的刘海中的外观。进度可以显示为图标周围的圆环或水平条。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "配置計時器在關閉的瀏海中的外觀。進度可以顯示為圖示周圍的圓環或水平條。"
           }
         }
       }
@@ -17464,6 +19390,12 @@
             "state" : "translated",
             "value" : "在外观标签页中配置锁屏材质。选择液态玻璃时，自定义液态将解锁两个小组件的变体滑块。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在外觀分頁中配置鎖定畫面材質。選擇液態玻璃時，自訂液態將解鎖兩個小工具的變體滑桿。"
+          }
         }
       }
     },
@@ -17511,6 +19443,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "在设置中配置预设"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在設定中配置預設組合"
           }
         }
       }
@@ -17560,6 +19498,12 @@
             "state" : "translated",
             "value" : "在设置中配置预设即可在此查看。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在設定中配置預設組合即可在此檢視。"
+          }
         }
       }
     },
@@ -17589,6 +19533,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "连接 Spotify"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "連線 Spotify"
           }
         }
       }
@@ -17631,6 +19581,12 @@
             "state" : "translated",
             "value" : "已连接"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已連線"
+          }
         }
       }
     },
@@ -17671,6 +19627,12 @@
             "state" : "translated",
             "value" : "直接连接 Apple Music 应用。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "直接連線 Apple Music App。"
+          }
         }
       }
     },
@@ -17710,6 +19672,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "直接连接 Spotify 应用。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "直接連線 Spotify App。"
           }
         }
       }
@@ -17823,6 +19791,12 @@
             "state" : "needs_review",
             "value" : "继续"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "繼續"
+          }
         }
       }
     },
@@ -17867,6 +19841,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "控制面板"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "控制面板"
@@ -17916,6 +19896,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "控制计时器可用性、实时活动行为，以及应用是否同步 macOS 时钟应用启动的计时器。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "控制計時器可用性、即時動態行為，以及 App 是否同步 macOS 時鐘 App 啟動的計時器。"
           }
         }
       }
@@ -17969,6 +19955,12 @@
             "state" : "translated",
             "value" : "控制"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "控制"
+          }
         }
       }
     },
@@ -18015,6 +20007,12 @@
             "state" : "translated",
             "value" : "控制监控激活时系统指标的刷新频率。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "控制監控啟用時系統指標的重新整理頻率。"
+          }
         }
       }
     },
@@ -18054,6 +20052,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "控制锁屏提醒标签及其位置。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "控制鎖定畫面提醒標籤及其位置。"
           }
         }
       }
@@ -18102,6 +20106,12 @@
             "state" : "translated",
             "value" : "控制浮动在媒体面板上方的可选计时器小组件，包括其经典、磨砂或液态玻璃表面（独立于全局材质设置）。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "控制浮動在媒體面板上方的可選計時器小工具，包括其經典、磨砂或液態玻璃表面（獨立於全域材質設定）。"
+          }
         }
       }
     },
@@ -18147,6 +20157,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "控制灵动岛是否通过自身的实时活动和提示音来响应锁屏/解锁事件。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "控制動態島是否透過自身的即時動態和提示音來響應鎖定畫面/解鎖事件。"
           }
         }
       }
@@ -18196,6 +20212,12 @@
             "state" : "translated",
             "value" : "复制事件链接"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "複製事件連結"
+          }
         }
       }
     },
@@ -18243,6 +20265,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "拖拽时复制项目"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "拖移時複製項目"
           }
         }
       }
@@ -18296,6 +20324,12 @@
             "state" : "translated",
             "value" : "复制最新崩溃报告"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "複製最新崩潰報告"
+          }
         }
       }
     },
@@ -18347,6 +20381,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "复制内容即可开始"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "複製內容即可開始"
           }
         }
       }
@@ -18400,6 +20440,12 @@
             "state" : "translated",
             "value" : "复制内容即可开始"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "複製內容即可開始"
+          }
         }
       }
     },
@@ -18448,6 +20494,12 @@
             "state" : "translated",
             "value" : "复制文本后将在此显示"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "複製文字後將在此顯示"
+          }
         }
       }
     },
@@ -18486,6 +20538,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "核心 %lld"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "核心 %lld"
@@ -18531,6 +20589,12 @@
             "state" : "translated",
             "value" : "核心时钟"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "核心時鐘"
+          }
         }
       }
     },
@@ -18571,6 +20635,12 @@
             "state" : "translated",
             "value" : "核心数"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "核心數"
+          }
         }
       }
     },
@@ -18610,6 +20680,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "圆角缩放"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "圓角縮放"
           }
         }
       }
@@ -18659,6 +20735,12 @@
             "state" : "translated",
             "value" : "倒计时样式"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "倒數計時樣式"
+          }
         }
       }
     },
@@ -18697,6 +20779,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "CPU"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "CPU"
@@ -18740,6 +20828,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "CPU 概览"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "CPU 概覽"
           }
         }
       }
@@ -18793,6 +20887,12 @@
             "state" : "translated",
             "value" : "CPU 使用率"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "CPU 使用率"
+          }
         }
       }
     },
@@ -18834,6 +20934,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "使用取色器、镜像和视觉效果进行创作和设计。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "使用取色器、鏡像和視覺效果進行創作和設計。"
           }
         }
       }
@@ -18881,6 +20987,12 @@
             "state" : "translated",
             "value" : "从剪贴板创建"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "從剪貼簿建立"
+          }
         }
       }
     },
@@ -18921,6 +21033,12 @@
             "state" : "translated",
             "value" : "严重"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "嚴重"
+          }
         }
       }
     },
@@ -18932,6 +21050,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Huidige build: %@"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "目前版本號：%@"
           }
         }
       }
@@ -18986,6 +21110,12 @@
             "state" : "translated",
             "value" : "当前自定义计时器："
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "目前自訂計時器："
+          }
         }
       }
     },
@@ -19033,6 +21163,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "当前默认："
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "目前預設："
           }
         }
       }
@@ -19086,6 +21222,12 @@
             "state" : "translated",
             "value" : "当前历史"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "目前歷史"
+          }
         }
       }
     },
@@ -19138,6 +21280,12 @@
             "state" : "translated",
             "value" : "当前项目"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "目前項目"
+          }
         }
       }
     },
@@ -19185,6 +21333,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "当前变换"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "目前變換"
           }
         }
       }
@@ -19240,6 +21394,12 @@
             "state" : "translated",
             "value" : "当前活跃"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "目前活躍"
+          }
         }
       }
     },
@@ -19288,6 +21448,12 @@
             "state" : "translated",
             "value" : "当前选择：%@"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "目前選擇：%@"
+          }
         }
       }
     },
@@ -19330,6 +21496,12 @@
             "state" : "translated",
             "value" : "当前：%@"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "目前：%@"
+          }
         }
       }
     },
@@ -19366,6 +21538,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cursor"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Cursor"
@@ -19409,6 +21587,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "光标样式"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "游標樣式"
           }
         }
       }
@@ -19462,6 +21646,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "自定义"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自訂"
           }
         }
       }
@@ -19522,6 +21712,12 @@
             "state" : "translated",
             "value" : "自定义颜色"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自訂顏色"
+          }
         }
       }
     },
@@ -19567,6 +21763,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "自定义专注模式元数据"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自訂專注模式中繼資料"
           }
         }
       }
@@ -19681,6 +21883,12 @@
             "state" : "needs_review",
             "value" : "自定义高度"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "自訂高度"
+          }
         }
       }
     },
@@ -19727,6 +21935,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "自定义液态玻璃"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自訂液態玻璃"
           }
         }
       }
@@ -19782,6 +21996,12 @@
             "state" : "translated",
             "value" : "自定义液态玻璃已使用 Apple 的液态材质渲染，因此此选项将自动管理。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自訂液態玻璃已使用 Apple 的液態材質渲染，因此此選項將自動管理。"
+          }
         }
       }
     },
@@ -19828,6 +22048,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "自定义液态玻璃仅在 macOS 26 或更高版本可用。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自訂液態玻璃僅在 macOS 26 或更高版本可用。"
           }
         }
       }
@@ -19882,6 +22108,12 @@
             "state" : "translated",
             "value" : "自定义液态玻璃设置需要液态玻璃材质。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自訂液態玻璃設定需要液態玻璃材質。"
+          }
         }
       }
     },
@@ -19928,6 +22160,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "自定义液态变体"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自訂液態變體"
           }
         }
       }
@@ -20042,6 +22280,12 @@
             "state" : "translated",
             "value" : "自定义音乐实时活动动画"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自訂音樂即時動態動畫"
+          }
         }
       }
     },
@@ -20154,6 +22398,12 @@
             "state" : "needs_review",
             "value" : "自定义Notch大小 - %.0f"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "自訂Notch大小 - %.0f"
+          }
         }
       }
     },
@@ -20202,6 +22452,12 @@
             "state" : "translated",
             "value" : "自定义 OSD"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自訂 OSD"
+          }
         }
       }
     },
@@ -20249,6 +22505,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "自定义 OSD 功能需要 macOS 15 或更高版本。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自訂 OSD 功能需要 macOS 15 或更高版本。"
           }
         }
       }
@@ -20302,6 +22564,12 @@
             "state" : "translated",
             "value" : "自定义计时器"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自訂計時器"
+          }
         }
       }
     },
@@ -20350,6 +22618,12 @@
             "state" : "translated",
             "value" : "自定义计时器时长"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自訂計時器時長"
+          }
         }
       }
     },
@@ -20373,6 +22647,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "自定义计时器样式"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自訂計時器樣式"
           }
         }
       }
@@ -20486,6 +22766,12 @@
             "state" : "needs_review",
             "value" : "自定义可视化器（Lottie）"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "自訂視覺化器（Lottie）"
+          }
         }
       }
     },
@@ -20537,6 +22823,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "自定义：%@"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自訂：%@"
           }
         }
       }
@@ -20590,6 +22882,12 @@
             "state" : "translated",
             "value" : "自定义动画"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自訂動畫"
+          }
         }
       }
     },
@@ -20637,6 +22935,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "自定义笔记的组织和创建方式。启用颜色过滤和搜索有助于管理大量列表。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自訂筆記的組織和建立方式。啟用顏色篩選和搜尋有助於管理大量列表。"
           }
         }
       }
@@ -20750,6 +23054,12 @@
             "state" : "needs_review",
             "value" : "在设置中自定义"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "在設定中自訂"
+          }
         }
       }
     },
@@ -20771,6 +23081,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "自定义实体刘海宽度"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自訂實體瀏海寬度"
           }
         }
       }
@@ -20813,6 +23129,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "自定义拖放文件时出现的 LocalSend 设备选择弹出窗口的外观。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自訂拖放檔案時出現的 LocalSend 裝置選擇彈出式視窗的外觀。"
           }
         }
       }
@@ -20862,6 +23184,12 @@
             "state" : "translated",
             "value" : "虚线轮廓等于确切的刘海边界。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "虛線輪廓等於確切的瀏海邊界。"
+          }
         }
       }
     },
@@ -20906,6 +23234,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "深度工作"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "深度工作"
@@ -21022,6 +23356,12 @@
             "state" : "needs_review",
             "value" : "默认"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "預設"
+          }
         }
       }
     },
@@ -21076,6 +23416,12 @@
             "state" : "translated",
             "value" : "默认自定义计时器"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "預設自訂計時器"
+          }
         }
       }
     },
@@ -21115,6 +23461,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "默认视图"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "預設檢視"
           }
         }
       }
@@ -21168,6 +23520,12 @@
             "state" : "translated",
             "value" : "默认：dynamic.m4a"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "預設：dynamic.m4a"
+          }
         }
       }
     },
@@ -21220,6 +23578,12 @@
             "state" : "translated",
             "value" : "删除"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "刪除"
+          }
         }
       }
     },
@@ -21265,6 +23629,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "删除所有笔记？"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "刪除所有筆記？"
           }
         }
       }
@@ -21320,6 +23690,12 @@
             "state" : "translated",
             "value" : "删除动画"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "刪除動畫"
+          }
         }
       }
     },
@@ -21372,6 +23748,12 @@
             "state" : "translated",
             "value" : "删除颜色"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "刪除顏色"
+          }
         }
       }
     },
@@ -21411,6 +23793,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "已拒绝"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已拒絕"
           }
         }
       }
@@ -21460,6 +23848,12 @@
             "state" : "translated",
             "value" : "已拒绝/已撤销"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已拒絕/已撤銷"
+          }
         }
       }
     },
@@ -21507,6 +23901,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "拒绝"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "拒絕"
           }
         }
       }
@@ -21621,6 +24021,12 @@
             "state" : "needs_review",
             "value" : "描述"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "描述"
+          }
         }
       }
     },
@@ -21660,6 +24066,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "取消全选"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "取消全選"
           }
         }
       }
@@ -21702,6 +24114,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "设计师"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "設計師"
           }
         }
       }
@@ -21757,6 +24175,12 @@
             "state" : "translated",
             "value" : "检测状态"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "偵測狀態"
+          }
         }
       }
     },
@@ -21799,6 +24223,12 @@
             "state" : "translated",
             "value" : "开发者"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "開發者"
+          }
         }
       }
     },
@@ -21840,6 +24270,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "设备选择样式"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "裝置選擇樣式"
           }
         }
       }
@@ -21889,6 +24325,12 @@
             "state" : "translated",
             "value" : "设备"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "裝置"
+          }
         }
       }
     },
@@ -21937,6 +24379,12 @@
             "state" : "translated",
             "value" : "诊断"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "診斷"
+          }
         }
       }
     },
@@ -21980,6 +24428,12 @@
             "state" : "translated",
             "value" : "数字"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "數字"
+          }
         }
       }
     },
@@ -22022,6 +24476,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "尺寸"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "尺寸"
@@ -22139,6 +24599,12 @@
             "state" : "needs_review",
             "value" : "禁用"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "停用"
+          }
         }
       }
     },
@@ -22178,6 +24644,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "禁用简约界面以配置标准刘海媒体控制。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "停用簡約介面以配置標準瀏海媒體控制。"
           }
         }
       }
@@ -22291,6 +24763,12 @@
             "state" : "needs_review",
             "value" : "已禁用"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "已停用"
+          }
         }
       }
     },
@@ -22318,6 +24796,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "启用外接显示器亮度集成时不可用。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "啟用外接顯示器亮度整合時不可用。"
           }
         }
       }
@@ -22359,6 +24843,12 @@
             "state" : "translated",
             "value" : "外部显示器集成激活时已禁用——亮度键由外部应用处理。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "外部顯示器整合啟用時已停用——亮度鍵由外部 App 處理。"
+          }
         }
       }
     },
@@ -22386,6 +24876,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "启用外接显示器音量集成时不可用。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "啟用外接顯示器音量整合時不可用。"
           }
         }
       }
@@ -22435,6 +24931,12 @@
             "state" : "translated",
             "value" : "离散过渡在绿色（0-60%）、黄色（60-85%）和红色（85-100%）之间切换。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "離散過渡在綠色（0-60%）、黃色（60-85%）和紅色（85-100%）之間切換。"
+          }
         }
       }
     },
@@ -22477,6 +24979,12 @@
             "state" : "translated",
             "value" : "磁盘"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "磁碟"
+          }
         }
       }
     },
@@ -22517,6 +25025,12 @@
             "state" : "translated",
             "value" : "磁盘 I/O"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "磁碟 I/O"
+          }
         }
       }
     },
@@ -22556,6 +25070,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "磁盘概览"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "磁碟概覽"
           }
         }
       }
@@ -22609,6 +25129,12 @@
             "state" : "translated",
             "value" : "磁盘读取"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "磁碟讀取"
+          }
         }
       }
     },
@@ -22661,6 +25187,12 @@
             "state" : "translated",
             "value" : "磁盘写入"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "磁碟寫入"
+          }
         }
       }
     },
@@ -22672,6 +25204,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Sluit"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "關閉"
           }
         }
       }
@@ -22725,6 +25263,12 @@
             "state" : "translated",
             "value" : "显示模式"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "顯示模式"
+          }
         }
       }
     },
@@ -22772,6 +25316,12 @@
             "state" : "translated",
             "value" : "显示选项"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "顯示選項"
+          }
         }
       }
     },
@@ -22811,6 +25361,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "显示样式"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "顯示樣式"
           }
         }
       }
@@ -22866,6 +25422,12 @@
             "state" : "translated",
             "value" : "蓝牙音频设备（耳机、AirPods、扬声器）连接时显示 HUD 通知，包含设备名称和电池电量。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "藍牙音訊裝置（耳機、AirPods、揚聲器）連線時顯示 HUD 通知，包含裝置名稱和電池電量。"
+          }
         }
       }
     },
@@ -22911,6 +25473,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "音乐播放时在刘海旁边显示播放/暂停和跳过按钮。默认禁用。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "音樂播放時在瀏海旁邊顯示播放/暫停和跳過按鈕。預設停用。"
           }
         }
       }
@@ -22958,6 +25526,12 @@
             "state" : "translated",
             "value" : "启用专注检测时，在天气胶囊上方显示当前专注状态。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "啟用專注偵測時，在天氣膠囊上方顯示目前專注狀態。"
+          }
         }
       }
     },
@@ -22997,6 +25571,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "在天气胶囊上方或下方显示下一个即将到来的日历事件。此处的日历选择独立于灵动岛日历过滤器。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在天氣膠囊上方或下方顯示下一個即將到來的行事曆事件。此處的行事曆選擇獨立於動態島行事曆篩選器。"
           }
         }
       }
@@ -23043,6 +25623,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "勿扰模式"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "勿擾模式"
           }
         }
       }
@@ -23092,6 +25678,12 @@
             "state" : "translated",
             "value" : "捐赠"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "捐贈"
+          }
         }
       }
     },
@@ -23136,6 +25728,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "完成"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "完成"
@@ -23185,6 +25783,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "下载"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "下載"
           }
         }
       }
@@ -23298,6 +25902,12 @@
             "state" : "needs_review",
             "value" : "下载"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "下載"
+          }
         }
       },
       "shouldTranslate" : false
@@ -23352,6 +25962,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "下载检测"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "下載偵測"
           }
         }
       }
@@ -23412,6 +26028,12 @@
             "state" : "translated",
             "value" : "下载图标样式"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "下載圖示樣式"
+          }
         }
       }
     },
@@ -23470,6 +26092,12 @@
             "state" : "translated",
             "value" : "下载指示器样式"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "下載指示器樣式"
+          }
         }
       }
     },
@@ -23517,6 +26145,12 @@
             "state" : "translated",
             "value" : "下载指示器"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "下載指示器"
+          }
         }
       }
     },
@@ -23562,6 +26196,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "已下载"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已下載"
           }
         }
       }
@@ -23675,6 +26315,12 @@
             "state" : "needs_review",
             "value" : "下载"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "下載"
+          }
         }
       },
       "shouldTranslate" : false
@@ -23724,6 +26370,12 @@
             "state" : "translated",
             "value" : "将控件拖到插槽上或点击将其放在第一个空插槽中。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "將控制元件拖到插槽上或點按將其放在第一個空插槽中。"
+          }
         }
       }
     },
@@ -23771,6 +26423,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "在插槽之间拖动项目或从面板中放置以重新映射控件。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在插槽之間拖移項目或從面板中放置以重新對映控制元件。"
           }
         }
       }
@@ -23820,6 +26478,12 @@
             "state" : "translated",
             "value" : "拖动预览调整垂直位置。正值上移面板，负值下移。使用下方宽度滑块缩小媒体和计时器小组件而不超过默认大小。更改在小组件可见时立即生效。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "拖移預覽調整垂直位置。正值上移面板，負值下移。使用下方寬度滑桿縮小媒體和計時器小工具而不超過預設大小。更改在小工具可見時立即生效。"
+          }
         }
       }
     },
@@ -23859,6 +26523,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "拖放 PNG、JPEG、TIFF 或 ICNS 文件以添加到图标库。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "拖放 PNG、JPEG、TIFF 或 ICNS 檔案以新增到圖示庫。"
           }
         }
       }
@@ -23972,6 +26642,12 @@
             "state" : "needs_review",
             "value" : "拖放文件到这里"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "拖放檔案到這裡"
+          }
         }
       }
     },
@@ -24013,6 +26689,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "灵动岛"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "動態島"
           }
         }
       }
@@ -24062,6 +26744,12 @@
             "state" : "translated",
             "value" : "灵动岛进度条"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "動態島進度條"
+          }
         }
       }
     },
@@ -24102,6 +26790,12 @@
             "state" : "translated",
             "value" : "灵动岛可见性"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "動態島可見性"
+          }
         }
       }
     },
@@ -24141,6 +26835,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "灵动岛"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "動態島"
           }
         }
       },
@@ -24195,6 +26895,12 @@
             "state" : "translated",
             "value" : "每个图表可以单独启用或禁用。网络活动显示下载/上传速度，磁盘 I/O 显示读写速度。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "每個圖表可以單獨啟用或停用。網路活動顯示下載/上傳速度，磁碟 I/O 顯示讀寫速度。"
+          }
         }
       }
     },
@@ -24236,6 +26942,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "欧洲空气质量指数"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "歐洲空氣品質指數"
           }
         }
       }
@@ -24349,6 +27061,12 @@
             "state" : "needs_review",
             "value" : "轻松复制、存储和管理您最常用的内容。升级后可解锁高级功能，如多项目存储和快速访问！"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "輕鬆複製、儲存和管理你最常用的內容。升級後可解鎖進階功能，如多項目儲存和快速存取！"
+          }
         }
       }
     },
@@ -24383,6 +27101,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Düzenle"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "編輯"
           }
         }
       }
@@ -24435,6 +27159,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "编辑动画"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "編輯動畫"
           }
         }
       }
@@ -24548,6 +27278,12 @@
             "state" : "needs_review",
             "value" : "编辑布局"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "編輯版面配置"
+          }
         }
       }
     },
@@ -24595,6 +27331,12 @@
             "state" : "translated",
             "value" : "电子邮件地址"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "電子郵件地址"
+          }
         }
       }
     },
@@ -24631,6 +27373,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "空插槽"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "空插槽"
@@ -24681,6 +27429,12 @@
             "state" : "translated",
             "value" : "启用「空闲动画」以自定义动画"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "啟用「閒置動畫」以自訂動畫"
+          }
         }
       }
     },
@@ -24730,6 +27484,12 @@
             "state" : "translated",
             "value" : "启用「空闲时显示有趣的表情动画」以自定义动画"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "啟用「閒置時顯示有趣的表情動畫」以自訂動畫"
+          }
         }
       }
     },
@@ -24769,6 +27529,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "启用专辑封面视差效果"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "啟用專輯封面視差效果"
           }
         }
       }
@@ -24810,6 +27576,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "启用专辑封面视差效果"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "啟用專輯封面視差效果"
           }
         }
       }
@@ -24859,6 +27631,12 @@
             "state" : "translated",
             "value" : "启用并设置屏幕锁定时系统时钟上方显示的媒体控制。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "啟用並設定螢幕鎖定時系統時鐘上方顯示的媒體控制。"
+          }
         }
       }
     },
@@ -24898,6 +27676,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "启用专辑封面后的模糊效果"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "啟用專輯封面後的模糊效果"
           }
         }
       }
@@ -24946,6 +27730,12 @@
             "state" : "translated",
             "value" : "启用内置系统 HUD"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "啟用內建系統 HUD"
+          }
         }
       }
     },
@@ -24993,6 +27783,12 @@
             "state" : "translated",
             "value" : "启用内置系统监控，用 Atoll 显示替代 macOS HUD 通知。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "啟用內建系統監控，用 Atoll 顯示替代 macOS HUD 通知。"
+          }
         }
       }
     },
@@ -25038,6 +27834,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "启用日历访问"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "啟用行事曆存取"
           }
         }
       }
@@ -25085,6 +27887,12 @@
             "state" : "translated",
             "value" : "启用相机访问"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "啟用相機存取"
+          }
         }
       }
     },
@@ -25124,6 +27932,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "启用相机检测"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "啟用相機偵測"
           }
         }
       }
@@ -25165,6 +27979,12 @@
             "state" : "translated",
             "value" : "启用剪贴板管理器"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "啟用剪貼簿管理程式"
+          }
         }
       }
     },
@@ -25204,6 +28024,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "启用颜色过滤"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "啟用顏色篩選"
           }
         }
       }
@@ -25245,6 +28071,12 @@
             "state" : "translated",
             "value" : "启用取色器"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "啟用取色器"
+          }
         }
       }
     },
@@ -25284,6 +28116,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "启用彩色频谱图"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "啟用彩色頻譜圖"
           }
         }
       }
@@ -25398,6 +28236,12 @@
             "state" : "needs_review",
             "value" : "启用彩色谱图"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "啟用彩色譜圖"
+          }
         }
       }
     },
@@ -25450,6 +28294,12 @@
             "state" : "translated",
             "value" : "在设置 → 取色器中启用取色器"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在設定 → 取色器中啟用取色器"
+          }
         }
       }
     },
@@ -25489,6 +28339,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "启用从剪贴板创建"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "啟用從剪貼簿建立"
           }
         }
       }
@@ -25538,6 +28394,12 @@
             "state" : "translated",
             "value" : "启用自定义控制"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "啟用自訂控制"
+          }
         }
       }
     },
@@ -25577,6 +28439,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "启用下载检测"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "啟用下載偵測"
           }
         }
       }
@@ -25618,6 +28486,12 @@
             "state" : "translated",
             "value" : "启用灵动岛媒体控制以管理锁屏面板。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "啟用動態島媒體控制以管理鎖定畫面面板。"
+          }
         }
       }
     },
@@ -25657,6 +28531,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "启用动态镜像"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "啟用動態鏡像"
           }
         }
       }
@@ -25699,6 +28579,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "启用扩展诊断日志"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "啟用延伸功能診斷日誌"
           }
         }
       }
@@ -25748,6 +28634,12 @@
             "state" : "translated",
             "value" : "启用扩展以允许第三方应用在 Atoll 中显示实时活动和锁屏小组件。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "啟用延伸功能以允許第三方 App 在 Atoll 中顯示即時動態和鎖定畫面小工具。"
+          }
         }
       }
     },
@@ -25790,6 +28682,12 @@
             "state" : "translated",
             "value" : "启用外部音量控制监听"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "啟用外部音量控制監聽"
+          }
         }
       }
     },
@@ -25829,6 +28727,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "启用专注模式检测"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "啟用專注模式偵測"
           }
         }
       }
@@ -25870,6 +28774,12 @@
             "state" : "translated",
             "value" : "启用手势"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "啟用手勢"
+          }
         }
       }
     },
@@ -25909,6 +28819,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "启用全局键盘快捷键"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "啟用全域鍵盤快速鍵"
           }
         }
       }
@@ -25956,6 +28872,12 @@
             "state" : "translated",
             "value" : "启用上方的全局键盘快捷键以自定义您的快捷键。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "啟用上方的全域鍵盤快速鍵以自訂你的快速鍵。"
+          }
         }
       }
     },
@@ -25995,6 +28917,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "启用发光效果"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "啟用發光效果"
           }
         }
       }
@@ -26043,6 +28971,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "在设置 → 统计中启用图表可见性以查看性能数据。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在設定 → 統計中啟用圖表可見性以檢視效能資料。"
           }
         }
       }
@@ -26155,6 +29089,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "启用触觉"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "啟用觸覺"
           }
         }
       }
@@ -26269,6 +29209,12 @@
             "state" : "needs_review",
             "value" : "启用 HUD 替换"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "啟用 HUD 替換"
+          }
         }
       }
     },
@@ -26309,6 +29255,12 @@
             "state" : "translated",
             "value" : "在设置 → 终端中启用"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在設定 → 終端機中啟用"
+          }
         }
       }
     },
@@ -26318,6 +29270,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Bewaak LLM-gebruik"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "啟用 LLM 用量監控"
           }
         }
       }
@@ -26359,6 +29317,12 @@
             "state" : "translated",
             "value" : "启用锁屏实时活动"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "啟用鎖定畫面即時動態"
+          }
         }
       }
     },
@@ -26398,6 +29362,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "启用歌词"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "啟用歌詞"
           }
         }
       }
@@ -26447,6 +29417,12 @@
             "state" : "translated",
             "value" : "启用媒体面板模糊"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "啟用媒體面板模糊"
+          }
         }
       }
     },
@@ -26487,6 +29463,12 @@
             "state" : "translated",
             "value" : "启用麦克风检测"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "啟用麥克風偵測"
+          }
         }
       }
     },
@@ -26526,6 +29508,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "启用简约界面"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "啟用簡約介面"
           }
         }
       }
@@ -26639,6 +29627,12 @@
             "state" : "translated",
             "value" : "启用音乐实时活动"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "啟用音樂即時動態"
+          }
         }
       }
     },
@@ -26678,6 +29672,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "启用笔记固定"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "啟用筆記固定"
           }
         }
       }
@@ -26719,6 +29719,12 @@
             "state" : "translated",
             "value" : "启用笔记搜索"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "啟用筆記搜尋"
+          }
         }
       }
     },
@@ -26758,6 +29764,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "启用笔记"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "啟用筆記"
           }
         }
       }
@@ -26799,6 +29811,12 @@
             "state" : "translated",
             "value" : "启用实时波形"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "啟用即時波形"
+          }
         }
       }
     },
@@ -26839,6 +29857,12 @@
             "state" : "translated",
             "value" : "启用提醒实时活动"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "啟用提醒即時動態"
+          }
         }
       }
     },
@@ -26878,6 +29902,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "启用屏幕助手"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "啟用螢幕助理"
           }
         }
       }
@@ -26925,6 +29955,12 @@
             "state" : "translated",
             "value" : "启用屏幕取色功能。使用 Cmd+Shift+P 快速访问取色器。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "啟用螢幕取色功能。使用 Cmd+Shift+P 快速存取取色器。"
+          }
         }
       }
     },
@@ -26965,6 +30001,12 @@
             "state" : "translated",
             "value" : "启用屏幕录制检测"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "啟用螢幕錄製偵測"
+          }
         }
       }
     },
@@ -27004,6 +30046,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "启用架子"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "啟用架子"
           }
         }
       }
@@ -27057,6 +30105,12 @@
             "state" : "translated",
             "value" : "启用快速预览"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "啟用快速預覽"
+          }
         }
       }
     },
@@ -27103,6 +30157,12 @@
             "state" : "translated",
             "value" : "在设置中启用统计监控以查看系统性能数据。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在設定中啟用統計監控以檢視系統效能資料。"
+          }
         }
       }
     },
@@ -27143,6 +30203,12 @@
             "state" : "translated",
             "value" : "启用系统统计监控"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "啟用系統統計監控"
+          }
         }
       }
     },
@@ -27182,6 +30248,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "启用终端"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "啟用終端機"
           }
         }
       }
@@ -27228,6 +30300,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "启用电池胶囊并配置其布局。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "啟用電池膠囊並配置其版面配置。"
           }
         }
       }
@@ -27277,6 +30355,12 @@
             "state" : "translated",
             "value" : "在设置中启用计时器功能以访问此标签页。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在設定中啟用計時器功能以存取此分頁。"
+          }
         }
       }
     },
@@ -27325,6 +30409,12 @@
             "state" : "translated",
             "value" : "启用天气胶囊并配置其布局、数据源、单位和可选的电池/AQI 指示器。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "啟用天氣膠囊並配置其版面配置、資料來源、單位和可選的電池/AQI 指示器。"
+          }
         }
       }
     },
@@ -27371,6 +30461,12 @@
             "state" : "translated",
             "value" : "启用思考模式"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "啟用思考模式"
+          }
         }
       }
     },
@@ -27410,6 +30506,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "启用第三方日历应用启动"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "啟用第三方行事曆 App 啟動"
           }
         }
       }
@@ -27453,6 +30555,12 @@
             "state" : "translated",
             "value" : "启用第三方 DDC 应用集成"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "啟用第三方 DDC App 整合"
+          }
         }
       }
     },
@@ -27495,6 +30603,12 @@
             "state" : "translated",
             "value" : "启用第三方扩展"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "啟用第三方延伸功能"
+          }
         }
       }
     },
@@ -27534,6 +30648,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "启用计时器功能"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "啟用計時器功能"
           }
         }
       }
@@ -27581,6 +30701,12 @@
             "state" : "translated",
             "value" : "启用计时器实时活动"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "啟用計時器即時動態"
+          }
         }
       }
     },
@@ -27622,6 +30748,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "启用后通过 Atoll 的活跃 HUD 样式传递 BetterDisplay 或 Lunar 的显示调整。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "啟用後透過 Atoll 的活躍 HUD 樣式傳遞 BetterDisplay 或 Lunar 的顯示調整。"
           }
         }
       }
@@ -27669,6 +30801,12 @@
             "state" : "translated",
             "value" : "当缩放超过 30x20 像素时启用以使 Atoll 优雅打开。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "當縮放超過 30x20 畫素時啟用以使 Atoll 優雅開啟。"
+          }
         }
       }
     },
@@ -27708,6 +30846,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "启用窗口阴影"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "啟用視窗陰影"
           }
         }
       }
@@ -27759,6 +30903,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "引擎利用率"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "引擎利用率"
@@ -27875,6 +31025,12 @@
             "state" : "needs_review",
             "value" : "用 HUD 提升您的体验"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "用 HUD 提升你的體驗"
+          }
         }
       }
     },
@@ -27987,6 +31143,12 @@
             "state" : "needs_review",
             "value" : "享受您的闲暇时光！"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "享受你的閒暇時光！"
+          }
         }
       }
     },
@@ -28038,6 +31200,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "输入您的 Gemini API 密钥"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "輸入你的 Gemini API 金鑰"
           }
         }
       }
@@ -28152,6 +31320,12 @@
             "state" : "needs_review",
             "value" : "错误"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "錯誤"
+          }
         }
       }
     },
@@ -28193,6 +31367,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "事件颜色"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "事件顏色"
           }
         }
       }
@@ -28238,6 +31418,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "事件列表"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "事件列表"
@@ -28294,6 +31480,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "排除应用"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "排除 App"
           }
         }
       }
@@ -28407,6 +31599,12 @@
             "state" : "needs_review",
             "value" : "退出"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "退出"
+          }
         }
       }
     },
@@ -28453,6 +31651,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "展开刘海以跟随动画宽度"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "展開瀏海以跟隨動畫寬度"
           }
         }
       }
@@ -28502,6 +31706,12 @@
             "state" : "translated",
             "value" : "扩展的拖拽检测区域"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "延伸功能的拖移偵測區域"
+          }
         }
       }
     },
@@ -28550,6 +31760,12 @@
             "state" : "translated",
             "value" : "展开的刘海宽度"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "展開的瀏海寬度"
+          }
         }
       }
     },
@@ -28573,6 +31789,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "展开宽度调整仅适用于标准刘海布局。请关闭简约界面后再编辑。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "展開寬度調整僅適用於標準瀏海版面配置。請關閉簡約介面後再編輯。"
           }
         }
       }
@@ -28613,6 +31835,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "扩展悬停区域"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "延伸功能懸停區域"
           }
         }
       }
@@ -28661,6 +31889,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "扩展标签页不可用"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "延伸功能分頁不可用"
           }
         }
       }
@@ -28775,6 +32009,12 @@
             "state" : "needs_review",
             "value" : "扩展"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "延伸功能"
+          }
         }
       }
     },
@@ -28829,6 +32069,12 @@
             "state" : "translated",
             "value" : "外置"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "外接"
+          }
         }
       }
     },
@@ -28871,6 +32117,12 @@
             "state" : "translated",
             "value" : "外接显示器样式"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "外接顯示器樣式"
+          }
         }
       }
     },
@@ -28892,6 +32144,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "华氏度"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "華氏度"
           }
         }
       }
@@ -28933,6 +32191,12 @@
             "state" : "translated",
             "value" : "风扇转速"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "風扇轉速"
+          }
         }
       }
     },
@@ -28971,6 +32235,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "收藏"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "收藏"
@@ -29017,6 +32287,12 @@
             "state" : "translated",
             "value" : "文件"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "檔案"
+          }
         }
       }
     },
@@ -29058,6 +32334,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "拖放到此处的文件将通过此服务共享"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "拖放到此處的檔案將透過此服務共享"
           }
         }
       }
@@ -29107,6 +32389,12 @@
             "state" : "translated",
             "value" : "拖放到架子上的文件将通过此服务共享"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "拖放到架子上的檔案將透過此服務共享"
+          }
         }
       }
     },
@@ -29148,6 +32436,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "从架子共享的文件将使用此服务"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "從架子共享的檔案將使用此服務"
           }
         }
       }
@@ -29194,6 +32488,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "填充刘海"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "填充瀏海"
           }
         }
       }
@@ -29307,6 +32607,12 @@
             "state" : "needs_review",
             "value" : "完成"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "完成"
+          }
         }
       }
     },
@@ -29352,6 +32658,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "适应刘海"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "適應瀏海"
           }
         }
       }
@@ -29401,6 +32713,12 @@
             "state" : "translated",
             "value" : "浮动窗口面板跳过行为"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "浮動視窗面板跳過行為"
+          }
         }
       }
     },
@@ -29442,6 +32760,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "专注"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "專注"
           }
         }
       }
@@ -29491,6 +32815,12 @@
             "state" : "translated",
             "value" : "专注模式已激活：%@"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "專注模式已啟用：%@"
+          }
         }
       }
     },
@@ -29532,6 +32862,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "专注检测模式"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "專注偵測模式"
           }
         }
       }
@@ -29579,6 +32915,12 @@
             "state" : "translated",
             "value" : "专注状态"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "專注狀態"
+          }
         }
       }
     },
@@ -29625,6 +32967,12 @@
             "state" : "translated",
             "value" : "专注小组件"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "專注小工具"
+          }
         }
       }
     },
@@ -29665,6 +33013,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "字体系列"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "字型系列"
           }
         }
       }
@@ -29708,6 +33062,12 @@
             "state" : "translated",
             "value" : "字体大小"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "字型大小"
+          }
         }
       }
     },
@@ -29744,6 +33104,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "前景"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "前景"
@@ -29788,6 +33154,12 @@
             "state" : "translated",
             "value" : "快进 10 秒"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "快進 10 秒"
+          }
         }
       }
     },
@@ -29827,6 +33199,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "空闲"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "閒置"
           }
         }
       }
@@ -29882,6 +33260,12 @@
             "state" : "translated",
             "value" : "可用 · %@"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "可用 · %@"
+          }
         }
       }
     },
@@ -29922,6 +33306,12 @@
             "state" : "translated",
             "value" : "频率"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "頻率"
+          }
         }
       }
     },
@@ -29960,6 +33350,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "磨砂玻璃"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "磨砂玻璃"
@@ -30004,6 +33400,12 @@
             "state" : "translated",
             "value" : "完全访问"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "完全存取"
+          }
         }
       }
     },
@@ -30031,6 +33433,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "满电量"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "滿電量"
           }
         }
       }
@@ -30060,6 +33468,12 @@
             "state" : "translated",
             "value" : "满电提示持续时间"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "滿電提示持續時間"
+          }
         }
       }
     },
@@ -30087,6 +33501,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "满电提示样式"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "滿電提示樣式"
           }
         }
       }
@@ -30130,6 +33550,12 @@
             "state" : "translated",
             "value" : "已充满"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已充滿"
+          }
         }
       }
     },
@@ -30157,6 +33583,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "满电阈值"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "滿電閾值"
           }
         }
       }
@@ -30205,6 +33637,12 @@
             "state" : "translated",
             "value" : "需要完全磁盘访问权限"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "需要完整磁碟取用權"
+          }
         }
       }
     },
@@ -30245,6 +33683,12 @@
             "state" : "translated",
             "value" : "完全磁盘访问解锁自定义专注模式图标、颜色和标签。标准专注检测无需此权限即可工作——仅在需要个性化指示器时授予访问权限。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "完整磁碟取用權解鎖自訂專注模式圖示、顏色和標籤。標準專注偵測無需此權限即可工作——僅在需要個人化指示器時授予存取權限。"
+          }
         }
       }
     },
@@ -30272,6 +33716,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "右键点按显示全屏封面"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "右鍵點按顯示全螢幕封面"
           }
         }
       }
@@ -30320,6 +33770,12 @@
             "state" : "translated",
             "value" : "已充满"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已充滿"
+          }
         }
       }
     },
@@ -30347,6 +33803,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "已充满提示框"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已充滿提示框"
           }
         }
       }
@@ -30399,6 +33861,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Gemini API 密钥"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gemini API 金鑰"
           }
         }
       }
@@ -30508,6 +33976,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "通用"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "通用"
@@ -30624,6 +34098,12 @@
             "state" : "needs_review",
             "value" : "手势控制"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "手勢控制"
+          }
         }
       }
     },
@@ -30736,6 +34216,12 @@
             "state" : "needs_review",
             "value" : "手势灵敏度"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "手勢靈敏度"
+          }
         }
       }
     },
@@ -30783,6 +34269,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "手势跳过行为"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "手勢跳過行為"
           }
         }
       }
@@ -30896,6 +34388,12 @@
             "state" : "needs_review",
             "value" : "开始使用"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "開始使用"
+          }
         }
       }
     },
@@ -30925,6 +34423,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "手动获取 cookie"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "手動取得 cookie"
           }
         }
       }
@@ -30977,6 +34481,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "从 Google AI Studio 获取免费 API 密钥"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "從 Google AI Studio 取得免費 API 金鑰"
           }
         }
       }
@@ -31090,6 +34600,12 @@
             "state" : "translated",
             "value" : "GitHub"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "GitHub"
+          }
         }
       },
       "shouldTranslate" : false
@@ -31129,6 +34645,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "玻璃"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "玻璃"
@@ -31180,6 +34702,12 @@
             "state" : "translated",
             "value" : "玻璃模式"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "玻璃模式"
+          }
         }
       }
     },
@@ -31227,6 +34755,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "全局设置"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "全域設定"
           }
         }
       }
@@ -31340,6 +34874,12 @@
             "state" : "needs_review",
             "value" : "明白了！"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "明白了！"
+          }
         }
       }
     },
@@ -31378,6 +34918,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "GPU"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "GPU"
@@ -31421,6 +34967,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "GPU 概览"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "GPU 概覽"
           }
         }
       }
@@ -31470,6 +35022,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "GPU 使用率"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "GPU 使用率"
@@ -31586,6 +35144,12 @@
             "state" : "needs_review",
             "value" : "渐变"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "漸變"
+          }
         }
       }
     },
@@ -31638,6 +35202,12 @@
             "state" : "translated",
             "value" : "图表可见性"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "圖表可見性"
+          }
         }
       }
     },
@@ -31680,6 +35250,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "绿色"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "綠色"
           }
         }
       }
@@ -31734,6 +35310,12 @@
             "state" : "translated",
             "value" : "高度："
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "高度："
+          }
         }
       }
     },
@@ -31780,6 +35362,12 @@
             "state" : "translated",
             "value" : "高度：%lld像素"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "高度：%lld畫素"
+          }
         }
       }
     },
@@ -31814,6 +35402,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Merhaba, cam!"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "哈囉，玻璃！"
           }
         }
       }
@@ -31855,6 +35449,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "时"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "時"
           }
         }
       }
@@ -31908,6 +35508,12 @@
             "state" : "translated",
             "value" : "隐藏"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "隱藏"
+          }
         }
       }
     },
@@ -31947,6 +35553,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "隐藏当前事件并显示下一个即将到来的事件"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "隱藏目前事件並顯示下一個即將到來的事件"
           }
         }
       }
@@ -31996,6 +35608,12 @@
             "state" : "translated",
             "value" : "隐藏全天事件"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "隱藏全天事件"
+          }
         }
       }
     },
@@ -32044,6 +35662,12 @@
             "state" : "translated",
             "value" : "隐藏已完成的提醒"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "隱藏已完成的提醒"
+          }
         }
       }
     },
@@ -32083,6 +35707,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "截图和录制时隐藏灵动岛"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "截圖和錄製時隱藏動態島"
           }
         }
       }
@@ -32136,6 +35766,12 @@
             "state" : "translated",
             "value" : "隐藏灵动岛选项"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "隱藏動態島選項"
+          }
         }
       }
     },
@@ -32175,6 +35811,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "隐藏锁屏预览"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "隱藏鎖定畫面預覽"
           }
         }
       }
@@ -32288,6 +35930,12 @@
             "state" : "needs_review",
             "value" : "仅在“当前播放”全屏时隐藏"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "僅在「正在播放」全螢幕時隱藏"
+          }
         }
       }
     },
@@ -32299,6 +35947,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Verberg versie-informatie"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "隱藏版本說明"
           }
         }
       }
@@ -32339,6 +35993,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "在无刘海显示器上隐藏直到悬停"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在無瀏海顯示器上隱藏直到懸停"
           }
         }
       }
@@ -32451,6 +36111,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "分级"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "分級"
           }
         }
       }
@@ -32565,6 +36231,12 @@
             "state" : "needs_review",
             "value" : "高"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "高"
+          }
         }
       }
     },
@@ -32611,6 +36283,12 @@
             "state" : "translated",
             "value" : "无超时的高频更新可能会增加电池消耗。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無超時的高頻更新可能會增加電池消耗。"
+          }
         }
       }
     },
@@ -32652,6 +36330,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "历史"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "歷史"
           }
         }
       }
@@ -32705,6 +36389,12 @@
             "state" : "translated",
             "value" : "历史大小"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "歷史大小"
+          }
         }
       }
     },
@@ -32742,6 +36432,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "水平："
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "水平："
@@ -32787,6 +36483,12 @@
             "state" : "translated",
             "value" : "小时"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "小時"
+          }
         }
       }
     },
@@ -32825,6 +36527,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "https://example.com/animation.json"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "https://example.com/animation.json"
@@ -32942,6 +36650,12 @@
             "state" : "translated",
             "value" : "https://github.com/th-ch/youtube-music"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "https://github.com/th-ch/youtube-music"
+          }
         }
       },
       "shouldTranslate" : false
@@ -32970,6 +36684,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "提示框持续时间"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "提示框持續時間"
           }
         }
       }
@@ -33013,6 +36733,12 @@
             "state" : "translated",
             "value" : "HUD 图标样式"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "HUD 圖示樣式"
+          }
         }
       }
     },
@@ -33055,6 +36781,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "HUD 位置"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "HUD 位置"
@@ -33171,6 +36903,12 @@
             "state" : "needs_review",
             "value" : "HUD 样式"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "HUD 樣式"
+          }
         }
       }
     },
@@ -33198,6 +36936,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "提示框测试"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "提示框測試"
           }
         }
       }
@@ -33312,6 +37056,12 @@
             "state" : "needs_review",
             "value" : "HUD"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "HUD"
+          }
         }
       },
       "shouldTranslate" : false
@@ -33360,6 +37110,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "图标和进度颜色"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "圖示和進度顏色"
           }
         }
       }
@@ -33415,6 +37171,12 @@
             "state" : "translated",
             "value" : "空闲"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "閒置"
+          }
         }
       }
     },
@@ -33454,6 +37216,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "空闲动画"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "閒置動畫"
           }
         }
       }
@@ -33509,6 +37277,12 @@
             "state" : "translated",
             "value" : "空闲动画样式"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "閒置動畫樣式"
+          }
         }
       }
     },
@@ -33550,6 +37324,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "图片"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "圖片"
           }
         }
       }
@@ -33602,6 +37382,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "导入"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "匯入"
           }
         }
       }
@@ -33657,6 +37443,12 @@
             "state" : "translated",
             "value" : "导入错误"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "匯入錯誤"
+          }
         }
       }
     },
@@ -33711,6 +37503,12 @@
             "state" : "translated",
             "value" : "导入文件..."
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "匯入檔案..."
+          }
         }
       }
     },
@@ -33741,6 +37539,12 @@
             "state" : "translated",
             "value" : "%@后"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@後"
+          }
         }
       }
     },
@@ -33770,6 +37574,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "还有 %lld"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "還有 %lld"
           }
         }
       }
@@ -33883,6 +37693,12 @@
             "state" : "needs_review",
             "value" : "进行中"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "進行中"
+          }
         }
       }
     },
@@ -33934,6 +37750,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "不活跃"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "不活躍"
           }
         }
       }
@@ -34047,6 +37869,12 @@
             "state" : "needs_review",
             "value" : "内嵌"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "內嵌"
+          }
         }
       }
     },
@@ -34093,6 +37921,12 @@
             "state" : "translated",
             "value" : "内联快照预览"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "內聯快照預覽"
+          }
         }
       }
     },
@@ -34133,6 +37967,12 @@
             "state" : "translated",
             "value" : "输入"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "輸入"
+          }
         }
       }
     },
@@ -34145,6 +37985,12 @@
             "state" : "translated",
             "value" : "Installeer en start opnieuw"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "安裝並重新啟動"
+          }
         }
       }
     },
@@ -34156,6 +38002,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Installeer update"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "安裝更新"
           }
         }
       }
@@ -34210,6 +38062,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "自动安装更新"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自動安裝更新"
           }
         }
       }
@@ -34325,6 +38183,12 @@
             "state" : "needs_review",
             "value" : "已安装扩展"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "已安裝延伸功能"
+          }
         }
       }
     },
@@ -34366,6 +38230,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "集成"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "整合"
           }
         }
       }
@@ -34413,6 +38283,12 @@
             "state" : "translated",
             "value" : "交互式（拖拽更改）"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "互動式（拖移更改）"
+          }
         }
       }
     },
@@ -34452,6 +38328,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "网络接口"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "網路介面"
           }
         }
       }
@@ -34495,6 +38377,12 @@
             "state" : "translated",
             "value" : "IPv4 · %@"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "IPv4 · %@"
+          }
         }
       },
       "shouldTranslate" : false
@@ -34534,6 +38422,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "IPv6 · %@"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "IPv6 · %@"
@@ -34585,6 +38479,12 @@
             "state" : "translated",
             "value" : "加入会议"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "加入會議"
+          }
         }
       }
     },
@@ -34626,6 +38526,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "刚刚"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "剛剛"
           }
         }
       }
@@ -34669,6 +38575,12 @@
             "state" : "translated",
             "value" : "刚刚"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "剛剛"
+          }
         }
       }
     },
@@ -34696,6 +38608,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "显示全屏封面时保留专辑封面"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "顯示全螢幕封面時保留專輯封面"
           }
         }
       }
@@ -34736,6 +38654,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "保持终端打开直到点击外部"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "保持終端機開啟直到點按外部"
           }
         }
       }
@@ -34789,6 +38713,12 @@
             "state" : "translated",
             "value" : "键盘背光 HUD"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "鍵盤背光 HUD"
+          }
         }
       }
     },
@@ -34836,6 +38766,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "键盘背光 OSD"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "鍵盤背光 OSD"
           }
         }
       }
@@ -34889,6 +38825,12 @@
             "state" : "translated",
             "value" : "键盘快捷键已禁用"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "鍵盤快速鍵已停用"
+          }
         }
       }
     },
@@ -34936,6 +38878,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "启用简短提示模式时，标签将强制为紧凑开/关文本。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "啟用簡短提示模式時，標籤將強制為緊湊開/關文字。"
           }
         }
       }
@@ -34985,6 +38933,12 @@
             "state" : "translated",
             "value" : "上次拒绝原因："
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "上次拒絕原因："
+          }
         }
       }
     },
@@ -35005,6 +38959,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "上次同步"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "上次同步"
@@ -35045,6 +39005,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "上次更新"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "上次更新"
@@ -35097,6 +39063,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "上次更新"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "上次更新"
@@ -35213,6 +39185,12 @@
             "state" : "needs_review",
             "value" : "稍后再说"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "稍後再說"
+          }
         }
       }
     },
@@ -35253,6 +39231,12 @@
             "state" : "translated",
             "value" : "登录时启动"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "登入時啟動"
+          }
         }
       }
     },
@@ -35288,6 +39272,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "布局"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "版面配置"
           }
         }
       },
@@ -35336,6 +39326,12 @@
             "state" : "translated",
             "value" : "布局预览"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "版面配置預覽"
+          }
         }
       }
     },
@@ -35382,6 +39378,12 @@
             "state" : "translated",
             "value" : "左"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "左"
+          }
         }
       }
     },
@@ -35403,6 +39405,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Классический"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "舊版"
           }
         }
       }
@@ -35451,6 +39459,12 @@
             "state" : "translated",
             "value" : "许可证密钥"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "許可證金鑰"
+          }
         }
       }
     },
@@ -35492,6 +39506,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "轻度使用"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "輕度使用"
           }
         }
       }
@@ -35539,6 +39559,12 @@
             "state" : "translated",
             "value" : "线宽：%lld像素"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "線寬：%lld畫素"
+          }
         }
       }
     },
@@ -35576,6 +39602,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "LinkedIn"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "LinkedIn"
@@ -35622,6 +39654,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "液态玻璃"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "液態玻璃"
           }
         }
       }
@@ -35676,6 +39714,12 @@
             "state" : "translated",
             "value" : "液态玻璃需要 macOS 26 或更高版本。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "液態玻璃需要 macOS 26 或更高版本。"
+          }
         }
       }
     },
@@ -35717,6 +39761,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "液态玻璃变体"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "液態玻璃變體"
           }
         }
       }
@@ -35764,6 +39814,12 @@
             "state" : "translated",
             "value" : "通过分布式通知监听专注模式会话变化"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "透過分散式通知監聽專注模式工作階段變化"
+          }
         }
       }
     },
@@ -35808,6 +39864,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "直播"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "直播"
@@ -35860,6 +39922,12 @@
             "state" : "translated",
             "value" : "实时活动"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "即時動態"
+          }
         }
       }
     },
@@ -35908,6 +39976,12 @@
             "state" : "translated",
             "value" : "实时活动与反馈"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "即時動態與回饋"
+          }
         }
       }
     },
@@ -35954,6 +40028,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "实时监控"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "即時監控"
           }
         }
       }
@@ -36007,6 +40087,12 @@
             "state" : "translated",
             "value" : "实时性能数据"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "即時效能資料"
+          }
         }
       }
     },
@@ -36054,6 +40140,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "实时预览"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "即時預覽"
           }
         }
       }
@@ -36103,6 +40195,12 @@
             "state" : "translated",
             "value" : "直播指示器"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "直播指示器"
+          }
         }
       }
     },
@@ -36112,6 +40210,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "LLM-aanbieders"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "LLM 服務供應商"
           }
         }
       }
@@ -36153,6 +40257,12 @@
             "state" : "translated",
             "value" : "1分钟负载"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1分鐘負載"
+          }
         }
       }
     },
@@ -36193,6 +40303,12 @@
             "state" : "translated",
             "value" : "5分钟负载"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "5分鐘負載"
+          }
         }
       }
     },
@@ -36232,6 +40348,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "15分钟负载"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "15分鐘負載"
           }
         }
       }
@@ -36287,6 +40409,12 @@
             "state" : "translated",
             "value" : "负载平均值"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "負載平均值"
+          }
         }
       }
     },
@@ -36329,6 +40457,12 @@
             "state" : "translated",
             "value" : "加载中..."
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "載入中..."
+          }
         }
       }
     },
@@ -36370,6 +40504,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "LocalSend 设备选择器"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "LocalSend 裝置選擇器"
           }
         }
       }
@@ -36423,6 +40563,12 @@
             "state" : "translated",
             "value" : "锁屏"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "鎖定畫面"
+          }
         }
       }
     },
@@ -36469,6 +40615,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "锁屏玻璃"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "鎖定畫面玻璃"
           }
         }
       }
@@ -36517,6 +40669,12 @@
             "state" : "translated",
             "value" : "锁屏玻璃模式"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "鎖定畫面玻璃模式"
+          }
         }
       }
     },
@@ -36562,6 +40720,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "锁屏集成"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "鎖定畫面整合"
           }
         }
       }
@@ -36611,6 +40775,12 @@
             "state" : "translated",
             "value" : "锁屏液态玻璃"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "鎖定畫面液態玻璃"
+          }
         }
       }
     },
@@ -36656,6 +40826,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "锁屏媒体"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "鎖定畫面媒體"
           }
         }
       }
@@ -36705,6 +40881,12 @@
             "state" : "translated",
             "value" : "锁屏面板预览"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "鎖定畫面面板預覽"
+          }
         }
       }
     },
@@ -36752,6 +40934,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "锁屏定位"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "鎖定畫面定位"
           }
         }
       }
@@ -36801,6 +40989,12 @@
             "state" : "translated",
             "value" : "锁屏提醒小组件"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "鎖定畫面提醒小工具"
+          }
         }
       }
     },
@@ -36849,6 +41043,12 @@
             "state" : "translated",
             "value" : "锁屏小组件"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "鎖定畫面小工具"
+          }
         }
       }
     },
@@ -36889,6 +41089,12 @@
             "state" : "translated",
             "value" : "逻辑核心"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "邏輯核心"
+          }
         }
       }
     },
@@ -36900,6 +41106,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Zoeken naar een nieuwe versie van Atoll"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在尋找 Atoll 新版本"
           }
         }
       }
@@ -36946,6 +41158,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "循环模式"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "迴圈模式"
           }
         }
       }
@@ -37058,6 +41276,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "Lottie JSON 链接"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Lottie JSON 連結"
           }
         }
       }
@@ -37172,6 +41396,12 @@
             "state" : "needs_review",
             "value" : "低"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "低"
+          }
         }
       }
     },
@@ -37214,6 +41444,12 @@
             "state" : "translated",
             "value" : "电量低"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "電量低"
+          }
         }
       }
     },
@@ -37241,6 +41477,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "低电量"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "低電量"
           }
         }
       }
@@ -37270,6 +41512,12 @@
             "state" : "translated",
             "value" : "低电量提示持续时间"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "低電量提示持續時間"
+          }
         }
       }
     },
@@ -37297,6 +41545,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "低电量提示框"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "低電量提示框"
           }
         }
       }
@@ -37326,6 +41580,12 @@
             "state" : "translated",
             "value" : "低电量提示样式"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "低電量提示樣式"
+          }
         }
       }
     },
@@ -37353,6 +41613,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "低电量阈值"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "低電量閾值"
           }
         }
       }
@@ -37466,6 +41732,12 @@
             "state" : "needs_review",
             "value" : "低电量模式"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "低電量模式"
+          }
         }
       }
     },
@@ -37508,6 +41780,12 @@
             "state" : "translated",
             "value" : "低电量：%@"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "低電量：%@"
+          }
         }
       }
     },
@@ -37547,6 +41825,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "歌词"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "歌詞"
           }
         }
       }
@@ -37595,6 +41879,12 @@
             "state" : "translated",
             "value" : "Mac 电池电量 %d%%"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mac 電池電量 %d%%"
+          }
         }
       }
     },
@@ -37639,6 +41929,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "需要 macOS 15 或更高版本"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "需要 macOS 15 或更高版本"
@@ -37691,6 +41987,12 @@
             "state" : "translated",
             "value" : "由 Ebullioscopic 用 ❤️ 制作"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "由 Ebullioscopic 用 ❤️ 製作"
+          }
         }
       }
     },
@@ -37730,6 +42032,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "主屏幕样式"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "主螢幕樣式"
           }
         }
       }
@@ -37772,6 +42080,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "请确保 LocalSend 在其他设备上运行"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "請確保 LocalSend 在其他裝置上執行"
           }
         }
       }
@@ -37821,6 +42135,12 @@
             "state" : "translated",
             "value" : "在设置 → 隐私中管理指示器偏好。无需手动切换麦克风。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在設定 → 隱私中管理指示器偏好。無需手動切換麥克風。"
+          }
         }
       }
     },
@@ -37844,6 +42164,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "手动"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "手動"
           }
         }
       }
@@ -37893,6 +42219,12 @@
             "state" : "translated",
             "value" : "标记为完成"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "標記為完成"
+          }
         }
       }
     },
@@ -37941,6 +42273,12 @@
             "state" : "translated",
             "value" : "标记为未完成"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "標記為未完成"
+          }
         }
       }
     },
@@ -37962,6 +42300,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "匹配专辑封面"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "匹配專輯封面"
           }
         }
       }
@@ -38075,6 +42419,12 @@
             "state" : "needs_review",
             "value" : "匹配菜单栏高度"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "匹配選單列高度"
+          }
         }
       }
     },
@@ -38187,6 +42537,12 @@
             "state" : "needs_review",
             "value" : "匹配Notch真实大小"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "匹配Notch真實大小"
+          }
         }
       }
     },
@@ -38222,6 +42578,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "材质"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "材質"
           }
         }
       },
@@ -38271,6 +42633,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "材质选项："
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "材質選項："
           }
         }
       }
@@ -38384,6 +42752,12 @@
             "state" : "needs_review",
             "value" : "最大容量：%lld%%"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "最大容量：%lld%%"
+          }
         }
       }
     },
@@ -38422,6 +42796,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "最大高度"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "最大高度"
@@ -38538,6 +42918,12 @@
             "state" : "needs_review",
             "value" : "媒体"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "媒體"
+          }
         }
       }
     },
@@ -38579,6 +42965,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "媒体与显示"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "媒體與顯示"
           }
         }
       }
@@ -38694,6 +43086,12 @@
             "state" : "needs_review",
             "value" : "横向手势改变媒体"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "橫向手勢改變媒體"
+          }
         }
       }
     },
@@ -38806,6 +43204,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "媒体控制"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "媒體控制"
           }
         }
       }
@@ -38920,6 +43324,12 @@
             "state" : "needs_review",
             "value" : "媒体非活动超时"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "媒體非活動超時"
+          }
         }
       }
     },
@@ -38967,6 +43377,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "媒体实时活动"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "媒體即時動態"
           }
         }
       }
@@ -39016,6 +43432,12 @@
             "state" : "translated",
             "value" : "媒体输出"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "媒體輸出"
+          }
         }
       }
     },
@@ -39064,6 +43486,12 @@
             "state" : "translated",
             "value" : "媒体面板"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "媒體面板"
+          }
         }
       }
     },
@@ -39103,6 +43531,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "媒体面板宽度"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "媒體面板寬度"
           }
         }
       }
@@ -39217,6 +43651,12 @@
             "state" : "translated",
             "value" : "媒体播放实时活动"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "媒體播放即時動態"
+          }
         }
       }
     },
@@ -39328,6 +43768,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "媒体来源"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "媒體來源"
           }
         }
       }
@@ -39442,6 +43888,12 @@
             "state" : "needs_review",
             "value" : "中"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "中"
+          }
         }
       }
     },
@@ -39488,6 +43940,12 @@
             "state" : "translated",
             "value" : "会议将在 %@ 开始"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "會議將在 %@ 開始"
+          }
         }
       }
     },
@@ -39530,6 +43988,12 @@
             "state" : "translated",
             "value" : "内存"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "記憶體"
+          }
         }
       }
     },
@@ -39569,6 +44033,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "内存时钟"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "記憶體時鐘"
           }
         }
       }
@@ -39610,6 +44080,12 @@
             "state" : "translated",
             "value" : "内存概览"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "記憶體概覽"
+          }
         }
       }
     },
@@ -39650,6 +44126,12 @@
             "state" : "translated",
             "value" : "内存压力严重；系统可能会激进地清理内存。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "記憶體壓力嚴重；系統可能會激進地清理記憶體。"
+          }
         }
       }
     },
@@ -39689,6 +44171,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "内存压力升高。关闭应用可能有助于缓解。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "記憶體壓力升高。關閉 App 可能有助於緩解。"
           }
         }
       }
@@ -39741,6 +44229,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "内存使用情况"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "記憶體使用情況"
           }
         }
       }
@@ -39854,6 +44348,12 @@
             "state" : "needs_review",
             "value" : "菜单栏图标"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "選單列圖示"
+          }
         }
       }
     },
@@ -39903,6 +44403,12 @@
             "state" : "translated",
             "value" : "消息"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "訊息"
+          }
         }
       }
     },
@@ -39932,6 +44438,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "方法来源"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "方法來源"
           }
         }
       }
@@ -39974,6 +44486,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "麦克风"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "麥克風"
           }
         }
       }
@@ -40088,6 +44606,12 @@
             "state" : "needs_review",
             "value" : "麦克风 %@"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "麥克風 %@"
+          }
         }
       }
     },
@@ -40136,6 +44660,12 @@
             "state" : "translated",
             "value" : "麦克风已静音"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "麥克風已靜音"
+          }
         }
       }
     },
@@ -40183,6 +44713,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "麦克风已取消静音"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "麥克風已取消靜音"
           }
         }
       }
@@ -40238,6 +44774,12 @@
             "state" : "translated",
             "value" : "麦克风"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "麥克風"
+          }
         }
       }
     },
@@ -40290,6 +44832,12 @@
             "state" : "translated",
             "value" : "麦克风已激活"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "麥克風已啟用"
+          }
         }
       }
     },
@@ -40324,6 +44872,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Yalnızca mikrofon"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "僅麥克風"
           }
         }
       }
@@ -40372,6 +44926,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "麦克风隐私指示器在应用访问音频时自动运行。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "麥克風隱私指示器在 App 存取音訊時自動執行。"
           }
         }
       }
@@ -40425,6 +44985,12 @@
             "state" : "translated",
             "value" : "麦克风状态"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "麥克風狀態"
+          }
         }
       }
     },
@@ -40471,6 +45037,12 @@
             "state" : "translated",
             "value" : "分钟"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "分鐘"
+          }
         }
       }
     },
@@ -40506,6 +45078,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "分钟"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "分鐘"
           }
         }
       }
@@ -40552,6 +45130,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "简约模式专注于媒体控制和系统 HUD，隐藏所有额外功能以提供简洁、专注的体验。自动启用更简单的动画。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "簡約模式專注於媒體控制和系統 HUD，隱藏所有額外功能以提供簡潔、專注的體驗。自動啟用更簡單的動畫。"
           }
         }
       }
@@ -40666,6 +45250,12 @@
             "state" : "needs_review",
             "value" : "悬停最短时长"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "懸停最短時長"
+          }
         }
       }
     },
@@ -40711,6 +45301,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "分钟"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "分鐘"
           }
         }
       }
@@ -40824,6 +45420,12 @@
             "state" : "translated",
             "value" : "镜像"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "鏡像"
+          }
         }
       }
     },
@@ -40857,6 +45459,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "镜像摄像头"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "鏡像攝像頭"
           }
         }
       }
@@ -40905,6 +45513,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "同步 macOS 时钟计时器"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "同步 macOS 時鐘計時器"
           }
         }
       }
@@ -41018,6 +45632,12 @@
             "state" : "translated",
             "value" : "镜像形状"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "鏡像形狀"
+          }
         }
       }
     },
@@ -41064,6 +45684,12 @@
             "state" : "translated",
             "value" : "镜像锁屏设置中的开关，以便计时器工作流可以无需切换标签页即可启用或禁用小组件。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "鏡像鎖定畫面設定中的開關，以便計時器工作流可以無需切換分頁即可啟用或停用小工具。"
+          }
         }
       }
     },
@@ -41101,6 +45727,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "分"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "分"
@@ -41151,6 +45783,12 @@
             "state" : "translated",
             "value" : "监控剪贴板变化并保留最近复制的历史记录。使用 Cmd+Shift+V 快速访问剪贴板历史。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "監控剪貼簿變化並保留最近複製的歷史記錄。使用 Cmd+Shift+V 快速存取剪貼簿歷史。"
+          }
         }
       }
     },
@@ -41199,6 +45837,12 @@
             "state" : "translated",
             "value" : "监控下载文件夹中 Chromium 风格的下载（.crdownload 文件），并在下载进行时在灵动岛中显示实时活动。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "監控下載資料夾中 Chromium 風格的下載（.crdownload 檔案），並在下載進行時在動態島中顯示即時動態。"
+          }
         }
       }
     },
@@ -41244,6 +45888,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "监控行为"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "監控行為"
           }
         }
       }
@@ -41297,6 +45947,12 @@
             "state" : "translated",
             "value" : "监控状态"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "監控狀態"
+          }
         }
       }
     },
@@ -41343,6 +45999,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "监控已停止"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "監控已停止"
           }
         }
       }
@@ -41456,6 +46118,12 @@
             "state" : "needs_review",
             "value" : "更多"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "更多"
+          }
         }
       }
     },
@@ -41500,6 +46168,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "下移"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "下移"
@@ -41552,6 +46226,12 @@
             "state" : "translated",
             "value" : "上移"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "上移"
+          }
         }
       }
     },
@@ -41591,6 +46271,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "音乐"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "音樂"
           }
         }
       }
@@ -41637,6 +46323,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "音乐面板变体"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "音樂面板變體"
           }
         }
       }
@@ -41750,6 +46442,12 @@
             "state" : "translated",
             "value" : "音乐来源"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "音樂來源"
+          }
         }
       }
     },
@@ -41789,6 +46487,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "音乐可视化"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "音樂視覺化"
           }
         }
       }
@@ -41902,6 +46606,12 @@
             "state" : "needs_review",
             "value" : "已静音"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "已靜音"
+          }
         }
       }
     },
@@ -41955,6 +46665,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "我的动画"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "我的動畫"
           }
         }
       }
@@ -42068,6 +46784,12 @@
             "state" : "needs_review",
             "value" : "名称"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "名稱"
+          }
         }
       }
     },
@@ -42119,6 +46841,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "导航"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "導航"
           }
         }
       }
@@ -42232,6 +46960,12 @@
             "state" : "needs_review",
             "value" : "需要重启"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "需要重啟"
+          }
         }
       }
     },
@@ -42274,6 +47008,12 @@
             "state" : "translated",
             "value" : "网络"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "網路"
+          }
         }
       }
     },
@@ -42313,6 +47053,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "网络活动"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "網路活動"
           }
         }
       }
@@ -42366,6 +47112,12 @@
             "state" : "translated",
             "value" : "网络下载"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "網路下載"
+          }
         }
       }
     },
@@ -42405,6 +47157,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "网络概览"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "網路概覽"
           }
         }
       }
@@ -42457,6 +47215,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "网络上传"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "網路上傳"
           }
         }
       }
@@ -42570,6 +47334,12 @@
             "state" : "needs_review",
             "value" : "永不隐藏"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "永不隱藏"
+          }
         }
       }
     },
@@ -42606,6 +47376,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "下一首"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "下一首"
@@ -42664,6 +47440,12 @@
             "state" : "translated",
             "value" : "尚未检测到活跃网络接口。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "尚未偵測到活躍網路介面。"
+          }
         }
       }
     },
@@ -42706,6 +47488,12 @@
             "state" : "translated",
             "value" : "未找到隔空播放设备"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未找到 AirPlay 裝置"
+          }
         }
       }
     },
@@ -42747,6 +47535,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "无可用隔空播放输出"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無可用 AirPlay 輸出"
           }
         }
       }
@@ -42795,6 +47589,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "无可用音频输出"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無可用音訊輸出"
           }
         }
       }
@@ -42848,6 +47648,12 @@
             "state" : "translated",
             "value" : "无剪贴板历史"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無剪貼簿歷史"
+          }
         }
       }
     },
@@ -42899,6 +47705,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "未找到颜色"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未找到顏色"
           }
         }
       }
@@ -42952,6 +47764,12 @@
             "state" : "translated",
             "value" : "没有颜色匹配 '%@'"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "沒有顏色匹配 '%@'"
+          }
         }
       }
     },
@@ -42997,6 +47815,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "暂无颜色"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "暫無顏色"
           }
         }
       }
@@ -43045,6 +47869,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "暂无复制记录"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "暫無複製記錄"
           }
         }
       }
@@ -43157,6 +47987,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "没有可用的自定义动画"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "沒有可用的自訂動畫"
           }
         }
       }
@@ -43271,6 +48107,12 @@
             "state" : "needs_review",
             "value" : "没有自定义可视化器"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "沒有自訂視覺化器"
+          }
         }
       }
     },
@@ -43312,6 +48154,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "未找到设备"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未找到裝置"
           }
         }
       }
@@ -43360,6 +48208,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "无事件"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無事件"
           }
         }
       }
@@ -43473,6 +48327,12 @@
             "state" : "needs_review",
             "value" : "今天无日程"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "今天無日程"
+          }
         }
       }
     },
@@ -43519,6 +48379,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "无排除项"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無排除項"
           }
         }
       }
@@ -43634,6 +48500,12 @@
             "state" : "needs_review",
             "value" : "未安装扩展"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "未安裝延伸功能"
+          }
         }
       }
     },
@@ -43681,6 +48553,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "暂无扩展"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "暫無延伸功能"
           }
         }
       }
@@ -43734,6 +48612,12 @@
             "state" : "translated",
             "value" : "无收藏"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無收藏"
+          }
         }
       }
     },
@@ -43782,6 +48666,12 @@
             "state" : "translated",
             "value" : "未启用图表"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未啟用圖表"
+          }
         }
       }
     },
@@ -43827,6 +48717,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "暂无笔记"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "暫無筆記"
           }
         }
       }
@@ -43876,6 +48772,12 @@
             "state" : "translated",
             "value" : "未配置预设。添加预设使其出现在计时器弹出窗口中。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未配置預設組合。新增預設組合使其出現在計時器彈出式視窗中。"
+          }
         }
       }
     },
@@ -43923,6 +48825,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "尚无进程数据。请保持统计打开片刻。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "尚無程序資料。請保持統計開啟片刻。"
           }
         }
       }
@@ -43976,6 +48884,12 @@
             "state" : "translated",
             "value" : "无结果"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無結果"
+          }
         }
       }
     },
@@ -44028,6 +48942,12 @@
             "state" : "translated",
             "value" : "未找到结果"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未找到結果"
+          }
         }
       }
     },
@@ -44075,6 +48995,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "尚未检测到存储设备。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "尚未偵測到儲存裝置。"
           }
         }
       }
@@ -44188,6 +49114,12 @@
             "state" : "needs_review",
             "value" : "非Notch显示高度"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "非Notch顯示高度"
+          }
         }
       }
     },
@@ -44224,6 +49156,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正常"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "正常"
@@ -44282,6 +49220,12 @@
             "state" : "translated",
             "value" : "不活跃"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "不活躍"
+          }
         }
       }
     },
@@ -44324,6 +49268,12 @@
             "state" : "translated",
             "value" : "未充电"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未充電"
+          }
         }
       }
     },
@@ -44363,6 +49313,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "未确定"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未確定"
           }
         }
       }
@@ -44476,6 +49432,12 @@
             "state" : "translated",
             "value" : "暂不"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "暫不"
+          }
         }
       }
     },
@@ -44510,6 +49472,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Kayıt yok"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未錄製"
           }
         }
       }
@@ -44556,6 +49524,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "未设置"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未設定"
           }
         }
       }
@@ -44669,6 +49643,12 @@
             "state" : "needs_review",
             "value" : "Notch行为"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Notch行為"
+          }
         }
       }
     },
@@ -44781,6 +49761,12 @@
             "state" : "needs_review",
             "value" : "Notch显示高度"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Notch顯示高度"
+          }
         }
       }
     },
@@ -44816,6 +49802,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "刘海体验"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "瀏海體驗"
           }
         }
       },
@@ -44930,6 +49922,12 @@
             "state" : "needs_review",
             "value" : "Notch高度"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Notch高度"
+          }
         }
       }
     },
@@ -44977,6 +49975,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "刘海宽度"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "瀏海寬度"
           }
         }
       }
@@ -45026,6 +50030,12 @@
             "state" : "translated",
             "value" : "笔记"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "筆記"
+          }
         }
       }
     },
@@ -45050,6 +50060,12 @@
             "state" : "translated",
             "value" : "“备忘录”返回了空响应。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "「備忘錄」返回了空響應。"
+          }
         }
       }
     },
@@ -45073,6 +50089,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "“备忘录”脚本未返回结果。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "「備忘錄」指令碼未返回結果。"
           }
         }
       }
@@ -45115,6 +50137,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "暂无内容播放"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "暫無內容播放"
           }
         }
       }
@@ -45164,6 +50192,12 @@
             "state" : "translated",
             "value" : "提前通知"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "提前通知"
+          }
         }
       }
     },
@@ -45193,6 +50227,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "现在"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "現在"
           }
         }
       }
@@ -45237,6 +50277,12 @@
             "state" : "translated",
             "value" : "正在播放"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在播放"
+          }
         }
       }
     },
@@ -45277,6 +50323,12 @@
             "state" : "translated",
             "value" : "回滚缓冲区保留的行数。较高的值会占用更多内存。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "回滾緩衝區保留的行數。較高的值會佔用更多記憶體。"
+          }
         }
       }
     },
@@ -45288,6 +50340,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "van %@"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "共 %@"
           }
         }
       }
@@ -45330,6 +50388,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "关"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "關"
           }
         }
       }
@@ -45443,6 +50507,12 @@
             "state" : "needs_review",
             "value" : "好的"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "好的"
+          }
         }
       },
       "shouldTranslate" : false
@@ -45486,6 +50556,12 @@
             "state" : "translated",
             "value" : "开"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "開"
+          }
         }
       }
     },
@@ -45514,6 +50590,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "暂停中"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "暫停中"
           }
         }
       }
@@ -45627,6 +50709,12 @@
             "state" : "needs_review",
             "value" : "一个或多个文件加载失败"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "一個或多個檔案載入失敗"
+          }
         }
       }
     },
@@ -45667,6 +50755,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Yalnızca uygulama simgesi"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "僅 App 圖示"
           }
         }
       }
@@ -45716,6 +50810,12 @@
             "state" : "translated",
             "value" : "仅在材质设置为磨砂玻璃时适用。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "僅在材質設定為磨砂玻璃時適用。"
+          }
         }
       }
     },
@@ -45764,6 +50864,12 @@
             "state" : "translated",
             "value" : "仅在材质设置为磨砂玻璃时可用。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "僅在材質設定為磨砂玻璃時可用。"
+          }
         }
       }
     },
@@ -45804,6 +50910,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Yalnızca indir simgesi"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "僅下載圖示"
           }
         }
       }
@@ -45851,6 +50963,12 @@
             "state" : "translated",
             "value" : "打开 Google AI Studio"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "開啟 Google AI Studio"
+          }
         }
       }
     },
@@ -45880,6 +50998,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "在浏览器中打开"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在瀏覽器中開啟"
           }
         }
       }
@@ -45929,6 +51053,12 @@
             "state" : "translated",
             "value" : "在日历中打开"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在行事曆中開啟"
+          }
         }
       }
     },
@@ -45975,6 +51105,12 @@
             "state" : "translated",
             "value" : "打开模型设置"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "開啟模型設定"
+          }
         }
       }
     },
@@ -46014,6 +51150,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "悬停时展开刘海"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "懸停時展開瀏海"
           }
         }
       }
@@ -46055,6 +51197,12 @@
             "state" : "translated",
             "value" : "打开隐私与安全性"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "開啟隱私與安全性"
+          }
         }
       }
     },
@@ -46077,6 +51225,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Открыть настройки"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "開啟設定"
           }
         }
       }
@@ -46118,6 +51272,12 @@
             "state" : "translated",
             "value" : "添加项目时默认打开搁板标签"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "新增項目時預設開啟擱板標籤"
+          }
         }
       }
     },
@@ -46147,6 +51307,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "打开 Spotify Web 播放器"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "開啟 Spotify Web 播放器"
           }
         }
       }
@@ -46194,6 +51360,12 @@
             "state" : "translated",
             "value" : "打开系统设置"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "開啟系統設定"
+          }
         }
       }
     },
@@ -46233,6 +51405,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "打开一个透明的预览窗口，其中包含反映当前锁屏小组件配置的模拟数据。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "開啟一個透明的預覽視窗，其中包含反映目前鎖定畫面小工具配置的模擬資料。"
           }
         }
       }
@@ -46280,6 +51458,12 @@
             "state" : "translated",
             "value" : "打开 AI 助手面板，进行文件分析与对话。默认为 Cmd+Shift+A。仅在启用屏幕助手功能时有效。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "開啟 AI 助理面板，進行檔案分析與對話。預設為 Cmd+Shift+A。僅在啟用螢幕助理功能時有效。"
+          }
         }
       }
     },
@@ -46325,6 +51509,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "打开剪贴板历史记录面板。默认为 Cmd+Shift+V（类似于 PC 上的 Windows+V）。仅在启用剪贴板功能时有效。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "開啟剪貼簿歷史記錄面板。預設為 Cmd+Shift+V（類似於 PC 上的 Windows+V）。僅在啟用剪貼簿功能時有效。"
           }
         }
       }
@@ -46372,6 +51562,12 @@
             "state" : "translated",
             "value" : "打开取色器面板进行屏幕颜色捕获。默认为 Cmd+Shift+P。仅在启用取色器功能时有效。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "開啟取色器面板進行螢幕顏色捕獲。預設為 Cmd+Shift+P。僅在啟用取色器功能時有效。"
+          }
         }
       }
     },
@@ -46411,6 +51607,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "在刘海中打开终端标签。默认为 Ctrl+`。仅在启用终端功能时有效。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在瀏海中開啟終端機標籤。預設為 Ctrl+`。僅在啟用終端機功能時有效。"
           }
         }
       }
@@ -46452,6 +51654,12 @@
             "state" : "translated",
             "value" : "Option 作为 Meta 键"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Option 作為 Meta 鍵"
+          }
         }
       }
     },
@@ -46492,6 +51700,12 @@
             "state" : "translated",
             "value" : "Option 作为 Meta 将发送 Esc+按键 而非 macOS 特殊字符。鼠标报告会将鼠标事件转发到如 vim 或 tmux 的终端应用程序。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Option 作為 Meta 將傳送 Esc+按鍵 而非 macOS 特殊字元。滑鼠報告會將滑鼠事件轉發到如 vim 或 tmux 的終端機 App。"
+          }
         }
       }
     },
@@ -46528,6 +51742,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "其他"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "其他"
@@ -46580,6 +51800,12 @@
             "state" : "translated",
             "value" : "输出设备"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "輸出裝置"
+          }
         }
       }
     },
@@ -46627,6 +51853,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "输出音量"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "輸出音量"
           }
         }
       }
@@ -46676,6 +51908,12 @@
             "state" : "translated",
             "value" : "超时"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "超時"
+          }
         }
       }
     },
@@ -46715,6 +51953,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "面板"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "面板"
@@ -46767,6 +52011,12 @@
             "state" : "translated",
             "value" : "面板模式会在刘海附近的浮动窗口中显示剪贴板。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "面板模式會在瀏海附近的浮動視窗中顯示剪貼簿。"
+          }
         }
       }
     },
@@ -46812,6 +52062,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "面板模式会在浮动窗口中显示取色器。弹出模式会将取色器显示为附加在取色器按钮上的下拉菜单。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "面板模式會在浮動視窗中顯示取色器。彈出模式會將取色器顯示為附加在取色器按鈕上的下拉選單。"
           }
         }
       }
@@ -46859,6 +52115,12 @@
             "state" : "translated",
             "value" : "面板模式会在刘海附近的浮动窗口中显示助手。弹出模式会将助手显示为附加在 AI 按钮上的下拉菜单。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "面板模式會在瀏海附近的浮動視窗中顯示助理。彈出模式會將助理顯示為附加在 AI 按鈕上的下拉選單。"
+          }
         }
       }
     },
@@ -46899,6 +52161,12 @@
             "state" : "translated",
             "value" : "视差效果强度"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "視差效果強度"
+          }
         }
       }
     },
@@ -46928,6 +52196,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "从剪贴板粘贴"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "從剪貼簿貼上"
           }
         }
       }
@@ -46963,6 +52237,12 @@
             "state" : "translated",
             "value" : "暂停"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "暫停"
+          }
         }
       },
       "shouldTranslate" : false
@@ -46993,6 +52273,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "已暂停"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已暫停"
           }
         }
       }
@@ -47030,6 +52316,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "峰值"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "峰值"
@@ -47082,6 +52374,12 @@
             "state" : "translated",
             "value" : "待处理"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "待處理"
+          }
         }
       }
     },
@@ -47122,6 +52420,12 @@
             "state" : "translated",
             "value" : "单核使用率"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "單核使用率"
+          }
         }
       }
     },
@@ -47149,6 +52453,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "每次按键调整的百分比。按住 Shift+Option 时使用微调步长。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "每次按鍵調整的百分比。按住 Shift+Option 時使用微調步長。"
           }
         }
       }
@@ -47192,6 +52502,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "百分比"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "百分比"
@@ -47244,6 +52560,12 @@
             "state" : "translated",
             "value" : "权限状态："
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "權限狀態："
+          }
         }
       }
     },
@@ -47290,6 +52612,12 @@
             "state" : "translated",
             "value" : "权限"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "權限"
+          }
         }
       }
     },
@@ -47332,6 +52660,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "取色"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "取色"
@@ -47383,6 +52717,12 @@
             "state" : "translated",
             "value" : "在下方为各小组件选择液态玻璃变体。更改会同步到“锁屏”标签页。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在下方為各小工具選擇液態玻璃變體。更改會同步到「鎖定畫面」分頁。"
+          }
         }
       }
     },
@@ -47428,6 +52768,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "已选取 %@"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已選取 %@"
           }
         }
       }
@@ -47475,6 +52821,12 @@
             "state" : "translated",
             "value" : "拾取的颜色"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "拾取的顏色"
+          }
         }
       }
     },
@@ -47521,6 +52873,12 @@
             "state" : "translated",
             "value" : "拾取状态"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "拾取狀態"
+          }
         }
       }
     },
@@ -47562,6 +52920,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "带有圆角的药丸状岛屿，类似于 iPhone 的灵动岛"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "帶有圓角的藥丸狀島嶼，類似於 iPhone 的動態島"
           }
         }
       }
@@ -47609,6 +52973,12 @@
             "state" : "translated",
             "value" : "从历史记录中固定项目以保存在此处"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "從歷史記錄中固定項目以儲存在此處"
+          }
         }
       }
     },
@@ -47654,6 +53024,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "固定项目以添加收藏"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "固定項目以新增收藏"
           }
         }
       }
@@ -47701,6 +53077,12 @@
             "state" : "translated",
             "value" : "固定项目以将它们添加到收藏夹"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "固定項目以將它們新增到收藏夾"
+          }
         }
       }
     },
@@ -47747,6 +53129,12 @@
             "state" : "translated",
             "value" : "已固定项目"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已固定項目"
+          }
         }
       }
     },
@@ -47786,6 +53174,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "播放 / 暂停"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "播放 / 暫停"
           }
         }
       }
@@ -47827,6 +53221,12 @@
             "state" : "translated",
             "value" : "调整音量时播放反馈音"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "調整音量時播放回饋音"
+          }
         }
       }
     },
@@ -47867,6 +53267,12 @@
             "state" : "translated",
             "value" : "播放锁屏/解锁提示音"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "播放鎖定畫面/解鎖提示音"
+          }
         }
       }
     },
@@ -47906,6 +53312,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "播放低电量提示音"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "播放低電量提示音"
           }
         }
       }
@@ -47955,6 +53367,12 @@
             "state" : "translated",
             "value" : "每次按下硬件音量键时播放随附的反馈声音剪辑。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "每次按下硬體音量鍵時播放隨附的回饋聲音剪輯。"
+          }
         }
       }
     },
@@ -48000,6 +53418,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "请在模型设置中为所选的 AI 提供商配置您的 API 密钥。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "請在模型設定中為所選的 AI 提供商配置你的 API 金鑰。"
           }
         }
       }
@@ -48113,6 +53537,12 @@
             "state" : "translated",
             "value" : "已连接电源"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已連線電源"
+          }
         }
       }
     },
@@ -48154,6 +53584,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "弹出窗口"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "彈出式視窗"
           }
         }
       }
@@ -48203,6 +53639,12 @@
             "state" : "translated",
             "value" : "弹出模式会将剪贴板显示为附加在剪贴板按钮上的下拉菜单。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "彈出模式會將剪貼簿顯示為附加在剪貼簿按鈕上的下拉選單。"
+          }
         }
       }
     },
@@ -48249,6 +53691,12 @@
             "state" : "translated",
             "value" : "弹出模式会将取色器显示为附加在取色器按钮上的下拉菜单。面板模式会在浮动窗口中显示取色器。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "彈出模式會將取色器顯示為附加在取色器按鈕上的下拉選單。面板模式會在浮動視窗中顯示取色器。"
+          }
         }
       }
     },
@@ -48294,6 +53742,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "弹出模式会将助手显示为附加在 AI 按钮上的下拉菜单。面板模式会在刘海附近的浮动窗口中显示助手。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "彈出模式會將助理顯示為附加在 AI 按鈕上的下拉選單。面板模式會在瀏海附近的浮動視窗中顯示助理。"
           }
         }
       }
@@ -48347,6 +53801,12 @@
             "state" : "translated",
             "value" : "位置"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "位置"
+          }
         }
       }
     },
@@ -48394,6 +53854,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "预设名称"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "預設組合名稱"
           }
         }
       }
@@ -48443,6 +53909,12 @@
             "state" : "translated",
             "value" : "预设"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "預設組合"
+          }
         }
       }
     },
@@ -48490,6 +53962,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "预设会以设定的名称、时长和强调色显示在计时器弹出窗口中。拖动预设可调整显示顺序。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "預設組合會以設定的名稱、時長和強調色顯示在計時器彈出式視窗中。拖移預設組合可調整顯示順序。"
           }
         }
       }
@@ -48545,6 +54023,12 @@
             "state" : "translated",
             "value" : "内存压力"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "記憶體壓力"
+          }
         }
       }
     },
@@ -48585,6 +54069,12 @@
             "state" : "translated",
             "value" : "内存压力与交换"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "記憶體壓力與交換"
+          }
         }
       }
     },
@@ -48624,6 +54114,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "防止当光标意外离开刘海区域时终端自动关闭。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "防止當游標意外離開瀏海區域時終端機自動關閉。"
           }
         }
       }
@@ -48677,6 +54173,12 @@
             "state" : "translated",
             "value" : "预览"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "預覽"
+          }
         }
       }
     },
@@ -48716,6 +54218,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "预览锁屏小组件"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "預覽鎖定畫面小工具"
           }
         }
       }
@@ -48765,6 +54273,12 @@
             "state" : "translated",
             "value" : "预览缩放"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "預覽縮放"
+          }
         }
       }
     },
@@ -48801,6 +54315,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "上一首"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "上一首"
@@ -48853,6 +54373,12 @@
             "state" : "translated",
             "value" : "隐私指示器"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "隱私指示器"
+          }
         }
       }
     },
@@ -48900,6 +54426,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "隐私政策"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "隱私政策"
           }
         }
       }
@@ -48978,6 +54510,12 @@
             "state" : "translated",
             "value" : "效率"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "效率"
+          }
         }
       }
     },
@@ -48989,6 +54527,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Voortgang"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "進度"
           }
         }
       }
@@ -49037,6 +54581,12 @@
             "state" : "translated",
             "value" : "进度条"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "進度條"
+          }
         }
       }
     },
@@ -49082,6 +54632,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "进度样式"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "進度樣式"
           }
         }
       }
@@ -49195,6 +54751,12 @@
             "state" : "needs_review",
             "value" : "进度条样式"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "進度條樣式"
+          }
         }
       }
     },
@@ -49233,6 +54795,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "提供商"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "提供商"
@@ -49289,6 +54857,12 @@
             "state" : "translated",
             "value" : "快捷操作"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "快捷操作"
+          }
         }
       }
     },
@@ -49321,6 +54895,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "快速共享"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "快速共享"
@@ -49374,6 +54954,12 @@
             "state" : "translated",
             "value" : "快速共享服务"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "快速共享服務"
+          }
         }
       }
     },
@@ -49415,6 +55001,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "快速共享设置"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "快速共享設定"
           }
         }
       }
@@ -49524,6 +55116,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "退出"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "退出"
@@ -49640,6 +55238,12 @@
             "state" : "needs_review",
             "value" : "退出应用"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "退出 App"
+          }
         }
       }
     },
@@ -49693,6 +55297,12 @@
             "state" : "translated",
             "value" : "退出 boring.notch"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "退出 boring.notch"
+          }
         }
       }
     },
@@ -49704,6 +55314,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "quotum niet beschikbaar"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無法取得配額"
           }
         }
       }
@@ -49743,6 +55359,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "R "
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "R "
@@ -49794,6 +55416,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "重新授权"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重新授權"
           }
         }
       }
@@ -49849,6 +55477,12 @@
             "state" : "translated",
             "value" : "读取"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "讀取"
+          }
         }
       }
     },
@@ -49900,6 +55534,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "就绪"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "就緒"
           }
         }
       }
@@ -49953,6 +55593,12 @@
             "state" : "translated",
             "value" : "推理模式"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "推理模式"
+          }
         }
       }
     },
@@ -50000,6 +55646,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "最近活动（最近 5 分钟）"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "最近活動（最近 5 分鐘）"
           }
         }
       }
@@ -50053,6 +55705,12 @@
             "state" : "translated",
             "value" : "最近颜色"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "最近顏色"
+          }
         }
       }
     },
@@ -50092,6 +55750,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "推荐最小宽度根据启用的标签页数量自动调整。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "推薦最小寬度根據啟用的分頁數量自動調整。"
           }
         }
       }
@@ -50145,6 +55809,12 @@
             "state" : "translated",
             "value" : "录制中"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "錄製中"
+          }
         }
       }
     },
@@ -50179,6 +55849,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Kayıt etkin"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "錄製中"
           }
         }
       }
@@ -50234,6 +55910,12 @@
             "state" : "translated",
             "value" : "检测到录制"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "偵測到錄製"
+          }
         }
       }
     },
@@ -50286,6 +55968,12 @@
             "state" : "translated",
             "value" : "录制状态"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "錄製狀態"
+          }
         }
       }
     },
@@ -50328,6 +56016,12 @@
             "state" : "translated",
             "value" : "刷新检测"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重新整理偵測"
+          }
         }
       }
     },
@@ -50367,6 +56061,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "刷新设备"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重新整理裝置"
           }
         }
       }
@@ -50409,6 +56109,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "已拒绝"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已拒絕"
           }
         }
       }
@@ -50522,6 +56228,12 @@
             "state" : "needs_review",
             "value" : "版本名称"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "版本名稱"
+          }
         }
       }
     },
@@ -50634,6 +56346,12 @@
             "state" : "needs_review",
             "value" : "记住上一个标签页"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "記住上一個分頁"
+          }
         }
       }
     },
@@ -50645,6 +56363,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Herinner me later"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "稍後提醒我"
           }
         }
       }
@@ -50694,6 +56418,12 @@
             "state" : "translated",
             "value" : "提醒实时活动"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "提醒即時動態"
+          }
         }
       }
     },
@@ -50733,6 +56463,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "提醒小组件"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "提醒小工具"
           }
         }
       }
@@ -50786,6 +56522,12 @@
             "state" : "translated",
             "value" : "提醒事项"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "提醒事項"
+          }
         }
       }
     },
@@ -50830,6 +56572,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "移除"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "移除"
@@ -50882,6 +56630,12 @@
             "state" : "translated",
             "value" : "从授权扩展列表中移除 %@？这将关闭此应用的所有活跃实时活动、锁屏小组件和刘海体验。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "從授權延伸功能列表中移除 %@？這將關閉此 App 的所有活躍即時動態、鎖定畫面小工具和瀏海體驗。"
+          }
         }
       }
     },
@@ -50927,6 +56681,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "移除扩展"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "移除延伸功能"
           }
         }
       }
@@ -50974,6 +56734,12 @@
             "state" : "translated",
             "value" : "拖拽后从架子上移除"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "拖移後從架子上移除"
+          }
         }
       }
     },
@@ -51014,6 +56780,12 @@
             "state" : "translated",
             "value" : "移除所选"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "移除所選"
+          }
         }
       }
     },
@@ -51050,6 +56822,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "渲染"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "渲染"
@@ -51094,6 +56872,12 @@
             "state" : "translated",
             "value" : "渲染器"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "渲染器"
+          }
         }
       }
     },
@@ -51134,6 +56918,12 @@
             "state" : "translated",
             "value" : "重复播放"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重複播放"
+          }
         }
       }
     },
@@ -51161,6 +56951,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "当当前应用提供动态 Canvas 时，用它替换封面磁贴，并重复利用该动态 Canvas 生成周围的灯光效果。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "當目前 App 提供動態 Canvas 時，用它替換封面拼貼，並重複利用該動態 Canvas 產生周圍的燈光效果。"
           }
         }
       }
@@ -51214,6 +57010,12 @@
             "state" : "translated",
             "value" : "请求访问"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "請求存取"
+          }
         }
       }
     },
@@ -51253,6 +57055,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "请求完全磁盘访问"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "請求完整磁碟取用權"
           }
         }
       }
@@ -51295,6 +57103,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "需要启用 API 插件的第三方客户端。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "需要啟用 API 外掛的第三方用戶端。"
           }
         }
       }
@@ -51341,6 +57155,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "需要辅助功能权限以便灵动岛拦截硬件音量键。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "需要輔助使用權限以便動態島攔截硬體音量鍵。"
           }
         }
       }
@@ -51390,6 +57210,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重置"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "重置"
@@ -51446,6 +57272,12 @@
             "state" : "translated",
             "value" : "全部重置"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "全部重置"
+          }
         }
       }
     },
@@ -51484,6 +57316,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重置上下文"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "重置上下文"
@@ -51536,6 +57374,12 @@
             "state" : "translated",
             "value" : "重置实时活动"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重置即時動態"
+          }
         }
       }
     },
@@ -51584,6 +57428,12 @@
             "state" : "translated",
             "value" : "重置锁屏小组件"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重置鎖定畫面小工具"
+          }
         }
       }
     },
@@ -51624,6 +57474,12 @@
             "state" : "translated",
             "value" : "重置媒体宽度"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重置媒體寬度"
+          }
         }
       }
     },
@@ -51663,6 +57519,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "重置音乐"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重置音樂"
           }
         }
       }
@@ -51712,6 +57574,12 @@
             "state" : "translated",
             "value" : "重置刘海体验"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重置瀏海體驗"
+          }
         }
       }
     },
@@ -51760,6 +57628,12 @@
             "state" : "translated",
             "value" : "重置速率限制"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重置速率限制"
+          }
         }
       }
     },
@@ -51789,6 +57663,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "重置会话"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重置工作階段"
           }
         }
       }
@@ -51830,6 +57710,12 @@
             "state" : "translated",
             "value" : "重置计时器"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重置計時器"
+          }
         }
       }
     },
@@ -51869,6 +57755,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "重置计时器宽度"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重置計時器寬度"
           }
         }
       }
@@ -51922,6 +57814,12 @@
             "state" : "translated",
             "value" : "恢复默认"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "恢復預設"
+          }
         }
       }
     },
@@ -51970,6 +57868,12 @@
             "state" : "translated",
             "value" : "恢复默认"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "恢復預設"
+          }
         }
       }
     },
@@ -52009,6 +57913,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "重置天气"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重置天氣"
           }
         }
       }
@@ -52057,6 +57967,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "重置宽度"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重置寬度"
           }
         }
       }
@@ -52171,6 +58087,12 @@
             "state" : "needs_review",
             "value" : "重启"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "重啟"
+          }
         }
       }
     },
@@ -52223,6 +58145,12 @@
             "state" : "translated",
             "value" : "重启 Atoll"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重啟 Atoll"
+          }
         }
       }
     },
@@ -52264,6 +58192,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "重启 Shell"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重啟 Shell"
           }
         }
       }
@@ -52307,6 +58241,12 @@
             "state" : "translated",
             "value" : "重启 Shell"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重啟 Shell"
+          }
         }
       }
     },
@@ -52348,6 +58288,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "重启 Shell 进程。终端中未保存的工作将丢失。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重啟 Shell 程序。終端機中未儲存的工作將丟失。"
           }
         }
       }
@@ -52397,6 +58343,12 @@
             "state" : "translated",
             "value" : "恢复"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "恢復"
+          }
         }
       }
     },
@@ -52444,6 +58396,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "恢复默认计时器预设？"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "恢復預設計時器預設組合？"
           }
         }
       }
@@ -52493,6 +58451,12 @@
             "state" : "translated",
             "value" : "恢复默认"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "恢復預設"
+          }
         }
       }
     },
@@ -52529,6 +58493,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "受限"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "受限"
@@ -52585,6 +58555,12 @@
             "state" : "translated",
             "value" : "继续"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "繼續"
+          }
         }
       }
     },
@@ -52625,6 +58601,12 @@
             "state" : "translated",
             "value" : "反转打开/关闭滚动手势"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "反轉開啟/關閉滾動手勢"
+          }
         }
       }
     },
@@ -52664,6 +58646,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "反转滑动手势"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "反轉滑動手勢"
           }
         }
       }
@@ -52713,6 +58701,12 @@
             "state" : "translated",
             "value" : "撤销访问"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "撤銷存取"
+          }
         }
       }
     },
@@ -52752,6 +58746,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "后退 10 秒"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "後退 10 秒"
           }
         }
       }
@@ -52794,6 +58794,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "富文本"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "富文字"
           }
         }
       }
@@ -52841,6 +58847,12 @@
             "state" : "translated",
             "value" : "右"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "右"
+          }
         }
       }
     },
@@ -52868,6 +58880,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "在锁屏上右键点击专辑封面将其设置为壁纸。再次右键点击或点击背景恢复原始壁纸。如果有 Canvas 可用，Atoll 还可以在动态 Canvas 上方保留相同的专辑封面和播放器布局。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在鎖定畫面上右鍵點按專輯封面將其設定為桌面背景。再次右鍵點按或點按背景恢復原始桌面背景。如果有 Canvas 可用，Atoll 還可以在動態 Canvas 上方保留相同的專輯封面和播放器版面配置。"
           }
         }
       }
@@ -52911,6 +58929,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "圆环"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "圓環"
           }
         }
       }
@@ -52959,6 +58983,12 @@
             "state" : "translated",
             "value" : "旋转："
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "旋轉："
+          }
         }
       }
     },
@@ -52982,6 +59012,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "标尺式"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "標尺式"
           }
         }
       }
@@ -53089,6 +59125,12 @@
             "state" : "needs_review",
             "value" : "运行中"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "執行中"
+          }
         }
       }
     },
@@ -53116,6 +59158,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "在当前目标显示器上运行真实的刘海动画。如果外部屏幕正在使用灵动岛模式，电池提示框将首先发送到那里。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在目前目標顯示器上執行真實的瀏海動畫。如果外部螢幕正在使用動態島模式，電池提示框將首先傳送到那裡。"
           }
         }
       }
@@ -53162,6 +59210,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "禁用超时后，采样可以在刘海关闭时继续。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "停用超時後，取樣可以在瀏海關閉時繼續。"
           }
         }
       }
@@ -53215,6 +59269,12 @@
             "state" : "translated",
             "value" : "保存"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "儲存"
+          }
         }
       }
     },
@@ -53266,6 +59326,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "保存更改"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "儲存更改"
           }
         }
       }
@@ -53319,6 +59385,12 @@
             "state" : "translated",
             "value" : "保存配置"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "儲存配置"
+          }
         }
       }
     },
@@ -53370,6 +59442,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "缩小"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "縮小"
           }
         }
       }
@@ -53423,6 +59501,12 @@
             "state" : "translated",
             "value" : "放大 2x"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "放大 2x"
+          }
         }
       }
     },
@@ -53470,6 +59554,12 @@
             "state" : "translated",
             "value" : "缩放："
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "縮放："
+          }
         }
       }
     },
@@ -53512,6 +59602,12 @@
             "state" : "translated",
             "value" : "重新扫描"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重新掃描"
+          }
         }
       }
     },
@@ -53553,6 +59649,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "正在扫描设备..."
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在掃描裝置..."
           }
         }
       }
@@ -53600,6 +59702,12 @@
             "state" : "translated",
             "value" : "屏幕助手"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "螢幕助理"
+          }
         }
       }
     },
@@ -53645,6 +59753,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "屏幕助手功能已禁用"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "螢幕助理功能已停用"
           }
         }
       }
@@ -53698,6 +59812,12 @@
             "state" : "translated",
             "value" : "屏幕助手："
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "螢幕助理："
+          }
         }
       }
     },
@@ -53744,6 +59864,12 @@
             "state" : "translated",
             "value" : "屏幕边距：%lld像素"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "螢幕邊距：%lld畫素"
+          }
         }
       }
     },
@@ -53789,6 +59915,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "屏幕录制"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "螢幕錄製"
           }
         }
       }
@@ -53842,6 +59974,12 @@
             "state" : "translated",
             "value" : "截图选项"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "截圖選項"
+          }
         }
       }
     },
@@ -53894,6 +60032,12 @@
             "state" : "translated",
             "value" : "截图类型"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "截圖型別"
+          }
         }
       }
     },
@@ -53942,6 +60086,12 @@
             "state" : "translated",
             "value" : "滚动"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "滾動"
+          }
         }
       }
     },
@@ -53981,6 +60131,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "在 HUD 中滚动显示设备名称"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在 HUD 中滾動顯示裝置名稱"
           }
         }
       }
@@ -54022,6 +60178,12 @@
             "state" : "translated",
             "value" : "回滚"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "回滾"
+          }
         }
       }
     },
@@ -54062,6 +60224,12 @@
             "state" : "translated",
             "value" : "回滚行数"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "回滾行數"
+          }
         }
       }
     },
@@ -54071,6 +60239,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Realtimegolfvorm waarin je kunt scrubben"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "可拖曳的即時波形"
           }
         }
       }
@@ -54124,6 +60298,12 @@
             "state" : "translated",
             "value" : "搜索剪贴板..."
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "搜尋剪貼簿..."
+          }
         }
       }
     },
@@ -54176,6 +60356,12 @@
             "state" : "translated",
             "value" : "搜索颜色..."
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "搜尋顏色..."
+          }
         }
       }
     },
@@ -54223,6 +60409,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "搜索扩展..."
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "搜尋延伸功能..."
           }
         }
       }
@@ -54272,6 +60464,12 @@
             "state" : "translated",
             "value" : "搜索笔记..."
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "搜尋筆記..."
+          }
         }
       }
     },
@@ -54319,6 +60517,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "搜索设置"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "搜尋設定"
           }
         }
       }
@@ -54371,6 +60575,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "搜索..."
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "搜尋..."
           }
         }
       }
@@ -54425,6 +60635,12 @@
             "state" : "translated",
             "value" : "秒"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "秒"
+          }
         }
       }
     },
@@ -54467,6 +60683,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "秒"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "秒"
@@ -54523,6 +60745,12 @@
             "state" : "translated",
             "value" : "分段"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "分段"
+          }
         }
       }
     },
@@ -54568,6 +60796,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "选择颜色查看详情"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選擇顏色檢視詳情"
           }
         }
       }
@@ -54616,6 +60850,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "选择计时器结束时播放的自定义声音。支持格式包括 MP3、M4A、WAV 和 AIFF。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選擇計時器結束時播放的自訂聲音。支援格式包括 MP3、M4A、WAV 和 AIFF。"
           }
         }
       }
@@ -54669,6 +60909,12 @@
             "state" : "translated",
             "value" : "选择日历"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選擇行事曆"
+          }
         }
       }
     },
@@ -54710,6 +60956,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "选择设备"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選擇裝置"
           }
         }
       }
@@ -54758,6 +61010,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "选择一个或多个配置文件以自定义您的体验"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選擇一個或多個配置檔案以自訂你的體驗"
           }
         }
       }
@@ -54871,6 +61129,12 @@
             "state" : "needs_review",
             "value" : "选择您想要使用的音乐源。您可以稍后在应用设置中更改此项。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "選擇你想要使用的音樂源。你可以稍後在 App 設定中更改此項。"
+          }
         }
       }
     },
@@ -54983,6 +61247,12 @@
             "state" : "needs_review",
             "value" : "已选择"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "已選擇"
+          }
         }
       }
     },
@@ -55036,6 +61306,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "已选择"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已選擇"
           }
         }
       }
@@ -55149,6 +61425,12 @@
             "state" : "needs_review",
             "value" : "所选动画"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "所選動畫"
+          }
         }
       }
     },
@@ -55196,6 +61478,12 @@
             "state" : "translated",
             "value" : "灵敏度"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "靈敏度"
+          }
         }
       }
     },
@@ -55238,6 +61526,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "独立标签页"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "獨立分頁"
           }
         }
       }
@@ -55286,6 +61580,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "独立标签页模式将复制项和笔记整合到单一视图中。如果两者都启用，笔记显示在右侧，剪贴板显示在左侧。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "獨立分頁模式將複製項和筆記整合到單一檢視中。如果兩者都啟用，筆記顯示在右側，剪貼簿顯示在左側。"
           }
         }
       }
@@ -55347,6 +61647,12 @@
             "state" : "translated",
             "value" : "会话 · ↓ %@ · ↑ %@"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "工作階段 · ↓ %@ · ↑ %@"
+          }
         }
       }
     },
@@ -55387,6 +61693,12 @@
             "state" : "translated",
             "value" : "会话平均"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "工作階段平均"
+          }
         }
       }
     },
@@ -55426,6 +61738,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "会话总计"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "工作階段總計"
           }
         }
       }
@@ -55478,6 +61796,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "设置"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "設定"
           }
         }
       }
@@ -55591,6 +61915,12 @@
             "state" : "needs_review",
             "value" : "设置"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "設定"
+          }
         }
       }
     },
@@ -55630,6 +61960,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "刘海中的设置图标"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "瀏海中的設定圖示"
           }
         }
       }
@@ -55678,6 +62014,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "设置…"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "設定…"
           }
         }
       }
@@ -55791,6 +62133,12 @@
             "state" : "needs_review",
             "value" : "暂存器"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "暫存器"
+          }
         }
       }
     },
@@ -55827,6 +62175,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Shell"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Shell"
@@ -55872,6 +62226,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Shell 路径"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Shell 路徑"
           }
         }
       }
@@ -55986,6 +62346,12 @@
             "state" : "needs_review",
             "value" : "快捷方式"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "快捷方式"
+          }
         }
       }
     },
@@ -56032,6 +62398,12 @@
             "state" : "translated",
             "value" : "显示「更改媒体输出」控制"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "顯示「更改媒體輸出」控制"
+          }
         }
       }
     },
@@ -56053,6 +62425,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Показывать смену режимов прослушивания AirPods"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "顯示 AirPods 聆聽模式變更"
           }
         }
       }
@@ -56094,6 +62472,12 @@
             "state" : "translated",
             "value" : "显示所有颜色格式"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "顯示所有顏色格式"
+          }
         }
       }
     },
@@ -56133,6 +62517,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "显示空气质量小组件"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "顯示空氣品質小工具"
           }
         }
       }
@@ -56246,6 +62636,12 @@
             "state" : "translated",
             "value" : "显示电池指示器"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "顯示電池指示器"
+          }
         }
       }
     },
@@ -56286,6 +62682,12 @@
             "state" : "translated",
             "value" : "显示电池百分比"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "顯示電池百分比"
+          }
         }
       }
     },
@@ -56315,6 +62717,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "在电池图标内显示百分比"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在電池圖示內顯示百分比"
           }
         }
       }
@@ -56356,6 +62764,12 @@
             "state" : "translated",
             "value" : "在 HUD 中显示电池百分比文本"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在 HUD 中顯示電池百分比文字"
+          }
         }
       }
     },
@@ -56395,6 +62809,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "显示蓝牙电池"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "顯示藍牙電池"
           }
         }
       }
@@ -56436,6 +62856,12 @@
             "state" : "translated",
             "value" : "显示蓝牙设备连接"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "顯示藍牙裝置連線"
+          }
         }
       }
     },
@@ -56475,6 +62901,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "显示日历"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "顯示行事曆"
           }
         }
       }
@@ -56516,6 +62948,12 @@
             "state" : "translated",
             "value" : "显示 Caps Lock 指示器"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "顯示 Caps Lock 指示器"
+          }
         }
       }
     },
@@ -56556,6 +62994,12 @@
             "state" : "translated",
             "value" : "显示 Caps Lock 标签"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "顯示 Caps Lock 標籤"
+          }
         }
       }
     },
@@ -56595,6 +63039,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "显示字符数"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "顯示字元數"
           }
         }
       }
@@ -56649,6 +63099,12 @@
             "state" : "translated",
             "value" : "显示充电指示器"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "顯示充電指示器"
+          }
         }
       }
     },
@@ -56688,6 +63144,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "显示充电百分比"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "顯示充電百分比"
           }
         }
       }
@@ -56729,6 +63191,12 @@
             "state" : "translated",
             "value" : "显示充电状态"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "顯示充電狀態"
+          }
         }
       }
     },
@@ -56768,6 +63236,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "显示剪贴板图标"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "顯示剪貼簿圖示"
           }
         }
       }
@@ -56821,6 +63295,12 @@
             "state" : "translated",
             "value" : "显示颜色历史"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "顯示顏色歷史"
+          }
         }
       }
     },
@@ -56860,6 +63340,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "显示取色器图标"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "顯示取色器圖示"
           }
         }
       }
@@ -56906,6 +63392,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "显示取色器面板"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "顯示取色器面板"
           }
         }
       }
@@ -57020,6 +63512,12 @@
             "state" : "needs_review",
             "value" : "不活动时显示动画"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "不活動時顯示動畫"
+          }
         }
       }
     },
@@ -57065,6 +63563,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "显示倒计时"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "顯示倒數計時"
           }
         }
       }
@@ -57125,6 +63629,12 @@
             "state" : "translated",
             "value" : "显示下载进度"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "顯示下載進度"
+          }
         }
       }
     },
@@ -57164,6 +63674,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "事件开始后显示"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "事件開始後顯示"
           }
         }
       }
@@ -57205,6 +63721,12 @@
             "state" : "translated",
             "value" : "在整个持续时间内显示事件"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在整個持續時間內顯示事件"
+          }
         }
       }
     },
@@ -57245,6 +63767,12 @@
             "state" : "translated",
             "value" : "显示所有日历的事件"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "顯示所有行事曆的事件"
+          }
         }
       }
     },
@@ -57284,6 +63812,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "显示接下来的事件"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "顯示接下來的事件"
           }
         }
       }
@@ -57327,6 +63861,12 @@
             "state" : "translated",
             "value" : "显示扩展标签页"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "顯示延伸功能分頁"
+          }
         }
       }
     },
@@ -57366,6 +63906,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "显示浮动媒体控制"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "顯示浮動媒體控制"
           }
         }
       }
@@ -57413,6 +63959,12 @@
             "state" : "translated",
             "value" : "显示浮动暂停/停止控制"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "顯示浮動暫停/停止控制"
+          }
         }
       }
     },
@@ -57452,6 +64004,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "以简短提示显示专注模式"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "以簡短提示顯示專注模式"
           }
         }
       }
@@ -57493,6 +64051,12 @@
             "state" : "translated",
             "value" : "显示专注指示器"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "顯示專注指示器"
+          }
         }
       }
     },
@@ -57533,6 +64097,12 @@
             "state" : "translated",
             "value" : "显示专注标签"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "顯示專注標籤"
+          }
         }
       }
     },
@@ -57572,6 +64142,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "显示专注小组件"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "顯示專注小工具"
           }
         }
       }
@@ -57621,6 +64197,12 @@
             "state" : "translated",
             "value" : "显示完整事件标题"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "顯示完整事件標題"
+          }
         }
       }
     },
@@ -57648,6 +64230,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "在灵动岛中显示动态 Canvas"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在動態島中顯示動態 Canvas"
           }
         }
       }
@@ -57689,6 +64277,12 @@
             "state" : "translated",
             "value" : "显示位置标签"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "顯示位置標籤"
+          }
         }
       }
     },
@@ -57728,6 +64322,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "显示锁屏媒体面板"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "顯示鎖定畫面媒體面板"
           }
         }
       }
@@ -57769,6 +64369,12 @@
             "state" : "translated",
             "value" : "显示锁屏提醒"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "顯示鎖定畫面提醒"
+          }
         }
       }
     },
@@ -57808,6 +64414,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "显示锁屏计时器"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "顯示鎖定畫面計時器"
           }
         }
       }
@@ -57849,6 +64461,12 @@
             "state" : "translated",
             "value" : "显示锁屏计时器小组件"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "顯示鎖定畫面計時器小工具"
+          }
         }
       }
     },
@@ -57888,6 +64506,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "显示锁屏天气"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "顯示鎖定畫面天氣"
           }
         }
       }
@@ -57929,6 +64553,12 @@
             "state" : "translated",
             "value" : "显示媒体应用图标"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "顯示媒體 App 圖示"
+          }
         }
       }
     },
@@ -57968,6 +64598,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "在灵动岛中显示媒体控制"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在動態島中顯示媒體控制"
           }
         }
       }
@@ -58009,6 +64645,12 @@
             "state" : "translated",
             "value" : "显示合并的隔空播放和输出设备"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "顯示合併的 AirPlay 和輸出裝置"
+          }
         }
       }
     },
@@ -58048,6 +64690,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "显示下一个日历事件"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "顯示下一個行事曆事件"
           }
         }
       }
@@ -58161,6 +64809,12 @@
             "state" : "needs_review",
             "value" : "在指定显示器上显示"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "在指定顯示器上顯示"
+          }
         }
       }
     },
@@ -58273,6 +64927,12 @@
             "state" : "needs_review",
             "value" : "在所有显示器上显示"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "在所有顯示器上顯示"
+          }
         }
       }
     },
@@ -58312,6 +64972,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "显示面板边框"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "顯示面板邊框"
           }
         }
       }
@@ -58359,6 +65025,12 @@
             "state" : "translated",
             "value" : "显示百分比"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "顯示百分比"
+          }
         }
       }
     },
@@ -58398,6 +65070,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "在进度条旁显示百分比"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在進度條旁顯示百分比"
           }
         }
       }
@@ -58439,6 +65117,12 @@
             "state" : "translated",
             "value" : "显示电源状态图标"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "顯示電源狀態圖示"
+          }
         }
       }
     },
@@ -58478,6 +65162,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "显示电源状态通知"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "顯示電源狀態通知"
           }
         }
       }
@@ -58527,6 +65217,12 @@
             "state" : "translated",
             "value" : "在计时器标签页中显示预设列表"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在計時器分頁中顯示預設組合列表"
+          }
         }
       }
     },
@@ -58573,6 +65269,12 @@
             "state" : "translated",
             "value" : "显示进度"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "顯示進度"
+          }
         }
       }
     },
@@ -58613,6 +65315,12 @@
             "state" : "translated",
             "value" : "显示录制指示器"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "顯示錄製指示器"
+          }
         }
       }
     },
@@ -58624,6 +65332,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Toon versie-informatie"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "顯示版本說明"
           }
         }
       }
@@ -58739,6 +65453,12 @@
             "state" : "needs_review",
             "value" : "显示随机播放和重复按钮"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "顯示隨機播放和重複按鈕"
+          }
         }
       }
     },
@@ -58787,6 +65507,12 @@
             "state" : "translated",
             "value" : "播放变化时显示快速预览"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "播放變化時顯示快速預覽"
+          }
         }
       }
     },
@@ -58814,6 +65540,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "在无刘海显示器上显示歌曲标题和艺人"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在無瀏海顯示器上顯示歌曲標題和藝人"
           }
         }
       }
@@ -58855,6 +65587,12 @@
             "state" : "translated",
             "value" : "事件开始后显示开始时间"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "事件開始後顯示開始時間"
+          }
         }
       }
     },
@@ -58894,6 +65632,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "显示日出时间"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "顯示日出時間"
           }
         }
       }
@@ -58943,6 +65687,12 @@
             "state" : "translated",
             "value" : "在指示器中显示活跃的专注模式名称。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在指示器中顯示活躍的專注模式名稱。"
+          }
         }
       }
     },
@@ -58982,6 +65732,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "显示剩余时间"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "顯示剩餘時間"
           }
         }
       }
@@ -59029,6 +65785,12 @@
             "state" : "translated",
             "value" : "显示计时器名称"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "顯示計時器名稱"
+          }
         }
       }
     },
@@ -59075,6 +65837,12 @@
             "state" : "translated",
             "value" : "使用时显示绿色相机图标和黄色麦克风图标。使用事件驱动的 CoreAudio 和 CoreMediaIO API。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "使用時顯示綠色相機圖示和黃色麥克風圖示。使用事件驅動的 CoreAudio 和 CoreMediaIO API。"
+          }
         }
       }
     },
@@ -59118,6 +65886,12 @@
             "state" : "translated",
             "value" : "将屏幕助手显示为附加到 AI 按钮的下拉菜单"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "將螢幕助理顯示為附加到 AI 按鈕的下拉選單"
+          }
         }
       }
     },
@@ -59160,6 +65934,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "在刘海附近的浮动面板中显示屏幕助手"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在瀏海附近的浮動面板中顯示螢幕助理"
           }
         }
       }
@@ -59213,6 +65993,12 @@
             "state" : "translated",
             "value" : "在最终答案之前显示模型的推理过程"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在最終答案之前顯示模型的推理過程"
+          }
         }
       }
     },
@@ -59259,6 +66045,12 @@
             "state" : "translated",
             "value" : "在可用时在刘海中显示系统时钟计时器。需要辅助功能权限来读取状态项。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在可用時在瀏海中顯示系統時鐘計時器。需要輔助使用權限來讀取狀態項。"
+          }
         }
       }
     },
@@ -59298,6 +66090,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "缩小锁屏媒体面板同时保持展开视图全宽。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "縮小鎖定畫面媒體面板同時保持展開檢視全寬。"
           }
         }
       }
@@ -59339,6 +66137,12 @@
             "state" : "translated",
             "value" : "随机播放"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "隨機播放"
+          }
         }
       }
     },
@@ -59369,6 +66173,12 @@
             "state" : "translated",
             "value" : "登录 Spotify 以自动捕获 `sp_dc` cookie，或者在下面粘贴。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "登入 Spotify 以自動捕獲 `sp_dc` cookie，或者在下面貼上。"
+          }
         }
       }
     },
@@ -59398,6 +66208,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "使用 Spotify 登录"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "使用 Spotify 登入"
           }
         }
       }
@@ -59438,6 +66254,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "简洁的界面，仅包含日常任务所需的基本功能。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "簡潔的介面，僅包含日常任務所需的基本功能。"
           }
         }
       }
@@ -59486,6 +66308,12 @@
             "state" : "translated",
             "value" : "大小与缩放"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "大小與縮放"
+          }
         }
       }
     },
@@ -59531,6 +66359,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "大小：%lld像素"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "大小：%lld畫素"
           }
         }
       }
@@ -59580,6 +66414,12 @@
             "state" : "translated",
             "value" : "跳过按钮"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "跳過按鈕"
+          }
         }
       }
     },
@@ -59623,6 +66463,12 @@
             "state" : "translated",
             "value" : "快进或后退 10 秒"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "快進或後退 10 秒"
+          }
         }
       }
     },
@@ -59634,6 +66480,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Sla deze versie over"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "略過此版本"
           }
         }
       }
@@ -59747,6 +66599,12 @@
             "state" : "needs_review",
             "value" : "滑块颜色"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "滑桿顏色"
+          }
         }
       }
     },
@@ -59786,6 +66644,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "平滑颜色过渡"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "平滑顏色過渡"
           }
         }
       }
@@ -59835,6 +66699,12 @@
             "state" : "translated",
             "value" : "平滑过渡在整个填充中混合绿色（0-60%）、黄色（60-85%）和红色（85-100%）。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "平滑過渡在整個填充中混合綠色（0-60%）、黃色（60-85%）和紅色（85-100%）。"
+          }
         }
       }
     },
@@ -59880,6 +66750,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "平滑过渡在整个填充中混合绿色（0-60%）、黄色（60-85%）和红色（85-100%）。从控制 › 灵动岛调整渐变行为。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "平滑過渡在整個填充中混合綠色（0-60%）、黃色（60-85%）和紅色（85-100%）。從控制 › 動態島調整漸變行為。"
           }
         }
       }
@@ -59928,6 +66804,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "快速预览时长"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "快速預覽時長"
           }
         }
       }
@@ -60041,6 +66923,12 @@
             "state" : "translated",
             "value" : "快速预览会在刘海下方短暂显示歌曲标题和艺人。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "快速預覽會在瀏海下方短暫顯示歌曲標題和藝人。"
+          }
         }
       }
     },
@@ -60153,6 +67041,12 @@
             "state" : "translated",
             "value" : "快速预览样式"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "快速預覽樣式"
+          }
         }
       }
     },
@@ -60201,6 +67095,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "简约模式下快速预览样式锁定为标准"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "簡約模式下快速預覽樣式鎖定為標準"
           }
         }
       }
@@ -60314,6 +67214,12 @@
             "state" : "needs_review",
             "value" : "软件更新"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "軟體更新"
+          }
         }
       }
     },
@@ -60361,6 +67267,12 @@
             "state" : "translated",
             "value" : "纯色"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "純色"
+          }
         }
       }
     },
@@ -60387,6 +67299,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "sp_dc cookie"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "sp_dc cookie"
@@ -60503,6 +67421,12 @@
             "state" : "needs_review",
             "value" : "速度"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "速度"
+          }
         }
       }
     },
@@ -60550,6 +67474,12 @@
             "state" : "translated",
             "value" : "速度："
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "速度："
+          }
         }
       }
     },
@@ -60593,6 +67523,12 @@
             "state" : "translated",
             "value" : "Spotify"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Spotify"
+          }
         }
       }
     },
@@ -60623,6 +67559,12 @@
             "state" : "translated",
             "value" : "Spotify Canvas 会话"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Spotify Canvas 工作階段"
+          }
         }
       }
     },
@@ -60652,6 +67594,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Spotify 经常屏蔽应用内登录。请通过您的常用浏览器登录，然后在设置中粘贴 sp_dc。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Spotify 經常封鎖 App 內登入。請透過你的常用瀏覽器登入，然後在設定中貼上 sp_dc。"
           }
         }
       }
@@ -60765,6 +67713,12 @@
             "state" : "needs_review",
             "value" : "方形"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "方形"
+          }
         }
       }
     },
@@ -60802,6 +67756,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "秒"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "秒"
@@ -60846,6 +67806,12 @@
             "state" : "translated",
             "value" : "标准"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "標準"
+          }
         }
       }
     },
@@ -60888,6 +67854,12 @@
             "state" : "translated",
             "value" : "标准刘海"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "標準瀏海"
+          }
         }
       }
     },
@@ -60928,6 +67900,12 @@
             "state" : "translated",
             "value" : "此开关关闭时标准刘海媒体控制已隐藏。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此開關關閉時標準瀏海媒體控制已隱藏。"
+          }
         }
       }
     },
@@ -60967,6 +67945,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "标准刘海媒体控制已隐藏。重新启用上方开关以恢复。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "標準瀏海媒體控制已隱藏。重新啟用上方開關以恢復。"
           }
         }
       }
@@ -61010,6 +67994,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "标准上/下一首曲目控制"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "標準上/下一首曲目控制"
           }
         }
       }
@@ -61063,6 +68053,12 @@
             "state" : "translated",
             "value" : "开始"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "開始"
+          }
         }
       }
     },
@@ -61114,6 +68110,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "开始对话以在此查看聊天记录"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "開始對話以在此檢視聊天記錄"
           }
         }
       }
@@ -61167,6 +68169,12 @@
             "state" : "translated",
             "value" : "开始取色"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "開始取色"
+          }
         }
       }
     },
@@ -61214,6 +68222,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "启动自定义计时器"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "啟動自訂計時器"
           }
         }
       }
@@ -61267,6 +68281,12 @@
             "state" : "translated",
             "value" : "启动演示计时器："
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "啟動演示計時器："
+          }
         }
       }
     },
@@ -61319,6 +68339,12 @@
             "state" : "translated",
             "value" : "开始监控"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "開始監控"
+          }
         }
       }
     },
@@ -61364,6 +68390,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "开始取色以建立历史记录"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "開始取色以建立歷史記錄"
           }
         }
       }
@@ -61417,6 +68449,12 @@
             "state" : "translated",
             "value" : "开始录制"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "開始錄製"
+          }
         }
       }
     },
@@ -61440,6 +68478,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "开始计时"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "開始計時"
           }
         }
       }
@@ -61489,6 +68533,12 @@
             "state" : "translated",
             "value" : "开始输入..."
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "開始輸入..."
+          }
         }
       }
     },
@@ -61534,6 +68584,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "启动 5 分钟演示计时器以测试实时活动功能。仅在启用计时器功能时有效。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "啟動 5 分鐘演示計時器以測試即時動態功能。僅在啟用計時器功能時有效。"
           }
         }
       }
@@ -61587,6 +68643,12 @@
             "state" : "translated",
             "value" : "统计"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "統計"
+          }
         }
       }
     },
@@ -61639,6 +68701,12 @@
             "state" : "translated",
             "value" : "统计已禁用"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "統計已停用"
+          }
         }
       }
     },
@@ -61686,6 +68754,12 @@
             "state" : "translated",
             "value" : "统计功能已禁用"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "統計功能已停用"
+          }
         }
       }
     },
@@ -61732,6 +68806,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "统计功能已禁用"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "統計功能已停用"
           }
         }
       }
@@ -61786,6 +68866,12 @@
             "state" : "translated",
             "value" : "统计面板已禁用"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "統計面板已停用"
+          }
         }
       }
     },
@@ -61839,6 +68925,12 @@
             "state" : "translated",
             "value" : "统计面板："
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "統計面板："
+          }
         }
       }
     },
@@ -61884,6 +68976,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "统计更新间隔"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "統計更新間隔"
           }
         }
       }
@@ -61932,6 +69030,12 @@
             "state" : "translated",
             "value" : "stats_resource_active"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "stats_resource_active"
+          }
         }
       }
     },
@@ -61973,6 +69077,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "状态"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "狀態"
           }
         }
       }
@@ -62026,6 +69136,12 @@
             "state" : "translated",
             "value" : "状态与操作"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "狀態與操作"
+          }
         }
       }
     },
@@ -62061,6 +69177,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "状态："
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "狀態："
           }
         }
       },
@@ -62103,6 +69225,12 @@
             "state" : "translated",
             "value" : "使用日历、计时器和电池监控保持井井有条。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "使用行事曆、計時器和電池監控保持井井有條。"
+          }
         }
       }
     },
@@ -62130,6 +69258,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "步长"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "步長"
           }
         }
       }
@@ -62179,6 +69313,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "停止"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "停止"
@@ -62235,6 +69375,12 @@
             "state" : "translated",
             "value" : "停止监控"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "停止監控"
+          }
         }
       }
     },
@@ -62274,6 +69420,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "关闭刘海后停止监控"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "關閉瀏海後停止監控"
           }
         }
       }
@@ -62326,6 +69478,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "停止录制"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "停止錄製"
           }
         }
       }
@@ -62439,6 +69597,12 @@
             "state" : "needs_review",
             "value" : "已停止"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "已停止"
+          }
         }
       }
     },
@@ -62478,6 +69642,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "存储设备"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "儲存裝置"
           }
         }
       }
@@ -62520,6 +69690,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "学生"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "學生"
           }
         }
       }
@@ -62566,6 +69742,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "样式"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "樣式"
           }
         }
       }
@@ -62614,6 +69796,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "日出时间 %@"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "日出時間 %@"
           }
         }
       }
@@ -62728,6 +69916,12 @@
             "state" : "needs_review",
             "value" : "支持我们"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "支援我們"
+          }
         }
       }
     },
@@ -62780,6 +69974,12 @@
             "state" : "translated",
             "value" : "支持推理模式"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "支援推理模式"
+          }
         }
       }
     },
@@ -62821,6 +70021,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "交换空间"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "交換空間"
           }
         }
       },
@@ -62877,6 +70083,12 @@
             "state" : "translated",
             "value" : "此系统已禁用交换空间。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此系統已停用交換空間。"
+          }
         }
       }
     },
@@ -62899,6 +70111,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Символ"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "符號"
           }
         }
       }
@@ -62924,6 +70142,12 @@
             "state" : "translated",
             "value" : "立即同步"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "立即同步"
+          }
         }
       }
     },
@@ -62945,6 +70169,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "与 Apple 备忘录同步"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "與 Apple 備忘錄同步"
           }
         }
       }
@@ -62999,6 +70229,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "系统"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "系統"
           }
         }
       }
@@ -63112,6 +70348,12 @@
             "state" : "needs_review",
             "value" : "系统功能"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "系統功能"
+          }
         }
       }
     },
@@ -63152,6 +70394,12 @@
             "state" : "translated",
             "value" : "系统内存压力正常。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "系統記憶體壓力正常。"
+          }
         }
       }
     },
@@ -63191,6 +70439,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "系统等宽字体"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "系統等寬字型"
           }
         }
       }
@@ -63239,6 +70493,12 @@
             "state" : "translated",
             "value" : "系统性能监视器"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "系統效能監視器"
+          }
         }
       }
     },
@@ -63280,6 +70540,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "标签页"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "分頁"
           }
         }
       }
@@ -63333,6 +70599,12 @@
             "state" : "translated",
             "value" : "区域截图"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "區域截圖"
+          }
         }
       }
     },
@@ -63372,6 +70644,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "温度"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "溫度"
           }
         }
       }
@@ -63419,6 +70697,12 @@
             "state" : "translated",
             "value" : "温度单位"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "溫度單位"
+          }
         }
       }
     },
@@ -63454,6 +70738,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "终端"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "終端機"
           }
         }
       },
@@ -63495,6 +70785,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "终端功能已禁用"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "終端機功能已停用"
           }
         }
       }
@@ -63538,6 +70834,12 @@
             "state" : "translated",
             "value" : "终端已禁用"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "終端機已停用"
+          }
         }
       }
     },
@@ -63580,6 +70882,12 @@
             "state" : "translated",
             "value" : "终端不透明度"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "終端機不透明度"
+          }
         }
       }
     },
@@ -63614,6 +70922,12 @@
             "state" : "translated",
             "value" : "终端透明度仅影响终端背景；文本保持完全不透明。模糊将使用窗口后方的系统材质。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "終端機透明度僅影響終端機背景；文字保持完全不透明。模糊將使用視窗後方的系統材質。"
+          }
         }
       }
     },
@@ -63641,6 +70955,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "测试充电提示框"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "測試充電提示框"
           }
         }
       }
@@ -63670,6 +70990,12 @@
             "state" : "translated",
             "value" : "测试充满电提示框"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "測試充滿電提示框"
+          }
         }
       }
     },
@@ -63697,6 +71023,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "测试低电量提示框"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "測試低電量提示框"
           }
         }
       }
@@ -63740,6 +71072,12 @@
             "state" : "translated",
             "value" : "文本"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "文字"
+          }
         }
       }
     },
@@ -63773,6 +71111,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "灵动岛"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "動態島"
           }
         }
       },
@@ -63814,6 +71158,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "这些控制镜像了锁屏标签页，方便您在关注播放设置的同时调整媒体覆盖层。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "這些控制鏡像了鎖定畫面分頁，方便你在關注播放設定的同時調整媒體覆蓋層。"
           }
         }
       }
@@ -63861,6 +71211,12 @@
             "state" : "translated",
             "value" : "计时器运行时这些控制位于刘海旁边。为了间距需要隐藏计时器名称。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "計時器執行時這些控制位於瀏海旁邊。為了間距需要隱藏計時器名稱。"
+          }
         }
       }
     },
@@ -63907,6 +71263,12 @@
             "state" : "translated",
             "value" : "当应用使用您的相机或麦克风时，这些指示器会出现在刘海中，与 macOS 原生隐私指示器一致。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "當 App 使用你的相機或麥克風時，這些指示器會出現在瀏海中，與 macOS 原生隱私指示器一致。"
+          }
         }
       }
     },
@@ -63934,6 +71296,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "这些临时提示框再现了充电、低电量和充满电时的刘海提醒。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "這些臨時提示框再現了充電、低電量和充滿電時的瀏海提醒。"
           }
         }
       }
@@ -63983,6 +71351,12 @@
             "state" : "translated",
             "value" : "使用 AtollExtensionKit 的第三方应用可以显示实时活动、锁屏小组件和专用刘海体验。在上方切换功能或在下方管理各应用权限。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "使用 AtollExtensionKit 的第三方 App 可以顯示即時動態、鎖定畫面小工具和專用瀏海體驗。在上方切換功能或在下方管理各 App 權限。"
+          }
         }
       }
     },
@@ -64022,6 +71396,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "第三方日历集成"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "第三方行事曆整合"
           }
         }
       }
@@ -64077,6 +71457,12 @@
             "state" : "translated",
             "value" : "此时长用于计时器弹出窗口中的「自定义」选项，方便快速访问。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此時長用於計時器彈出式視窗中的「自訂」選項，方便快速存取。"
+          }
         }
       }
     },
@@ -64116,6 +71502,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "这是可选的。您可以随时从菜单栏更改。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "這是可選的。你可以隨時從選單列更改。"
           }
         }
       }
@@ -64162,6 +71554,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "这将永久删除所有已保存的笔记及其附件。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "這將永久刪除所有已儲存的筆記及其附件。"
           }
         }
       }
@@ -64211,6 +71609,12 @@
             "state" : "translated",
             "value" : "这将从刘海标签页中移除所有已保存的剪贴板项目。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "這將從瀏海分頁中移除所有已儲存的剪貼簿項目。"
+          }
         }
       }
     },
@@ -64250,6 +71654,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "窗口管理"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "視窗管理"
           }
         }
       }
@@ -64297,6 +71707,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "时间范围"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "時間範圍"
           }
         }
       }
@@ -64410,6 +71826,12 @@
             "state" : "translated",
             "value" : "距离充满还需：%lld 分钟"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "距離充滿還需：%lld 分鐘"
+          }
         }
       }
     },
@@ -64462,6 +71884,12 @@
             "state" : "translated",
             "value" : "计时器"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "計時器"
+          }
         }
       }
     },
@@ -64509,6 +71937,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "计时器控制显示为"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "計時器控制顯示為"
           }
         }
       }
@@ -64562,6 +71996,12 @@
             "state" : "translated",
             "value" : "计时器已禁用"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "計時器已停用"
+          }
         }
       }
     },
@@ -64613,6 +72053,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "计时器功能"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "計時器功能"
           }
         }
       }
@@ -64666,6 +72112,12 @@
             "state" : "translated",
             "value" : "计时器功能已禁用"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "計時器功能已停用"
+          }
         }
       }
     },
@@ -64713,6 +72165,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "计时器玻璃材质"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "計時器玻璃材質"
           }
         }
       }
@@ -64762,6 +72220,12 @@
             "state" : "translated",
             "value" : "计时器液态模式"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "計時器液態模式"
+          }
         }
       }
     },
@@ -64809,6 +72273,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "计时器预设"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "計時器預設組合"
           }
         }
       }
@@ -64862,6 +72332,12 @@
             "state" : "translated",
             "value" : "计时器声音"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "計時器聲音"
+          }
         }
       }
     },
@@ -64910,6 +72386,12 @@
             "state" : "translated",
             "value" : "计时器表面"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "計時器表面"
+          }
         }
       }
     },
@@ -64955,6 +72437,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "计时器着色"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "計時器著色"
           }
         }
       }
@@ -65004,6 +72492,12 @@
             "state" : "translated",
             "value" : "计时器小组件"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "計時器小工具"
+          }
         }
       }
     },
@@ -65050,6 +72544,12 @@
             "state" : "translated",
             "value" : "计时器小组件变体"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "計時器小工具變體"
+          }
         }
       }
     },
@@ -65089,6 +72589,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "计时器小组件宽度"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "計時器小工具寬度"
           }
         }
       }
@@ -65137,6 +72643,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "标题"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "標題"
           }
         }
       }
@@ -65250,6 +72762,12 @@
             "state" : "needs_review",
             "value" : "切换Notch："
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "切換Notch："
+          }
         }
       }
     },
@@ -65362,6 +72880,12 @@
             "state" : "translated",
             "value" : "切换快速预览："
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "切換快速預覽："
+          }
         }
       }
     },
@@ -65403,6 +72927,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "切换终端标签页："
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "切換終端機分頁："
           }
         }
       }
@@ -65452,6 +72982,12 @@
             "state" : "translated",
             "value" : "从任何位置切换灵动岛的打开或关闭。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "從任何位置切換動態島的開啟或關閉。"
+          }
         }
       }
     },
@@ -65492,6 +73028,12 @@
             "state" : "translated",
             "value" : "活跃进程"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "活躍程序"
+          }
         }
       }
     },
@@ -65531,6 +73073,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "总计"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "總計"
           }
         }
       }
@@ -65580,6 +73128,12 @@
             "state" : "translated",
             "value" : "总计 · %@"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "總計 · %@"
+          }
         }
       },
       "shouldTranslate" : false
@@ -65623,6 +73177,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "跳过曲目"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "跳過曲目"
           }
         }
       }
@@ -65671,6 +73231,12 @@
             "state" : "translated",
             "value" : "变换"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "變換"
+          }
         }
       }
     },
@@ -65717,6 +73283,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "将刘海变成真正属于你的空间"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "將瀏海變成真正屬於你的空間"
           }
         }
       }
@@ -65770,6 +73342,12 @@
             "state" : "translated",
             "value" : "请尝试调整搜索词"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "請嘗試調整搜尋詞"
+          }
         }
       }
     },
@@ -65781,6 +73359,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Probeer opnieuw"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "再試一次"
           }
         }
       }
@@ -65834,6 +73418,12 @@
             "state" : "translated",
             "value" : "请尝试不同的搜索词"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "請嘗試不同的搜尋詞"
+          }
         }
       }
     },
@@ -65873,6 +73463,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "关闭「在整个持续时间内显示事件」以使用开始后时长选项。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "關閉「在整個持續時間內顯示事件」以使用開始後時長選項。"
           }
         }
       }
@@ -65922,6 +73518,12 @@
             "state" : "translated",
             "value" : "开启自定义控制以重新排列媒体按钮。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "開啟自訂控制以重新排列媒體按鈕。"
+          }
         }
       }
     },
@@ -65969,6 +73571,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "关闭此项以在刘海日历和提醒实时活动中包含全天事件。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "關閉此項以在瀏海行事曆和提醒即時動態中包含全天事件。"
           }
         }
       }
@@ -66084,6 +73692,12 @@
             "state" : "needs_review",
             "value" : "在Notch里双指向上滑动以关闭。当**悬停在Notch时打开**选项禁用时，双指向下滑动即可打开"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "在Notch裡雙指向上滑動以關閉。當**懸停在Notch時開啟**選項停用時，雙指向下滑動即可開啟"
+          }
         }
       }
     },
@@ -66107,6 +73721,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "与 macOS“备忘录”进行双向同步。在 Atoll 中创建的备忘录会显示在“备忘录”的 Atoll 文件夹中，现有的 Apple 备忘录也会导入刘海区域。出现提示时，请授予“备忘录”自动化权限。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "與 macOS「備忘錄」進行雙向同步。在 Atoll 中建立的備忘錄會顯示在「備忘錄」的 Atoll 資料夾中，現有的 Apple 備忘錄也會匯入瀏海區域。出現提示時，請授予「備忘錄」自動化權限。"
           }
         }
       }
@@ -66159,6 +73779,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "界面模式"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "介面模式"
           }
         }
       }
@@ -66274,6 +73900,12 @@
             "state" : "needs_review",
             "value" : "卸载"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "解除安裝"
+          }
         }
       }
     },
@@ -66312,6 +73944,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未知"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "未知"
@@ -66429,6 +74067,12 @@
             "state" : "needs_review",
             "value" : "解锁高级功能并提升您的体验。现在升级以获取更多自定义功能！"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "解鎖進階功能並提升你的體驗。現在升級以取得更多自訂功能！"
+          }
         }
       }
     },
@@ -66541,6 +74185,12 @@
             "state" : "needs_review",
             "value" : "已取消静音"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "已取消靜音"
+          }
         }
       }
     },
@@ -66583,6 +74233,12 @@
             "state" : "translated",
             "value" : "未充电"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未充電"
+          }
         }
       }
     },
@@ -66606,6 +74262,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "无标题备忘录"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無標題備忘錄"
           }
         }
       }
@@ -66647,6 +74309,12 @@
             "state" : "translated",
             "value" : "上传"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "上傳"
+          }
         }
       }
     },
@@ -66659,6 +74327,12 @@
             "state" : "translated",
             "value" : "Updatekanaal"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "更新通道"
+          }
         }
       }
     },
@@ -66670,6 +74344,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Bijwerken mislukt"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "更新失敗"
           }
         }
       }
@@ -66716,6 +74396,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "更新间隔"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "更新間隔"
           }
         }
       }
@@ -66769,6 +74455,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "更新计时器"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "更新計時器"
           }
         }
       }
@@ -66882,6 +74574,12 @@
             "state" : "needs_review",
             "value" : "升级至 Pro"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "升級至 Pro"
+          }
         }
       }
     },
@@ -66930,6 +74628,12 @@
             "state" : "translated",
             "value" : "上传"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "上傳"
+          }
         }
       },
       "shouldTranslate" : false
@@ -66971,6 +74675,12 @@
             "state" : "translated",
             "value" : "已上传"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已上傳"
+          }
         }
       }
     },
@@ -67010,6 +74720,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "运行时间"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "執行時間"
           }
         }
       }
@@ -67052,6 +74768,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "链接"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "連結"
           }
         }
       }
@@ -67107,6 +74829,12 @@
             "state" : "translated",
             "value" : "使用情况"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "使用情況"
+          }
         }
       }
     },
@@ -67161,6 +74889,12 @@
             "state" : "translated",
             "value" : "使用详情"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "使用詳情"
+          }
         }
       }
     },
@@ -67200,6 +74934,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "使用强调色"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "使用強調色"
           }
         }
       }
@@ -67247,6 +74987,12 @@
             "state" : "translated",
             "value" : "使用强调色"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "使用強調色"
+          }
         }
       }
     },
@@ -67274,6 +75020,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "在全屏动态画布上使用专辑封面布局"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在全螢幕動態畫布上使用專輯封面版面配置"
           }
         }
       }
@@ -67315,6 +75067,12 @@
             "state" : "translated",
             "value" : "使用圆形电池指示器"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "使用圓形電池指示器"
+          }
         }
       }
     },
@@ -67354,6 +75112,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "使用彩色仪表"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "使用彩色儀表"
           }
         }
       }
@@ -67397,6 +75161,12 @@
             "state" : "translated",
             "value" : "使用开发工具"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "使用開發工具"
+          }
         }
       }
     },
@@ -67430,6 +75200,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "使用增强型液态玻璃边框"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "使用增強型液態玻璃邊框"
           }
         }
       }
@@ -67470,6 +75246,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "使用电池时显示 MacBook 图标"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "使用電池時顯示 MacBook 圖示"
           }
         }
       }
@@ -67584,6 +75366,12 @@
             "state" : "needs_review",
             "value" : "使用音乐可视化器谱图"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "使用音樂視覺化器譜圖"
+          }
         }
       }
     },
@@ -67623,6 +75411,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "使用更简单的关闭动画"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "使用更簡單的關閉動畫"
           }
         }
       }
@@ -67672,6 +75466,12 @@
             "state" : "translated",
             "value" : "使用媒体标签页配置快速预览、歌词和浮动媒体控制。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "使用媒體分頁配置快速預覽、歌詞和浮動媒體控制。"
+          }
         }
       }
     },
@@ -67719,6 +75519,12 @@
             "state" : "translated",
             "value" : "使用下方滑块为每个小组件选择独特的 Apple 液态玻璃变体。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "使用下方滑桿為每個小工具選擇獨特的 Apple 液態玻璃變體。"
+          }
         }
       }
     },
@@ -67760,6 +75566,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "不使用开发工具"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "不使用開發工具"
           }
         }
       }
@@ -67811,6 +75623,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已使用"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "已使用"
@@ -67869,6 +75687,12 @@
             "state" : "translated",
             "value" : "已使用 · %@"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已使用 · %@"
+          }
         }
       }
     },
@@ -67908,6 +75732,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "用户"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "使用者"
           }
         }
       }
@@ -67955,6 +75785,12 @@
             "state" : "translated",
             "value" : "使用事件驱动的私有 API 进行实时屏幕录制检测"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "使用事件驅動的私有 API 進行即時螢幕錄製偵測"
+          }
         }
       }
     },
@@ -67966,6 +75802,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Gebruikt 'Huidig onderdeel' van macOS wanneer Cider de actieve mediabron is. De afspeelregelaars volgen het systeemdoel 'Huidig onderdeel'."
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "當 Cider 是使用中的媒體來源時，使用 macOS 正在播放。播放控制會遵循系統的正在播放目標。"
           }
         }
       }
@@ -68002,6 +75844,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "当 Amazon Music 应用是活动媒体源时使用 macOS 正在播放。播放控制遵循系统正在播放目标。如果 Amazon Music 应用不支持远程拖拽，在时间轴上拖动可能无效。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "當 Amazon Music App 是活動媒體源時使用 macOS 正在播放。播放控制遵循系統正在播放目標。如果 Amazon Music App 不支援遠端拖移，在時間軸上拖移可能無效。"
           }
         }
       }
@@ -68051,6 +75899,12 @@
             "state" : "translated",
             "value" : "启用玻璃模式时使用磨砂模糊效果。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "啟用玻璃模式時使用磨砂模糊效果。"
+          }
         }
       }
     },
@@ -68092,6 +75946,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "实用工具"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "實用工具"
           }
         }
       }
@@ -68147,6 +76007,12 @@
             "state" : "translated",
             "value" : "利用率"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "利用率"
+          }
         }
       }
     },
@@ -68187,6 +76053,12 @@
             "state" : "translated",
             "value" : "v%lld"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "v%lld"
+          }
         }
       },
       "shouldTranslate" : false
@@ -68218,6 +76090,12 @@
             "state" : "translated",
             "value" : "验证 Cookie"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "驗證 Cookie"
+          }
         }
       }
     },
@@ -68247,6 +76125,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "正在验证..."
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在驗證..."
           }
         }
       }
@@ -68289,6 +76173,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "变体 %lld"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "變體 %lld"
           }
         }
       }
@@ -68398,6 +76288,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "版本"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "版本"
@@ -68514,6 +76410,12 @@
             "state" : "needs_review",
             "value" : "版本信息"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "版本資訊"
+          }
         }
       }
     },
@@ -68554,6 +76456,12 @@
             "state" : "translated",
             "value" : "垂直条"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "垂直條"
+          }
         }
       }
     },
@@ -68590,6 +76498,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "垂直偏移"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "垂直偏移"
@@ -68641,6 +76555,12 @@
             "state" : "translated",
             "value" : "垂直："
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "垂直："
+          }
         }
       },
       "shouldTranslate" : false
@@ -68663,6 +76583,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Яркий"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "鮮明"
           }
         }
       }
@@ -68703,6 +76629,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "视频"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "影片"
           }
         }
       }
@@ -68816,6 +76748,12 @@
             "state" : "needs_review",
             "value" : "在 GitHub 上查看：th-ch/youtube-music"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "在 GitHub 上檢視：th-ch/youtube-music"
+          }
         }
       }
     },
@@ -68837,6 +76775,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Столбцы визуализатора"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "視覺化長條"
           }
         }
       }
@@ -68886,6 +76830,12 @@
             "state" : "translated",
             "value" : "音量"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "音量"
+          }
         }
       }
     },
@@ -68913,6 +76863,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "音量微调步长"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "音量微調步長"
           }
         }
       }
@@ -68966,6 +76922,12 @@
             "state" : "translated",
             "value" : "音量 HUD"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "音量 HUD"
+          }
         }
       }
     },
@@ -69014,6 +76976,12 @@
             "state" : "translated",
             "value" : "音量 OSD"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "音量 OSD"
+          }
         }
       }
     },
@@ -69041,6 +77009,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "音量步长"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "音量步長"
           }
         }
       }
@@ -69084,6 +77058,12 @@
             "state" : "translated",
             "value" : "W "
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "W "
+          }
         }
       }
     },
@@ -69120,6 +77100,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "警告"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "警告"
@@ -69172,6 +77158,12 @@
             "state" : "translated",
             "value" : "天气"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "天氣"
+          }
         }
       }
     },
@@ -69217,6 +77209,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "天气数据源"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "天氣資料來源"
           }
         }
       }
@@ -69265,6 +77263,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "天气小组件"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "天氣小工具"
           }
         }
       }
@@ -69319,6 +77323,12 @@
             "state" : "translated",
             "value" : "天气：%1$@ %2$@"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "天氣：%1$@ %2$@"
+          }
         }
       }
     },
@@ -69371,6 +77381,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "天气：%1$@ %2$@ 在 %3$@"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "天氣：%1$@ %2$@ 在 %3$@"
           }
         }
       }
@@ -69484,6 +77500,12 @@
             "state" : "needs_review",
             "value" : "欢迎"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "歡迎"
+          }
         }
       }
     },
@@ -69518,6 +77540,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Karşılama penceresi"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "歡迎視窗"
           }
         }
       }
@@ -69631,6 +77659,12 @@
             "state" : "needs_review",
             "value" : "更新内容"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "更新內容"
+          }
         }
       }
     },
@@ -69670,6 +77704,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "关闭粗体变亮时，粗体文本使用更粗的字体而非明亮的 ANSI 颜色。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "關閉粗體變亮時，粗體文字使用更粗的字型而非明亮的 ANSI 顏色。"
           }
         }
       }
@@ -69717,6 +77757,12 @@
             "state" : "translated",
             "value" : "禁用后，所有键盘快捷键将不可用。您仍然可以使用界面控制。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "停用後，所有鍵盤快速鍵將不可用。你仍然可以使用介面控制。"
+          }
         }
       }
     },
@@ -69757,6 +77803,12 @@
             "state" : "translated",
             "value" : "禁用时，刘海音乐播放器即使在未播放时也会显示占位元数据。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "停用時，瀏海音樂播放器即使在未播放時也會顯示佔位中繼資料。"
+          }
         }
       }
     },
@@ -69796,6 +77848,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "启用后，点击日历事件将打开选定的第三方日历应用程序，而不是 Apple 日历。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "啟用後，點按行事曆事件將開啟選定的第三方行事曆 App，而不是 Apple 行事曆。"
           }
         }
       }
@@ -69845,6 +77903,12 @@
             "state" : "translated",
             "value" : "启用时，专注模式短暂显示（开/关）后折叠而非保持可见。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "啟用時，專注模式短暫顯示（開/關）後摺疊而非保持可見。"
+          }
         }
       }
     },
@@ -69891,6 +77955,12 @@
             "state" : "translated",
             "value" : "启用后，刘海关闭几秒后统计监控将停止。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "啟用後，瀏海關閉幾秒後統計監控將停止。"
+          }
         }
       }
     },
@@ -69930,6 +78000,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "启用时，音乐可视化将显示与音乐同步的实时音频频谱数据。需要 macOS 14.2+，通过 Accelerate 框架使用最少的 CPU/GPU 资源。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "啟用時，音樂視覺化將顯示與音樂同步的即時音訊頻譜資料。需要 macOS 14.2+，透過 Accelerate 框架使用最少的 CPU/GPU 資源。"
           }
         }
       }
@@ -69972,6 +78048,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "启用时，刘海在外接（无刘海）显示器上会向上滑动隐藏，直到您将鼠标悬停在上方。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "啟用時，瀏海在外接（無瀏海）顯示器上會向上滑動隱藏，直到你將滑鼠懸停在上方。"
           }
         }
       }
@@ -70020,6 +78102,12 @@
             "state" : "translated",
             "value" : "启用后，统计标签页将显示实时系统性能图表。此功能需要系统权限，可能会消耗额外电量。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "啟用後，統計分頁將顯示即時系統效能圖表。此功能需要系統權限，可能會消耗額外電量。"
+          }
         }
       }
     },
@@ -70029,6 +78117,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Als deze optie is ingeschakeld, toont het tabblad Statistieken realtimegrafieken van de systeemprestaties. Voor deze functie zijn systeemmachtigingen vereist en wordt mogelijk extra energie verbruikt. Als je LLM-gebruik bewaakt, wordt het tabblad Gebruik toegevoegd. Hierop worden het tokengebruik en de kosten van je geconfigureerde AI-aanbieders bijgehouden."
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "啟用後，統計分頁會顯示即時系統效能圖表。此功能需要系統權限，並可能增加電量消耗。啟用 LLM 用量監控會新增用量分頁，追蹤你所設定的各 AI 服務供應商的 token 用量與花費。"
           }
         }
       }
@@ -70066,6 +78160,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "白色"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "白色"
@@ -70118,6 +78218,12 @@
             "state" : "translated",
             "value" : "小组件更新"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "小工具更新"
+          }
         }
       }
     },
@@ -70158,6 +78264,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "宽度调整仅适用于标准刘海布局。禁用简约界面以编辑此值。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "寬度調整僅適用於標準瀏海版面配置。停用簡約介面以編輯此值。"
           }
         }
       }
@@ -70212,6 +78324,12 @@
             "state" : "translated",
             "value" : "宽度："
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "寬度："
+          }
         }
       }
     },
@@ -70258,6 +78376,12 @@
             "state" : "translated",
             "value" : "宽度：%lld像素"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "寬度：%lld畫素"
+          }
         }
       }
     },
@@ -70294,6 +78418,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "固定"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "固定"
@@ -70344,6 +78474,12 @@
             "state" : "translated",
             "value" : "启用 %lld 个图表后，灵动岛将水平扩展以在单行中容纳所有图表。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "啟用 %lld 個圖表後，動態島將水平延伸功能以在單行中容納所有圖表。"
+          }
         }
       }
     },
@@ -70385,6 +78521,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "支持大多数媒体应用（包括浏览器）来检测正在播放的内容。注意：此功能可能在未来的 macOS 版本中被移除。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "支援大多數媒體 App（包括瀏覽器）來偵測正在播放的內容。注意：此功能可能在未來的 macOS 版本中被移除。"
           }
         }
       }
@@ -70440,6 +78582,12 @@
             "state" : "translated",
             "value" : "写入"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "寫入"
+          }
         }
       }
     },
@@ -70480,6 +78628,12 @@
             "state" : "translated",
             "value" : "仅写入"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "僅寫入"
+          }
         }
       }
     },
@@ -70519,6 +78673,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "已写入"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已寫入"
           }
         }
       }
@@ -70568,6 +78728,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "你"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "你"
@@ -70684,6 +78850,12 @@
             "state" : "needs_review",
             "value" : "如果您想进一步调整内容，您可以随时访问设置。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "如果你想進一步調整內容，你可以隨時存取設定。"
+          }
         }
       }
     },
@@ -70796,6 +78968,12 @@
             "state" : "needs_review",
             "value" : "一切都准备好了！"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "一切都準備好了！"
+          }
         }
       }
     },
@@ -70807,6 +78985,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Atoll is up-to-date!"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "你已是最新版本！"
           }
         }
       }
@@ -70854,6 +79038,12 @@
             "state" : "translated",
             "value" : "您的日历数据仅用于显示事件，绝不会被分享。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "你的行事曆資料僅用於顯示事件，絕不會被分享。"
+          }
         }
       }
     },
@@ -70900,6 +79090,12 @@
             "state" : "translated",
             "value" : "未经您同意，相机不会被使用，且不会录制或存储任何内容。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未經你同意，相機不會被使用，且不會錄製或儲存任何內容。"
+          }
         }
       }
     },
@@ -70942,6 +79138,12 @@
             "state" : "translated",
             "value" : "您的支持将资助高中生的软件开发学习。"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "你的支援將資助高中生的軟體開發學習。"
+          }
         }
       }
     },
@@ -70981,6 +79183,12 @@
           }
         },
         "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "YouTube Music"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "YouTube Music"
@@ -71097,6 +79305,12 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "YouTube 音乐需要安装此第三方应用程序： "
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "YouTube 音樂需要安裝此第三方 App： "
           }
         }
       }

--- a/Localizable.xcstrings
+++ b/Localizable.xcstrings
@@ -140,6 +140,12 @@
             "state": "translated",
             "value": ""
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": ""
+          }
         }
       }
     },
@@ -278,6 +284,12 @@
           }
         },
         "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": " – %lld"
+          }
+        },
+        "zh-Hant": {
           "stringUnit": {
             "state": "translated",
             "value": " – %lld"
@@ -425,6 +437,12 @@
             "state": "translated",
             "value": " %@"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": " %@"
+          }
         }
       }
     },
@@ -564,6 +582,12 @@
             "state": "translated",
             "value": "-%@"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "-%@"
+          }
         }
       },
       "shouldTranslate": false
@@ -698,6 +722,12 @@
           }
         },
         "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "—"
+          }
+        },
+        "zh-Hant": {
           "stringUnit": {
             "state": "translated",
             "value": "—"
@@ -857,6 +887,12 @@
             "state": "translated",
             "value": "'Huidig onderdeel' was de enige optie in eerdere versies en werkt met alle media-apps."
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "「正在播放」是以前版本中唯一的選項，並適用於所有媒體 App。"
+          }
         }
       }
     },
@@ -997,6 +1033,12 @@
         "nl": {
           "stringUnit": {
             "state": "translated",
+            "value": "(%@)"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
             "value": "(%@)"
           }
         }
@@ -1141,6 +1183,12 @@
             "state": "translated",
             "value": "%.0f seconden"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "%.0f 秒"
+          }
         }
       }
     },
@@ -1282,6 +1330,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "%.1fs"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%.1f秒"
           }
         }
       }
@@ -1427,6 +1481,12 @@
             "state": "translated",
             "value": "%@"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "%@"
+          }
         }
       }
     },
@@ -1570,6 +1630,12 @@
             "state": "translated",
             "value": "%1$@ · %2$@"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ · %@"
+          }
         }
       }
     },
@@ -1711,6 +1777,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "%@ Modellen"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 模型"
           }
         }
       }
@@ -1855,6 +1927,12 @@
             "state": "translated",
             "value": "%@ Offset"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 偏移"
+          }
         }
       }
     },
@@ -1988,6 +2066,12 @@
           }
         },
         "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ pt"
+          }
+        },
+        "zh-Hant": {
           "stringUnit": {
             "state": "translated",
             "value": "%@ pt"
@@ -2126,6 +2210,12 @@
           }
         },
         "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@°"
+          }
+        },
+        "zh-Hant": {
           "stringUnit": {
             "state": "translated",
             "value": "%@°"
@@ -2273,6 +2363,12 @@
             "state": "translated",
             "value": "%d%%"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "%d%%"
+          }
         }
       }
     },
@@ -2405,6 +2501,12 @@
           }
         },
         "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld"
+          }
+        },
+        "zh-Hant": {
           "stringUnit": {
             "state": "translated",
             "value": "%lld"
@@ -2553,6 +2655,12 @@
             "state": "translated",
             "value": "%lld animaties"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld 個動畫"
+          }
         }
       }
     },
@@ -2694,6 +2802,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "%lld kleuren"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld 種顏色"
           }
         }
       }
@@ -2838,6 +2952,12 @@
             "state": "translated",
             "value": "%lld min"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld 分鐘"
+          }
         }
       }
     },
@@ -2981,6 +3101,12 @@
             "state": "translated",
             "value": "%lld px"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld 畫素"
+          }
         }
       }
     },
@@ -3117,6 +3243,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "%lld s"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld 秒"
           }
         }
       },
@@ -3261,6 +3393,12 @@
             "state": "translated",
             "value": "%lld%%"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "%lld%%"
+          }
         }
       }
     },
@@ -3403,6 +3541,12 @@
             "state": "translated",
             "value": "%lldx"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lldx"
+          }
         }
       }
     },
@@ -3536,6 +3680,12 @@
           }
         },
         "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "•"
+          }
+        },
+        "zh-Hant": {
           "stringUnit": {
             "state": "translated",
             "value": "•"
@@ -3689,6 +3839,12 @@
             "state": "translated",
             "value": "• Bugfixes"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "• Bug 修復"
+          }
         }
       }
     },
@@ -3838,6 +3994,12 @@
             "state": "translated",
             "value": "• Matglas: doorschijnend vervagingseffect"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• 磨砂玻璃：半透明模糊效果"
+          }
         }
       }
     },
@@ -3985,6 +4147,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "• Verbeterde prestaties"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "• 提升效能"
           }
         }
       }
@@ -4141,6 +4309,12 @@
             "state": "translated",
             "value": "• Liquid Glass: modern glaseffect (macOS 26+)"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• 液態玻璃：現代玻璃效果（macOS 26+）"
+          }
         }
       }
     },
@@ -4288,6 +4462,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "• Nieuwe functie 1"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "• 新功能1"
           }
         }
       }
@@ -4444,6 +4624,12 @@
             "state": "translated",
             "value": "• Effen donker/licht/automatisch: ondoorzichtige achtergronden"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• 純色深色/淺色/自動：不透明背景"
+          }
         }
       }
     },
@@ -4591,6 +4777,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "• Denken"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• 思考中"
           }
         }
       }
@@ -4741,6 +4933,12 @@
             "state": "translated",
             "value": "• %@ bijgewerkt"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• 更新於 %@"
+          }
         }
       }
     },
@@ -4873,6 +5071,12 @@
           }
         },
         "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "••••••••"
+          }
+        },
+        "zh-Hant": {
           "stringUnit": {
             "state": "translated",
             "value": "••••••••"
@@ -5020,6 +5224,12 @@
             "state": "translated",
             "value": "+%lld meer"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "+%lld 更多"
+          }
         }
       }
     },
@@ -5067,6 +5277,12 @@
             "state": "translated",
             "value": "⚠️ WAARSCHUWING: Systeem-HUD werkt mogelijk niet correct!"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "⚠️ 警告：系統 HUD 可能無法正常工作！"
+          }
         }
       }
     },
@@ -5101,6 +5317,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "⚠️ Fout:"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "⚠️ 錯誤："
           }
         }
       }
@@ -5137,6 +5359,12 @@
             "state": "translated",
             "value": "🔋 Maximale capaciteit"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "🔋 最大容量"
+          }
         }
       }
     },
@@ -5171,6 +5399,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "🕒 Tijd tot volledig opladen:"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "🕒 充滿所需時間："
           }
         }
       }
@@ -5309,6 +5543,12 @@
             "state": "translated",
             "value": "0"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "0"
+          }
         }
       },
       "shouldTranslate": false
@@ -5443,6 +5683,12 @@
           }
         },
         "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "00:05:00"
+          }
+        },
+        "zh-Hant": {
           "stringUnit": {
             "state": "translated",
             "value": "00:05:00"
@@ -5590,6 +5836,12 @@
             "state": "translated",
             "value": "1x"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1x"
+          }
         }
       }
     },
@@ -5731,6 +5983,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "3 items"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "3 個項目"
           }
         }
       }
@@ -5874,6 +6132,12 @@
             "state": "translated",
             "value": "5 kleuren"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "5 種顏色"
+          }
         }
       }
     },
@@ -6015,6 +6279,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "5 items"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "5 個項目"
           }
         }
       }
@@ -6158,6 +6428,12 @@
             "state": "translated",
             "value": "7 items"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "7 個項目"
+          }
         }
       }
     },
@@ -6299,6 +6575,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "10 kleuren"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "10 種顏色"
           }
         }
       }
@@ -6442,6 +6724,12 @@
             "state": "translated",
             "value": "10 items"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "10 個項目"
+          }
         }
       }
     },
@@ -6584,6 +6872,12 @@
             "state": "translated",
             "value": "15 kleuren"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "15 種顏色"
+          }
         }
       }
     },
@@ -6716,6 +7010,12 @@
           }
         },
         "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "20"
+          }
+        },
+        "zh-Hant": {
           "stringUnit": {
             "state": "translated",
             "value": "20"
@@ -6863,6 +7163,12 @@
             "state": "translated",
             "value": "20 kleuren"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "20 種顏色"
+          }
         }
       }
     },
@@ -6995,6 +7301,12 @@
           }
         },
         "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "30"
+          }
+        },
+        "zh-Hant": {
           "stringUnit": {
             "state": "translated",
             "value": "30"
@@ -7137,6 +7449,12 @@
             "state": "translated",
             "value": "100"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "100"
+          }
         }
       },
       "shouldTranslate": false
@@ -7270,6 +7588,12 @@
           }
         },
         "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "100%"
+          }
+        },
+        "zh-Hant": {
           "stringUnit": {
             "state": "translated",
             "value": "100%"
@@ -7417,6 +7741,12 @@
             "state": "translated",
             "value": "Over"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "關於"
+          }
         }
       }
     },
@@ -7560,6 +7890,12 @@
             "state": "translated",
             "value": "Accentkleur"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "首選顏色"
+          }
         }
       }
     },
@@ -7702,6 +8038,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Accentkleur"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "點綴色"
           }
         }
       }
@@ -7851,6 +8193,12 @@
             "state": "translated",
             "value": "Toegang geweigerd"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "被拒絕存取"
+          }
         }
       }
     },
@@ -7992,6 +8340,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Toegankelijkheid"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "輔助使用"
           }
         }
       }
@@ -8148,6 +8502,12 @@
             "state": "translated",
             "value": "Toegankelijkheidstoestemming vereist"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "需要存取權限"
+          }
         }
       }
     },
@@ -8289,6 +8649,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Acties"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "操作"
           }
         }
       }
@@ -8432,6 +8798,12 @@
             "state": "translated",
             "value": "Activeer"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "啟用"
+          }
         }
       }
     },
@@ -8573,6 +8945,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Activeer je licentie"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "啟用你的許可證"
           }
         }
       }
@@ -8716,6 +9094,12 @@
             "state": "translated",
             "value": "Activering"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "啟用"
+          }
         }
       }
     },
@@ -8858,6 +9242,12 @@
             "state": "translated",
             "value": "Actief"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "活躍"
+          }
         }
       }
     },
@@ -8999,6 +9389,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Actief - Geen focus"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "活躍 - 無專注模式"
           }
         }
       }
@@ -9149,6 +9545,12 @@
             "state": "translated",
             "value": "Actief - Geen opname"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "活躍 - 未錄製"
+          }
         }
       }
     },
@@ -9290,6 +9692,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Toevoegen"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "新增"
           }
         }
       }
@@ -9434,6 +9842,12 @@
             "state": "translated",
             "value": "Animatie toevoegen vanaf URL"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "從 URL 新增動畫"
+          }
         }
       }
     },
@@ -9575,6 +9989,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Bestanden toevoegen"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "新增檔案"
           }
         }
       }
@@ -9719,6 +10139,12 @@
             "state": "translated",
             "value": "Toevoegen vanaf URL..."
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "從 URL 新增..."
+          }
         }
       }
     },
@@ -9861,6 +10287,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Handmatig toevoegen"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "手動新增"
           }
         }
       }
@@ -10005,6 +10437,12 @@
             "state": "translated",
             "value": "Nieuw toevoegen"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "新增"
+          }
         }
       }
     },
@@ -10146,6 +10584,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Nieuwe visualisatie toevoegen"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "新增新的視覺化器"
           }
         }
       }
@@ -10290,6 +10734,12 @@
             "state": "translated",
             "value": "Voorinstelling toevoegen"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "新增預設組合"
+          }
         }
       }
     },
@@ -10431,6 +10881,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Extra functies"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "其他功能"
           }
         }
       }
@@ -10587,6 +11043,12 @@
             "state": "translated",
             "value": "Pas de bovenstaande instellingen aan om wijzigingen in realtime te zien. Het daadwerkelijke OSD verschijnt midden onderaan je scherm."
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "調整上方設定即可即時檢視變化。實際螢幕顯示選單（OSD）位於螢幕底部中央位置。"
+          }
         }
       }
     },
@@ -10728,6 +11190,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "AI-assistent"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AI 助理"
           }
         }
       }
@@ -10871,6 +11339,12 @@
             "state": "translated",
             "value": "AI denkt..."
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AI 正在思考..."
+          }
         }
       }
     },
@@ -11012,6 +11486,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "AI-modelselectie"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AI 模型選擇"
           }
         }
       }
@@ -11160,6 +11640,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "AI-aanbieder"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AI 服務商"
           }
         }
       }
@@ -11315,6 +11801,12 @@
             "state": "translated",
             "value": "AI-aangedreven assistent die bestanden en afbeeldingen kan analyseren en gesprekshulp kan bieden. Gebruik Cmd+Shift+A om snel toegang te krijgen tot de assistent."
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "人工智慧驅動的助理，能夠分析檔案和影像，並提供對話式幫助。使用 Cmd+Shift+A 快速存取該助理。"
+          }
         }
       }
     },
@@ -11464,6 +11956,12 @@
             "state": "translated",
             "value": "Luchtkwaliteitsindex %1$d, %2$@"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "空氣品質指數 %1$d, %2$@"
+          }
         }
       }
     },
@@ -11611,6 +12109,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Luchtkwaliteit vereist de Open Meteo-provider."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "空氣品質需要Open Meteo服務提供商。"
           }
         }
       }
@@ -11760,6 +12264,12 @@
             "state": "translated",
             "value": "Schaal van de luchtkwaliteit"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "空氣品質量表"
+          }
         }
       }
     },
@@ -11898,6 +12408,12 @@
           }
         },
         "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AirDrop"
+          }
+        },
+        "zh-Hant": {
           "stringUnit": {
             "state": "translated",
             "value": "AirDrop"
@@ -12044,6 +12560,12 @@
             "state": "translated",
             "value": "AirDrop-service niet beschikbaar"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "AirDrop 服務不可用"
+          }
         }
       }
     },
@@ -12185,6 +12707,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "De hele dag"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "全天"
           }
         }
       }
@@ -12328,6 +12856,12 @@
             "state": "translated",
             "value": "Toegang toestaan"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "允許存取"
+          }
         }
       }
     },
@@ -12464,6 +12998,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "อัลฟา"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "測試版"
           }
         }
       },
@@ -12609,6 +13149,12 @@
             "state": "translated",
             "value": "Waarschuwing voor alpha-functie"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "測試版功能警告"
+          }
         }
       }
     },
@@ -12750,6 +13296,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Verberg altijd op volledig scherm"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "總是隱藏在全螢幕"
           }
         }
       }
@@ -12893,6 +13445,12 @@
             "state": "translated",
             "value": "Toon altijd tabbladen"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "總是顯示分頁"
+          }
         }
       }
     },
@@ -13031,6 +13589,12 @@
           }
         },
         "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Amazon Music"
+          }
+        },
+        "zh-Hant": {
           "stringUnit": {
             "state": "translated",
             "value": "Amazon Music"
@@ -13177,6 +13741,12 @@
             "state": "translated",
             "value": "Animatie"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "動畫"
+          }
         }
       }
     },
@@ -13320,6 +13890,12 @@
             "state": "translated",
             "value": "Animatienaam"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "動畫名稱"
+          }
         }
       }
     },
@@ -13461,6 +14037,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "API-configuratie"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API 配置"
           }
         }
       }
@@ -13604,6 +14186,12 @@
             "state": "translated",
             "value": "API-sleutel vereist"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "需要 API 金鑰"
+          }
         }
       }
     },
@@ -13745,6 +14333,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "App-pictogram"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "App 圖示"
           }
         }
       }
@@ -13888,6 +14482,12 @@
             "state": "translated",
             "value": "Uiterlijk"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "外觀"
+          }
         }
       }
     },
@@ -13923,6 +14523,12 @@
             "state": "translated",
             "value": "uiterlijk"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "外觀"
+          }
         }
       }
     },
@@ -13946,6 +14552,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "AQI"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "空氣品質指數"
           }
         }
       }
@@ -14095,6 +14707,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Weet je zeker dat je \"%@\" wilt verwijderen?"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "你確定要刪除「%@」嗎？"
           }
         }
       }
@@ -14250,6 +14868,12 @@
             "state": "translated",
             "value": "Weet je zeker dat je deze kleur uit je geschiedenis wilt verwijderen?"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "你確定要從歷史記錄中刪除此顏色嗎？"
+          }
         }
       }
     },
@@ -14391,6 +15015,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Vraag me wat je wilt..."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "隨便問我..."
           }
         }
       }
@@ -14534,6 +15164,12 @@
             "state": "translated",
             "value": "Atoll"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Atoll"
+          }
         }
       }
     },
@@ -14569,6 +15205,12 @@
             "state": "translated",
             "value": "Atoll heeft toegang nodig om AI-assistentbestanden op te slaan en te lezen."
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Atoll 需要權限來儲存和讀取 AI 助理檔案。"
+          }
         }
       }
     },
@@ -14603,6 +15245,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Atoll heeft toegang nodig om schermafbeeldingen op je bureaublad op te slaan."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Atoll 需要權限將截圖儲存到桌面。"
           }
         }
       }
@@ -14645,6 +15293,12 @@
             "state": "translated",
             "value": "Atoll heeft Bluetooth-toegang nodig om te detecteren wanneer audioapparaten verbinding maken en om hun batterijstatus in de HUD weer te geven."
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Atoll 需要藍牙存取權限來偵測音訊裝置連線並在 HUD 中顯示其電池狀態。"
+          }
         }
       }
     },
@@ -14685,6 +15339,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Atoll gebruikt AppleScripts om Spotify en Apple Music te besturen"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Atoll 使用 AppleScript 控制 Spotify 和 Apple Music"
           }
         }
       }
@@ -14828,6 +15488,12 @@
             "state": "translated",
             "value": "Bijgevoegde bestanden"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "附件"
+          }
         }
       }
     },
@@ -14970,6 +15636,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Automatisch scrollen naar de volgende activiteit"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自動滾動到下一個事件"
           }
         }
       }
@@ -15125,6 +15797,12 @@
             "state": "translated",
             "value": "Automatisch controleren op updates"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "自動檢查更新"
+          }
         }
       }
     },
@@ -15267,6 +15945,12 @@
             "state": "translated",
             "value": "Updates automatisch downloaden"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "自動下載更新"
+          }
         }
       }
     },
@@ -15301,6 +15985,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Automatisch schakelen tussen schermen"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自動切換顯示器"
           }
         }
       }
@@ -15445,6 +16135,12 @@
             "state": "translated",
             "value": "Gemiddelden"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "平均值"
+          }
         }
       }
     },
@@ -15588,6 +16284,12 @@
             "state": "translated",
             "value": "Achtergrondverlichting"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "背光"
+          }
         }
       }
     },
@@ -15729,6 +16431,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Batterij"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "電池"
           }
         }
       }
@@ -15873,6 +16581,12 @@
             "state": "translated",
             "value": "Batterij op %d procent"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "電池電量 %d%%"
+          }
         }
       }
     },
@@ -16015,6 +16729,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Batterij opladen"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "電池充電中"
           }
         }
       }
@@ -16159,6 +16879,12 @@
             "state": "translated",
             "value": "Batterij wordt opgeladen, nog %@ resterend"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "電池充電中，剩餘 %@"
+          }
         }
       }
     },
@@ -16302,6 +17028,12 @@
             "state": "translated",
             "value": "Batterij volledig opgeladen"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "電池已充滿"
+          }
         }
       }
     },
@@ -16443,6 +17175,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Batterij-informatie"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "電池資訊"
           }
         }
       }
@@ -16586,6 +17324,12 @@
             "state": "translated",
             "value": "Batterij-instellingen"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "電池設定"
+          }
         }
       }
     },
@@ -16728,6 +17472,12 @@
             "state": "translated",
             "value": "Batterijstatus"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "電池狀態"
+          }
         }
       }
     },
@@ -16869,6 +17619,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Het blauw gestippelde vak geeft de werkelijke grootte op Atoll weer"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "藍色虛線框顯示 Atoll 中的實際大小"
           }
         }
       }
@@ -17013,6 +17769,12 @@
             "state": "translated",
             "value": "Bluetooth-audioapparaten"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "藍牙音訊裝置"
+          }
         }
       }
     },
@@ -17155,6 +17917,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Bluetooth-apparaat %1$@ op %2$d procent"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "藍牙裝置 %1$@ 已充電至 %2$d 百分比"
           }
         }
       }
@@ -17304,6 +18072,12 @@
             "state": "translated",
             "value": "Verhoog je productiviteit met Klembordbeheer"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "使用剪貼簿管理程式提升你的效率"
+          }
         }
       }
     },
@@ -17446,6 +18220,12 @@
             "state": "translated",
             "value": "Beide"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "兩者"
+          }
         }
       }
     },
@@ -17587,6 +18367,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Onderste pad:"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "底部間距："
           }
         }
       }
@@ -17731,6 +18517,12 @@
             "state": "translated",
             "value": "Uitsplitsing"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "詳細資訊"
+          }
         }
       }
     },
@@ -17874,6 +18666,12 @@
             "state": "translated",
             "value": "Helderheid"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "亮度"
+          }
         }
       }
     },
@@ -18015,6 +18813,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Helderheid HUD"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "亮度 HUD"
           }
         }
       }
@@ -18159,6 +18963,12 @@
             "state": "translated",
             "value": "Helderheid OSD"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "亮度 OSD"
+          }
         }
       }
     },
@@ -18302,6 +19112,12 @@
             "state": "translated",
             "value": "Ingebouwd"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "內建"
+          }
         }
       }
     },
@@ -18444,6 +19260,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Ingebouwde systeembewaking"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "內建系統監控"
           }
         }
       }
@@ -18600,6 +19422,12 @@
             "state": "translated",
             "value": "Ingebouwde systeemmonitoring detecteert veranderingen in volume, helderheid en toetsenbordverlichting direct zonder dat hiervoor externe apps nodig zijn."
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "內建系統監控功能可直接偵測音量、亮度和鍵盤背光的變化，無需外部 App。"
+          }
         }
       }
     },
@@ -18741,6 +19569,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Koop een koffie voor ons"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "請我們喝杯咖啡"
           }
         }
       }
@@ -18884,6 +19718,12 @@
             "state": "translated",
             "value": "Agenda"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "行事曆"
+          }
         }
       }
     },
@@ -19026,6 +19866,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Toegang tot agenda is geweigerd. Schakel dit in Systeeminstellingen in."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "行事曆存取被拒絕。請在系統設定中啟用它。"
           }
         }
       }
@@ -19176,6 +20022,12 @@
             "state": "translated",
             "value": "Toegang tot agenda of herinneringen is geweigerd. Schakel dit in Systeeminstellingen in."
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "行事曆或提醒事項存取被拒絕。請在系統設定中啟用。"
+          }
         }
       }
     },
@@ -19317,6 +20169,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Agenda's"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "行事曆"
           }
         }
       }
@@ -19461,6 +20319,12 @@
             "state": "translated",
             "value": "Camera"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "相機"
+          }
         }
       }
     },
@@ -19603,6 +20467,12 @@
             "state": "translated",
             "value": "Camera actief"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "相機已啟用"
+          }
         }
       }
     },
@@ -19643,6 +20513,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Camera wordt gebruikt door een applicatie"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "相機正被某個 App 使用"
           }
         }
       }
@@ -19786,6 +20662,12 @@
             "state": "translated",
             "value": "Camerastatus"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "相機狀態"
+          }
         }
       }
     },
@@ -19927,6 +20809,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Annuleer"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "取消"
           }
         }
       }
@@ -20070,6 +20958,12 @@
             "state": "translated",
             "value": "Midden"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "居中"
+          }
         }
       }
     },
@@ -20211,6 +21105,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Verandering"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "更改"
           }
         }
       }
@@ -20355,6 +21255,12 @@
             "state": "translated",
             "value": "Opladen"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "充電中"
+          }
         }
       }
     },
@@ -20496,6 +21402,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Opladen onderbroken: Desktopmodus"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "暫停充電：桌面模式"
           }
         }
       }
@@ -20639,6 +21551,12 @@
             "state": "translated",
             "value": "Controleer op updates…"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "檢查更新…"
+          }
         }
       }
     },
@@ -20781,6 +21699,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Kleur chip"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "晶片顏色"
           }
         }
       }
@@ -20931,6 +21855,12 @@
             "state": "translated",
             "value": "Kies een aangepast geluidsbestand dat wordt afgespeeld wanneer de timer is voltooid. Ondersteunde formaten: MP3, M4A, WAV, AIFF."
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "選擇一個自訂聲音檔案，該檔案將在計時器結束時播放。支援的格式：MP3、M4A、WAV、AIFF。"
+          }
         }
       }
     },
@@ -21073,6 +22003,12 @@
             "state": "translated",
             "value": "Kies een muziekbron"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "選擇音樂來源"
+          }
         }
       }
     },
@@ -21214,6 +22150,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Kies AI-model"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "選擇 AI 模型"
           }
         }
       }
@@ -21364,6 +22306,12 @@
             "state": "translated",
             "value": "Kies een animatie die moet worden weergegeven wanneer het Atoll inactief is. Tik om te selecteren, houd ingedrukt om aangepaste animaties te verwijderen."
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "選擇在 Atoll 閒置時顯示的動畫效果。輕點選擇，長按刪除自訂動畫。"
+          }
         }
       }
     },
@@ -21505,6 +22453,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Kies Bestand"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "選擇檔案"
           }
         }
       }
@@ -21649,6 +22603,12 @@
             "state": "translated",
             "value": "Kies welke systeembedieningen aangepaste OSD-vensters moeten weergeven."
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "選擇哪些系統控制元件應顯示自訂OSD視窗。"
+          }
         }
       }
     },
@@ -21791,6 +22751,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Kies welke systeembedieningen HUD-meldingen moeten weergeven."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "選擇哪些系統控制元件應顯示HUD通知。"
           }
         }
       }
@@ -21940,6 +22906,12 @@
             "state": "translated",
             "value": "Kies het AI-model en de configuratie van je voorkeur"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "選擇你偏好的 AI 模型和配置"
+          }
         }
       }
     },
@@ -22083,6 +23055,12 @@
             "state": "translated",
             "value": "Kies je profiel"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "選擇你的配置檔案"
+          }
         }
       }
     },
@@ -22224,6 +23202,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Cirkel"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "圓形"
           }
         }
       }
@@ -22368,6 +23352,12 @@
             "state": "translated",
             "value": "Duidelijk"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "清除"
+          }
         }
       }
     },
@@ -22509,6 +23499,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Wis alle bestanden"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "清除所有檔案"
           }
         }
       }
@@ -22652,6 +23648,12 @@
             "state": "translated",
             "value": "Alle bestanden wissen verwijdert alle bijgevoegde bestanden en audio-opnamen. Deze actie is permanent."
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "清除所有檔案將刪除所有附加檔案和音訊錄音。此操作不可撤銷。"
+          }
         }
       }
     },
@@ -22793,6 +23795,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Klembordgeschiedenis wissen"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "清除剪貼簿歷史"
           }
         }
       }
@@ -22936,6 +23944,12 @@
             "state": "translated",
             "value": "Door de geschiedenis van het klembord te wissen, worden recente kopieën verwijderd. Door vastgezette items te wissen, worden je favorieten verwijderd. Beide acties zijn permanent."
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "清除剪貼簿歷史記錄將刪除最近的複製內容。清除固定項目將刪除你的收藏項。這兩項操作均為永久性操作。"
+          }
         }
       }
     },
@@ -23077,6 +24091,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Kleurgeschiedenis wissen"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "清除顏色歷史"
           }
         }
       }
@@ -23220,6 +24240,12 @@
             "state": "translated",
             "value": "Door de kleurgeschiedenis te wissen, worden alle gekozen kleuren verwijderd. Kleur kiezen starten begint de modus voor het vastleggen van schermkleuren."
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "清除顏色歷史記錄將刪除所有選取的顏色。開始顏色拾取將啟動螢幕顏色捕獲模式。"
+          }
         }
       }
     },
@@ -23362,6 +24388,12 @@
             "state": "translated",
             "value": "Gegevens wissen"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "清除資料"
+          }
         }
       }
     },
@@ -23503,6 +24535,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Wis vastgezette items"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "清除固定項"
           }
         }
       }
@@ -23647,6 +24685,12 @@
             "state": "translated",
             "value": "Duidelijke zoekopdracht"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "清除搜尋"
+          }
         }
       }
     },
@@ -23788,6 +24832,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Klik op 'Kies kleur' of gebruik Cmd+Shift+P om kleuren te kiezen"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "點按「取色」或使用 Cmd+Shift+P 開始取色"
           }
         }
       }
@@ -23932,6 +24982,12 @@
             "state": "translated",
             "value": "Klik voor details"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "點按檢視詳情"
+          }
         }
       }
     },
@@ -24073,6 +25129,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Klembord"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "剪貼簿"
           }
         }
       }
@@ -24216,6 +25278,12 @@
             "state": "translated",
             "value": "Klembordfunctie is uitgeschakeld"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "剪貼簿功能已停用"
+          }
         }
       }
     },
@@ -24357,6 +25425,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Klembordgeschiedenis"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "剪貼簿歷史"
           }
         }
       }
@@ -24500,6 +25574,12 @@
             "state": "translated",
             "value": "Klembordgeschiedenis:"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "剪貼簿歷史："
+          }
         }
       }
     },
@@ -24641,6 +25721,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Klembordbeheer"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "剪貼簿管理程式"
           }
         }
       }
@@ -24784,6 +25870,12 @@
             "state": "translated",
             "value": "Sluiten"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "關閉"
+          }
         }
       }
     },
@@ -24926,6 +26018,12 @@
             "state": "translated",
             "value": "Dichtbij assistent"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "關閉助理"
+          }
         }
       }
     },
@@ -24960,6 +26058,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "dichtbij gebaar"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "關閉手勢"
           }
         }
       }
@@ -25104,6 +26208,12 @@
             "state": "translated",
             "value": "Verzamel het laatste crashrapport om te delen met de ontwikkelaar bij het melden van problemen met het vergrendelscherm of de overlay."
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "收集最新崩潰報告以便向開發者報告鎖定畫面或覆蓋層問題時分享。"
+          }
         }
       }
     },
@@ -25245,6 +26355,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Kleurdetails"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "顏色詳情"
           }
         }
       }
@@ -25388,6 +26504,12 @@
             "state": "translated",
             "value": "Kleurformaten"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "顏色格式"
+          }
         }
       }
     },
@@ -25529,6 +26651,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Kleur geschiedenis"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "顏色歷史"
           }
         }
       }
@@ -25679,6 +26807,12 @@
             "state": "translated",
             "value": "Kleuropties bepalen het pictogram en het uiterlijk van de voortgangsbalk. Past zich automatisch aan het systeemthema aan."
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "顏色選項控制圖示和進度條外觀。自動適應系統主題。"
+          }
         }
       }
     },
@@ -25820,6 +26954,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Kleur gekozen!"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已取色！"
           }
         }
       }
@@ -25963,6 +27103,12 @@
             "state": "translated",
             "value": "Kleurkiezer"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "取色器"
+          }
         }
       }
     },
@@ -26104,6 +27250,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "De functie Kleurkiezer is uitgeschakeld"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "取色器功能已停用"
           }
         }
       }
@@ -26247,6 +27399,12 @@
             "state": "translated",
             "value": "Kleurkiezerpaneel:"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "取色器面板："
+          }
         }
       }
     },
@@ -26281,6 +27439,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Kleurgecodeerde batterijweergave"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "彩色電池顯示"
           }
         }
       }
@@ -26437,6 +27601,12 @@
             "state": "translated",
             "value": "Kleurgecodeerde vullingen en vloeiende verlopen zijn niet beschikbaar in de gesegmenteerde modus. Schakel naar Hiërarchisch of Verloop om deze opties aan te passen."
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "分段模式下不支援彩色填充和平滑漸變。切換到層級或漸變模式來調整這些選項。"
+          }
         }
       }
     },
@@ -26586,6 +27756,12 @@
             "state": "translated",
             "value": "Kleurgecodeerde voortgangsbalken"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "彩色進度條"
+          }
         }
       }
     },
@@ -26727,6 +27903,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Kleurkiezer uitgeschakeld"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "取色器已停用"
           }
         }
       }
@@ -26870,6 +28052,12 @@
             "state": "translated",
             "value": "Binnenkort beschikbaar"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "即將上線"
+          }
         }
       }
     },
@@ -27011,6 +28199,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Configuratie"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "配置"
           }
         }
       }
@@ -27167,6 +28361,12 @@
             "state": "translated",
             "value": "Configureer de aftelstijl en vergrendelschermwidgets op het tabblad 'Agenda'."
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在行事曆分頁中配置倒數計時樣式和鎖定畫面小工具。"
+          }
         }
       }
     },
@@ -27321,6 +28521,12 @@
             "state": "translated",
             "value": "Configureer hoe de timer eruitziet in de gesloten inkeping. Vooruitgang kan worden weergegeven als een ring rond het pictogram of als horizontale balken."
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "配置計時器在關閉的瀏海中的外觀。進度可以顯示為圖示周圍的圓環或水平條。"
+          }
         }
       }
     },
@@ -27464,6 +28670,12 @@
             "state": "translated",
             "value": "Configureer voorinstellingen in Instellingen"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在設定中配置預設組合"
+          }
         }
       }
     },
@@ -27601,6 +28813,12 @@
             "state": "translated",
             "value": "Verbonden"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已連線"
+          }
         }
       }
     },
@@ -27635,6 +28853,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Container"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "容器"
           }
         }
       }
@@ -27777,6 +29001,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Ga door"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "繼續"
           }
         }
       }
@@ -27932,6 +29162,12 @@
             "state": "translated",
             "value": "Beheer de beschikbaarheid van timers, het gedrag van live-activiteiten en of de app timers weerspiegelt die zijn gestart vanuit de macOS Clock-app."
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "控制計時器可用性、即時動態行為，以及 App 是否同步 macOS 時鐘 App 啟動的計時器。"
+          }
         }
       }
     },
@@ -28073,6 +29309,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Bediening"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "控制"
           }
         }
       }
@@ -28227,6 +29469,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Bepaalt hoe vaak systeemstatistieken worden vernieuwd terwijl monitoring actief is."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "控制監控啟用時系統指標的重新整理頻率。"
           }
         }
       }
@@ -28383,6 +29631,12 @@
             "state": "translated",
             "value": "Bestuurt de optionele timerwidget die boven het mediapaneel zweeft. Vervaging voegt een matte afwerking toe achter de compacte weergave."
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "控制浮動在媒體面板上方的可選計時器小工具。模糊效果為緊湊檢視新增磨砂效果。"
+          }
         }
       }
     },
@@ -28537,6 +29791,12 @@
             "state": "translated",
             "value": "Bepaalt of Dynamic Island vergrendelings- en ontgrendelingsgebeurtenissen weergeeft via zijn eigen live-activiteit en geluidssignalen."
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "控制動態島是否透過自身的即時動態和提示音來響應鎖定畫面/解鎖事件。"
+          }
         }
       }
     },
@@ -28680,6 +29940,12 @@
             "state": "translated",
             "value": "Kopieer de koppeling naar de activiteit"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "複製事件連結"
+          }
         }
       }
     },
@@ -28821,6 +30087,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Kopieer het laatste crashrapport"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "複製最新崩潰報告"
           }
         }
       }
@@ -28964,6 +30236,12 @@
             "state": "translated",
             "value": "Kopieer iets om aan de slag te gaan"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "複製內容即可開始"
+          }
         }
       }
     },
@@ -29105,6 +30383,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Kopieer iets om te beginnen"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "複製內容即可開始"
           }
         }
       }
@@ -29249,6 +30533,12 @@
             "state": "translated",
             "value": "Kern %lld"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "核心 %lld"
+          }
         }
       }
     },
@@ -29283,6 +30573,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Schaling van de hoekradius"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "圓角縮放"
           }
         }
       }
@@ -29427,6 +30723,12 @@
             "state": "translated",
             "value": "Countdown-stijl"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "倒數計時樣式"
+          }
         }
       }
     },
@@ -29568,6 +30870,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "CPU-gebruik"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "CPU 使用率"
           }
         }
       }
@@ -29712,6 +31020,12 @@
             "state": "translated",
             "value": "Huidige aangepaste timer:"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "目前自訂計時器："
+          }
         }
       }
     },
@@ -29855,6 +31169,12 @@
             "state": "translated",
             "value": "Huidige standaard:"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "目前預設："
+          }
         }
       }
     },
@@ -29997,6 +31317,12 @@
             "state": "translated",
             "value": "Huidige geschiedenis"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "目前歷史"
+          }
         }
       }
     },
@@ -30138,6 +31464,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Huidige items"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "目前項目"
           }
         }
       }
@@ -30282,6 +31614,12 @@
             "state": "translated",
             "value": "Momenteel actief"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "目前活躍"
+          }
         }
       }
     },
@@ -30423,6 +31761,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Aangepast"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自訂"
           }
         }
       }
@@ -30567,6 +31911,12 @@
             "state": "translated",
             "value": "Aangepaste kleur"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自訂顏色"
+          }
         }
       }
     },
@@ -30708,6 +32058,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Aangepaste hoogte"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "自訂高度"
           }
         }
       }
@@ -30851,6 +32207,12 @@
             "state": "translated",
             "value": "Aangepaste muziek-live-activiteitsanimatie"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "自訂音樂即時動畫"
+          }
         }
       }
     },
@@ -30992,6 +32354,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Aangepaste inkepingsgrootte - %.0f"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "自訂Notch大小 - %.0f"
           }
         }
       }
@@ -31135,6 +32503,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Aangepaste OSD"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自訂 OSD"
           }
         }
       }
@@ -31284,6 +32658,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Voor de aangepaste OSD-functie is macOS 15 of hoger vereist."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自訂 OSD 功能需要 macOS 15 或更高版本。"
           }
         }
       }
@@ -31438,6 +32818,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Aangepaste OSD is een experimentele alpha-functie en kan bugs of onverwacht gedrag bevatten.\n\nDeze functie vereist macOS 15 of hoger en wordt nog steeds actief ontwikkeld. Het wordt aanbevolen om dit uitgeschakeld te houden, tenzij je wilt helpen met testen."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自訂 OSD 是一個實驗性測試功能，可能包含錯誤或意外行為。\n\n此功能需要 macOS 15 或更高版本，仍在積極開發中。除非你想幫助測試，否則建議保持停用。"
           }
         }
       }
@@ -31594,6 +32980,12 @@
             "state": "translated",
             "value": "Aangepaste OSD is uitgeschakeld omdat HUD's zijn ingeschakeld. Schakel HUD's uit op het tabblad HUD's om Aangepaste OSD te gebruiken."
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自訂 OSD 已停用，因為 HUD 已啟用。請在 HUD 分頁中停用 HUD 以使用自訂 OSD。"
+          }
         }
       }
     },
@@ -31735,6 +33127,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Aangepaste timer"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自訂計時器"
           }
         }
       }
@@ -31879,6 +33277,12 @@
             "state": "translated",
             "value": "Aangepaste timerduur"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自訂計時器時長"
+          }
         }
       }
     },
@@ -32020,6 +33424,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Aangepaste vizualizers (Lottie)"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "自訂視覺化器（Lottie）"
           }
         }
       }
@@ -32163,6 +33573,12 @@
             "state": "translated",
             "value": "Aangepast: %@"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自訂：%@"
+          }
         }
       }
     },
@@ -32304,6 +33720,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Animatie aanpassen"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自訂動畫"
           }
         }
       }
@@ -32447,6 +33869,12 @@
             "state": "translated",
             "value": "Pas aan in Instellingen"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "在設定中自訂"
+          }
         }
       }
     },
@@ -32588,6 +34016,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Standaard"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "預設"
           }
         }
       }
@@ -32732,6 +34166,12 @@
             "state": "translated",
             "value": "Standaard aangepaste timer"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "預設自訂計時器"
+          }
         }
       }
     },
@@ -32874,6 +34314,12 @@
             "state": "translated",
             "value": "Standaard: dynamic.m4a"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "預設：dynamic.m4a"
+          }
         }
       }
     },
@@ -33015,6 +34461,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Verwijderen"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "刪除"
           }
         }
       }
@@ -33159,6 +34611,12 @@
             "state": "translated",
             "value": "Animatie verwijderen"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "刪除動畫"
+          }
         }
       }
     },
@@ -33300,6 +34758,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Kleur verwijderen"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "刪除顏色"
           }
         }
       }
@@ -33444,6 +34908,12 @@
             "state": "translated",
             "value": "Beschrijving"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "描述"
+          }
         }
       }
     },
@@ -33478,6 +34948,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Detailweergave"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "詳細檢視"
           }
         }
       }
@@ -33622,6 +35098,12 @@
             "state": "translated",
             "value": "Detectiestatus"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "偵測狀態"
+          }
         }
       }
     },
@@ -33764,6 +35246,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Diagnostiek"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "診斷"
           }
         }
       }
@@ -33908,6 +35396,12 @@
             "state": "translated",
             "value": "Uitschakelen"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "停用"
+          }
         }
       }
     },
@@ -34049,6 +35543,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Uitgeschakeld"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "已停用"
           }
         }
       }
@@ -34199,6 +35699,12 @@
             "state": "translated",
             "value": "Er zijn discrete overgangen tussen groen (0–60%), geel (60–85%) en rood (85–100%)."
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "離散過渡在綠色（0-60%）、黃色（60-85%）和紅色（85-100%）之間切換。"
+          }
         }
       }
     },
@@ -34341,6 +35847,12 @@
             "state": "translated",
             "value": "Schijf lezen"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "磁碟讀取"
+          }
         }
       }
     },
@@ -34482,6 +35994,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Schijf schrijven"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "磁碟寫入"
           }
         }
       }
@@ -34638,6 +36156,12 @@
             "state": "translated",
             "value": "Toon aangepaste OSD-vensters in macOS-stijl midden onderaan het scherm wanneer je het volume, de helderheid of de toetsenbordverlichting aanpast."
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "調節音量、亮度或鍵盤背光時在螢幕底部居中顯示自訂 macOS 風格的 OSD 視窗。"
+          }
         }
       }
     },
@@ -34780,6 +36304,12 @@
             "state": "translated",
             "value": "Weergavemodus"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "顯示模式"
+          }
         }
       }
     },
@@ -34921,6 +36451,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Weergaveopties"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "顯示選項"
           }
         }
       }
@@ -35077,6 +36613,12 @@
             "state": "translated",
             "value": "Geeft een HUD-melding weer wanneer Bluetooth-audioapparaten (hoofdtelefoon, AirPods, luidsprekers) verbinding maken, waarbij de apparaatnaam en het batterijniveau worden weergegeven."
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "藍牙音訊裝置（耳機、AirPods、揚聲器）連線時顯示 HUD 通知，包含裝置名稱和電池電量。"
+          }
         }
       }
     },
@@ -35231,6 +36773,12 @@
             "state": "translated",
             "value": "Toont knoppen voor afspelen/pauzeren en overslaan naast de inkeping terwijl de muziek actief is. Standaard uitgeschakeld."
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "音樂播放時在瀏海旁邊顯示播放/暫停和跳過按鈕。預設停用。"
+          }
         }
       }
     },
@@ -35372,6 +36920,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Niet storen"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "勿擾模式"
           }
         }
       }
@@ -35515,6 +37069,12 @@
             "state": "translated",
             "value": "Downloaden"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "下載"
+          }
         }
       }
     },
@@ -35656,6 +37216,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Pictogramstijl downloaden"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "下載圖示樣式"
           }
         }
       }
@@ -35799,6 +37365,12 @@
             "state": "translated",
             "value": "Indicatorstijl downloaden"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "下載指示器樣式"
+          }
         }
       }
     },
@@ -35941,6 +37513,12 @@
             "state": "translated",
             "value": "Indicatoren downloaden"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "下載指示器"
+          }
         }
       }
     },
@@ -35975,6 +37553,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "downloads"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "下載"
           }
         }
       }
@@ -36117,6 +37701,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Downloads"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "下載"
           }
         }
       }
@@ -36272,6 +37862,12 @@
             "state": "translated",
             "value": "Versleep de voorbeelden om de verticale plaatsing aan te passen. Positieve waarden tillen het paneel omhoog; negatieve waarden verlagen deze. Wijzigingen zijn onmiddellijk van toepassing zolang de widgets zichtbaar zijn."
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "拖移預覽以調整垂直位置。正值上移面板，負值下移。更改在小工具可見時立即生效。"
+          }
         }
       }
     },
@@ -36414,6 +38010,12 @@
             "state": "translated",
             "value": "Zet hier bestanden neer"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "拖放檔案到這裡"
+          }
         }
       }
     },
@@ -36549,6 +38151,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "dynamic.island"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "動態島"
           }
         }
       },
@@ -36705,6 +38313,12 @@
             "state": "translated",
             "value": "Elke grafiek kan afzonderlijk worden in- of uitgeschakeld. Netwerkactiviteit toont download-/uploadsnelheden, en schijf-I/O toont lees-/schrijfsnelheden."
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "每個圖表可以單獨啟用或停用。網路活動顯示下載/上傳速度，磁碟 I/O 顯示讀寫速度。"
+          }
         }
       }
     },
@@ -36739,6 +38353,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "EAQI"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "歐洲空氣品質指數"
           }
         }
       }
@@ -36894,6 +38514,12 @@
             "state": "translated",
             "value": "Kopieer, bewaar en beheer eenvoudig je meest gebruikte inhoud. Upgrade nu voor geavanceerde functies zoals opslag voor meerdere items en snelle toegang!"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "輕鬆複製、儲存和管理你最常用的內容。升級後可解鎖進階功能，如多項目儲存和快速存取！"
+          }
         }
       }
     },
@@ -37035,6 +38661,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Animatie bewerken"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "編輯動畫"
           }
         }
       }
@@ -37178,6 +38810,12 @@
             "state": "translated",
             "value": "Lay-out bewerken"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "編輯版面配置"
+          }
         }
       }
     },
@@ -37319,6 +38957,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "E-mailadres"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "電子郵件地址"
           }
         }
       }
@@ -37475,6 +39119,12 @@
             "state": "translated",
             "value": "Schakel 'Toon coole gezichtsanimatie tijdens inactiviteit' in om animaties aan te passen"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "啟用「閒置時顯示有趣的表情動畫」以自訂動畫"
+          }
         }
       }
     },
@@ -37630,6 +39280,12 @@
             "state": "translated",
             "value": "Schakel de mediabediening in en vorm deze die boven de systeemklok verschijnt wanneer het scherm is vergrendeld."
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "啟用並設定螢幕鎖定時系統時鐘上方顯示的媒體控制。"
+          }
         }
       }
     },
@@ -37773,6 +39429,12 @@
             "state": "translated",
             "value": "Hoe dan ook inschakelen"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "仍然啟用"
+          }
         }
       }
     },
@@ -37807,6 +39469,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Schakel het vervagingseffect achter albumhoezen in"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "啟用專輯封面後的模糊效果"
           }
         }
       }
@@ -37956,6 +39624,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Schakel ingebouwde systeem-HUD in"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "啟用內建系統 HUD"
           }
         }
       }
@@ -38112,6 +39786,12 @@
             "state": "translated",
             "value": "Schakel ingebouwde systeemmonitoring in om macOS HUD-meldingen te vervangen door Atoll-schermen."
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "啟用內建系統監控，用 Atoll 顯示替代 macOS HUD 通知。"
+          }
         }
       }
     },
@@ -38146,6 +39826,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Cameradetectie inschakelen"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "啟用相機偵測"
           }
         }
       }
@@ -38290,6 +39976,12 @@
             "state": "translated",
             "value": "Schakel gekleurde spectrogrammen in"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "啟用彩色譜圖"
+          }
         }
       }
     },
@@ -38431,6 +40123,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Schakel ColorPicker in Instellingen → ColorPicker in"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在設定 → 取色器中啟用取色器"
           }
         }
       }
@@ -38575,6 +40273,12 @@
             "state": "translated",
             "value": "Aangepaste OSD inschakelen"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "啟用自訂 OSD"
+          }
         }
       }
     },
@@ -38610,6 +40314,12 @@
             "state": "translated",
             "value": "Schakel dynamische spiegel in"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "啟用動態鏡像"
+          }
         }
       }
     },
@@ -38644,6 +40354,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Schakel gebaren in"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "啟用手勢"
           }
         }
       }
@@ -38793,6 +40509,12 @@
             "state": "translated",
             "value": "Schakel hierboven de algemene sneltoetsen in om je sneltoetsen aan te passen."
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "啟用上方的全域鍵盤快速鍵以自訂你的快速鍵。"
+          }
         }
       }
     },
@@ -38935,6 +40657,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Schakel de zichtbaarheid van grafieken in Instellingen → Statistieken in om prestatiegegevens te bekijken."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在設定 → 統計中啟用圖表可見性以檢視效能資料。"
           }
         }
       }
@@ -39079,6 +40807,12 @@
             "state": "translated",
             "value": "Schakel haptiek in"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "啟用觸覺"
+          }
         }
       }
     },
@@ -39221,6 +40955,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Schakel HUD-vervanging in"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "啟用 HUD 替換"
           }
         }
       }
@@ -39365,6 +41105,12 @@
             "state": "translated",
             "value": "Schakel HUD's in"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "啟用 HUD"
+          }
         }
       }
     },
@@ -39399,6 +41145,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Schakel songteksten in"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "啟用歌詞"
           }
         }
       }
@@ -39435,6 +41187,12 @@
             "state": "translated",
             "value": "Media inschakelen"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "啟用媒體 "
+          }
         }
       }
     },
@@ -39470,6 +41228,12 @@
             "state": "translated",
             "value": "Schakel mediapaneelvervaging in"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "啟用媒體面板模糊"
+          }
         }
       }
     },
@@ -39504,6 +41268,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Schakel microfoondetectie in"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "啟用麥克風偵測"
           }
         }
       }
@@ -39647,6 +41417,12 @@
             "state": "translated",
             "value": "Schakel live muziekactiviteit in"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "啟用音樂即時動態"
+          }
         }
       }
     },
@@ -39681,6 +41457,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Schakel herinnering live-activiteiten in"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "啟用提醒即時動態"
           }
         }
       }
@@ -39830,6 +41612,12 @@
             "state": "translated",
             "value": "Schakel de functionaliteit voor het kiezen van schermkleuren in. Gebruik Cmd+Shift+P om snel toegang te krijgen tot de kleurenkiezer."
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "啟用螢幕取色功能。使用 Cmd+Shift+P 快速存取取色器。"
+          }
         }
       }
     },
@@ -39864,6 +41652,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Schakel schermopnamedetectie in"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "啟用螢幕錄製偵測"
           }
         }
       }
@@ -40006,6 +41800,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Schakel sneak peek in"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "啟用快速預覽"
           }
         }
       }
@@ -40154,6 +41954,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Schakel statistische monitoring in Instellingen in om systeemprestatiegegevens te bekijken."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在設定中啟用統計監控以檢視系統效能資料。"
           }
         }
       }
@@ -40310,6 +42116,12 @@
             "state": "translated",
             "value": "Schakel de weercapsule in en configureer de lay-out, provider, eenheden en optionele batterij-/AQI-indicatoren."
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "啟用天氣膠囊並配置其版面配置、資料來源、單位和可選的電池/AQI 指示器。"
+          }
         }
       }
     },
@@ -40452,6 +42264,12 @@
             "state": "translated",
             "value": "Denkmodus inschakelen"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "啟用思考模式"
+          }
         }
       }
     },
@@ -40486,6 +42304,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Schakel timervervaging in"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "啟用計時器模糊"
           }
         }
       }
@@ -40629,6 +42453,12 @@
             "state": "translated",
             "value": "Schakel de timerfunctie in Instellingen in om dit tabblad te gebruiken"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在設定中啟用計時器功能以使用此分頁"
+          }
         }
       }
     },
@@ -40771,6 +42601,12 @@
             "state": "translated",
             "value": "Schakel live-activiteit van de timer in"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "啟用計時器即時動態"
+          }
         }
       }
     },
@@ -40805,6 +42641,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Schakel vensterschaduw in"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "啟用視窗陰影"
           }
         }
       }
@@ -40949,6 +42791,12 @@
             "state": "translated",
             "value": "Motorgebruik"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "引擎利用率"
+          }
         }
       }
     },
@@ -41090,6 +42938,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Verbeter je ervaring met HUD's"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "用 HUD 提升你的體驗"
           }
         }
       }
@@ -41233,6 +43087,12 @@
             "state": "translated",
             "value": "Geniet van je vrije tijd!"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "享受你的閒暇時光！"
+          }
         }
       }
     },
@@ -41375,6 +43235,12 @@
             "state": "translated",
             "value": "Voer je Gemini API-sleutel in"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "輸入你的 Gemini API 金鑰"
+          }
         }
       }
     },
@@ -41516,6 +43382,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Fout"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "錯誤"
           }
         }
       }
@@ -41660,6 +43532,12 @@
             "state": "translated",
             "value": "Evenementenlijst"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "事件列表"
+          }
         }
       }
     },
@@ -41801,6 +43679,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Sluit apps uit"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "排除 App"
           }
         }
       }
@@ -41944,6 +43828,12 @@
             "state": "translated",
             "value": "Afsluiten"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "退出"
+          }
         }
       }
     },
@@ -42085,6 +43975,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Breid inkeping uit met animatie"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "展開瀏海時帶動畫"
           }
         }
       }
@@ -42229,6 +44125,12 @@
             "state": "translated",
             "value": "Uitgebreide inkepingsbreedte"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "展開的瀏海寬度"
+          }
         }
       }
     },
@@ -42263,6 +44165,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Verleng de inkeping zodat het klembord, de kleurkiezer en andere vervolgpictogrammen zichtbaar blijven op geschaalde schermen (bijvoorbeeld Meer ruimte)."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "延伸功能瀏海範圍，使剪貼簿、取色器和其他尾部圖示在縮放顯示（如更多空間）上保持可見。"
           }
         }
       }
@@ -42407,6 +44315,12 @@
             "state": "translated",
             "value": "Extensies"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "延伸功能"
+          }
         }
       }
     },
@@ -42550,6 +44464,12 @@
             "state": "translated",
             "value": "Extern"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "外接"
+          }
         }
       }
     },
@@ -42584,6 +44504,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Kan crashrapporten niet lezen:"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "讀取崩潰報告失敗："
           }
         }
       }
@@ -42727,6 +44653,12 @@
             "state": "translated",
             "value": "Vul inkeping"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "填充瀏海"
+          }
         }
       }
     },
@@ -42868,6 +44800,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Voltooien"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "完成"
           }
         }
       }
@@ -43011,6 +44949,12 @@
             "state": "translated",
             "value": "Passend bij inkeping"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "適應瀏海"
+          }
         }
       }
     },
@@ -43152,6 +45096,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Focusstatus"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "專注狀態"
           }
         }
       }
@@ -43296,6 +45246,12 @@
             "state": "translated",
             "value": "Beschikbaar · %@"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "可用 · %@"
+          }
         }
       }
     },
@@ -43439,6 +45395,12 @@
             "state": "translated",
             "value": "Volledig opgeladen"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已充滿"
+          }
         }
       }
     },
@@ -43580,6 +45542,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Gemini API-sleutel"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gemini API 金鑰"
           }
         }
       }
@@ -43723,6 +45691,12 @@
             "state": "translated",
             "value": "Algemeen"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "通用"
+          }
         }
       }
     },
@@ -43864,6 +45838,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Gebaarbediening"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "手勢控制"
           }
         }
       }
@@ -44007,6 +45987,12 @@
             "state": "translated",
             "value": "Gevoeligheid van gebaren"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "手勢靈敏度"
+          }
         }
       }
     },
@@ -44148,6 +46134,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Aan de slag"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "開始使用"
           }
         }
       }
@@ -44291,6 +46283,12 @@
             "state": "translated",
             "value": "Ontvang je gratis API-sleutel van Google AI Studio"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "從 Google AI Studio 取得免費 API 金鑰"
+          }
         }
       }
     },
@@ -44429,6 +46427,12 @@
           }
         },
         "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GitHub"
+          }
+        },
+        "zh-Hant": {
           "stringUnit": {
             "state": "translated",
             "value": "GitHub"
@@ -44575,6 +46579,12 @@
             "state": "translated",
             "value": "Begrepen!"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "明白了！"
+          }
         }
       }
     },
@@ -44717,6 +46727,12 @@
             "state": "translated",
             "value": "GPU-gebruik"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GPU 使用率"
+          }
         }
       }
     },
@@ -44858,6 +46874,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Verloop"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "漸變"
           }
         }
       }
@@ -45013,6 +47035,12 @@
             "state": "translated",
             "value": "Verleen Toegankelijkheidstoestemming in Systeeminstellingen om vanaf hier macOS HUD-vervangingen te beheren."
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在系統設定中授予輔助使用權限以從此處控制 macOS HUD 替代。"
+          }
         }
       }
     },
@@ -45167,6 +47195,12 @@
             "state": "translated",
             "value": "Verleen Toegankelijkheidstoestemming in Systeeminstellingen om de schermvervangingen hier aan te passen."
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在系統設定中授予輔助使用權限以自訂螢幕顯示替代。"
+          }
         }
       }
     },
@@ -45308,6 +47342,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Grafiekzichtbaarheid"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "圖表可見性"
           }
         }
       }
@@ -45451,6 +47491,12 @@
             "state": "translated",
             "value": "Hoogte:"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "高度："
+          }
         }
       }
     },
@@ -45592,6 +47638,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Verbergen"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "隱藏"
           }
         }
       }
@@ -45736,6 +47788,12 @@
             "state": "translated",
             "value": "Activiteiten die de hele dag duren verbergen"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "隱藏全天事件"
+          }
         }
       }
     },
@@ -45879,6 +47937,12 @@
             "state": "translated",
             "value": "Verberg voltooide herinneringen"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "隱藏已完成的提醒"
+          }
         }
       }
     },
@@ -46020,6 +48084,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Verberg Dynamic Island-opties"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "隱藏動態島選項"
           }
         }
       }
@@ -46164,6 +48234,12 @@
             "state": "translated",
             "value": "Verbergen voor inkeping"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "從瀏海中隱藏"
+          }
         }
       }
     },
@@ -46306,6 +48382,12 @@
             "state": "translated",
             "value": "Alleen verbergen als de NowPlaying-app op volledig scherm wordt weergegeven"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "僅在「正在播放」全螢幕時隱藏"
+          }
         }
       }
     },
@@ -46447,6 +48529,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Hiërarchisch"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "分級"
           }
         }
       }
@@ -46591,6 +48679,12 @@
             "state": "translated",
             "value": "Hoog"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "高"
+          }
         }
       }
     },
@@ -46732,6 +48826,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Hoogfrequente updates zonder time-out kunnen het batterijgebruik verhogen."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "無超時的高頻更新可能會增加電池消耗。"
           }
         }
       }
@@ -46875,6 +48975,12 @@
             "state": "translated",
             "value": "Geschiedenis Grootte"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "歷史大小"
+          }
         }
       }
     },
@@ -47017,6 +49123,12 @@
             "state": "translated",
             "value": "Horizontaal:"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "水平："
+          }
         }
       }
     },
@@ -47150,6 +49262,12 @@
           }
         },
         "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "https://example.com/animation.json"
+          }
+        },
+        "zh-Hant": {
           "stringUnit": {
             "state": "translated",
             "value": "https://example.com/animation.json"
@@ -47297,6 +49415,12 @@
             "state": "translated",
             "value": "https://github.com/th-ch/youtube-music"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "https://github.com/th-ch/youtube-music"
+          }
         }
       }
     },
@@ -47439,6 +49563,12 @@
             "state": "translated",
             "value": "HUD-stijl"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "HUD 樣式"
+          }
         }
       }
     },
@@ -47580,6 +49710,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "HUD's"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "HUD"
           }
         }
       }
@@ -47736,6 +49872,12 @@
             "state": "translated",
             "value": "HUD's zijn uitgeschakeld omdat Aangepaste OSD is ingeschakeld. Schakel Aangepaste OSD uit op het tabblad Aangepaste OSD om HUD's te gebruiken."
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "由於已啟用自訂 OSD，HUD 已停用。請在自訂 OSD 分頁中停用以使用 HUD。"
+          }
         }
       }
     },
@@ -47878,6 +50020,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Icoon en voortgangskleur"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "圖示和進度顏色"
           }
         }
       }
@@ -48022,6 +50170,12 @@
             "state": "translated",
             "value": "Inactief"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "閒置"
+          }
         }
       }
     },
@@ -48165,6 +50319,12 @@
             "state": "translated",
             "value": "Inactieve animatiestijl"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "閒置動畫樣式"
+          }
         }
       }
     },
@@ -48306,6 +50466,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Importeren"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "匯入"
           }
         }
       }
@@ -48450,6 +50616,12 @@
             "state": "translated",
             "value": "Importfout"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "匯入錯誤"
+          }
         }
       }
     },
@@ -48593,6 +50765,12 @@
             "state": "translated",
             "value": "Bestand importeren..."
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "匯入檔案..."
+          }
         }
       }
     },
@@ -48734,6 +50912,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "In uitvoering"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "進行中"
           }
         }
       }
@@ -48877,6 +51061,12 @@
             "state": "translated",
             "value": "Inactief"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "不活躍"
+          }
         }
       }
     },
@@ -49019,6 +51209,12 @@
             "state": "translated",
             "value": "Inline"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "內嵌"
+          }
         }
       }
     },
@@ -49160,6 +51356,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Inline momentopnamevoorbeeld"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "內聯快照預覽"
           }
         }
       }
@@ -49304,6 +51506,12 @@
             "state": "translated",
             "value": "Updates automatisch installeren"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自動安裝更新"
+          }
         }
       }
     },
@@ -49447,6 +51655,12 @@
             "state": "translated",
             "value": "Geïnstalleerde extensies"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "已安裝延伸功能"
+          }
         }
       }
     },
@@ -49580,6 +51794,12 @@
           }
         },
         "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "IPv4 · %@"
+          }
+        },
+        "zh-Hant": {
           "stringUnit": {
             "state": "translated",
             "value": "IPv4 · %@"
@@ -49722,6 +51942,12 @@
             "state": "translated",
             "value": "IPv6 · %@"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "IPv6 · %@"
+          }
         }
       },
       "shouldTranslate": false
@@ -49758,6 +51984,12 @@
             "state": "translated",
             "value": "Sleutel"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "金鑰"
+          }
         }
       }
     },
@@ -49786,6 +52018,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Sleutel 1"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "金鑰 1"
           }
         }
       }
@@ -49928,6 +52166,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Toetsenbordverlichting HUD"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "鍵盤背光 HUD"
           }
         }
       }
@@ -50072,6 +52316,12 @@
             "state": "translated",
             "value": "Toetsenbordverlichting OSD"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "鍵盤背光 OSD"
+          }
         }
       }
     },
@@ -50213,6 +52463,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Sneltoetsen zijn uitgeschakeld"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "鍵盤快速鍵已停用"
           }
         }
       }
@@ -50356,6 +52612,12 @@
             "state": "translated",
             "value": "Laatst bijgewerkt"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "上次更新"
+          }
         }
       }
     },
@@ -50498,6 +52760,12 @@
             "state": "translated",
             "value": "Later"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "稍後再說"
+          }
         }
       }
     },
@@ -50532,6 +52800,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Start bij inloggen"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "登入時啟動"
           }
         }
       }
@@ -50676,6 +52950,12 @@
             "state": "translated",
             "value": "Indeling"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "版面配置"
+          }
         }
       }
     },
@@ -50818,6 +53098,12 @@
             "state": "translated",
             "value": "Licentiesleutel"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "許可證金鑰"
+          }
         }
       }
     },
@@ -50950,6 +53236,12 @@
           }
         },
         "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "LinkedIn"
+          }
+        },
+        "zh-Hant": {
           "stringUnit": {
             "state": "translated",
             "value": "LinkedIn"
@@ -51096,6 +53388,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Voor Liquid Glass is macOS 26 of hoger vereist."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "液態玻璃需要 macOS 26 或更高版本。"
           }
         }
       }
@@ -51245,6 +53543,12 @@
             "state": "translated",
             "value": "Luistert naar wijzigingen in de Focus-sessie via gedistribueerde meldingen"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "透過分散式通知監聽專注模式工作階段變化"
+          }
         }
       }
     },
@@ -51387,6 +53691,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "LEEF"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "直播"
           }
         }
       }
@@ -51531,6 +53841,12 @@
             "state": "translated",
             "value": "Live activiteiten"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "即時動態"
+          }
         }
       }
     },
@@ -51673,6 +53989,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Live activiteit en feedback"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "即時動態與回饋"
           }
         }
       }
@@ -51817,6 +54139,12 @@
             "state": "translated",
             "value": "Live-monitoring"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "即時監控"
+          }
         }
       }
     },
@@ -51958,6 +54286,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Live prestatiegegevens"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "即時效能資料"
           }
         }
       }
@@ -52102,6 +54436,12 @@
             "state": "translated",
             "value": "Live voorbeeld"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "即時預覽"
+          }
         }
       }
     },
@@ -52244,6 +54584,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Livestream-indicator"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "直播指示器"
           }
         }
       }
@@ -52388,6 +54734,12 @@
             "state": "translated",
             "value": "Gemiddeld laden"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "負載平均值"
+          }
         }
       }
     },
@@ -52530,6 +54882,12 @@
             "state": "translated",
             "value": "Vergrendelscherm"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "鎖定畫面"
+          }
         }
       }
     },
@@ -52671,6 +55029,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Integratie van vergrendelscherm"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "鎖定畫面整合"
           }
         }
       }
@@ -52815,6 +55179,12 @@
             "state": "translated",
             "value": "Voorbeeld van vergrendelschermpaneel"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "鎖定畫面面板預覽"
+          }
         }
       }
     },
@@ -52957,6 +55327,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Positionering van het vergrendelscherm"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "鎖定畫面定位"
           }
         }
       }
@@ -53101,6 +55477,12 @@
             "state": "translated",
             "value": "Herinneringswidget voor vergrendelscherm"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "鎖定畫面提醒小工具"
+          }
         }
       }
     },
@@ -53124,6 +55506,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "หน้าจอล็อก"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "鎖定畫面"
           }
         }
       }
@@ -53267,6 +55655,12 @@
             "state": "translated",
             "value": "Loop-modus"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "迴圈模式"
+          }
         }
       }
     },
@@ -53409,6 +55803,12 @@
             "state": "translated",
             "value": "Lusmodus:"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "迴圈模式："
+          }
         }
       }
     },
@@ -53550,6 +55950,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Lottie JSON-URL"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Lottie JSON 連結"
           }
         }
       }
@@ -53694,6 +56100,12 @@
             "state": "translated",
             "value": "Laag"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "低"
+          }
         }
       }
     },
@@ -53835,6 +56247,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Low Power-modus"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "低電量模式"
           }
         }
       }
@@ -53979,6 +56397,12 @@
             "state": "translated",
             "value": "Mac-batterij op %d procent"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mac 電池電量 %d%%"
+          }
         }
       }
     },
@@ -54121,6 +56545,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "macOS 15 of hoger vereist"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "需要 macOS 15 或更高版本"
           }
         }
       }
@@ -54270,6 +56700,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Met ❤️ gemaakt door Ebullioscopic"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "由 Ebullioscopic 用 ❤️ 製作"
           }
         }
       }
@@ -54426,6 +56862,12 @@
             "state": "translated",
             "value": "Beheer indicatorvoorkeuren via Instellingen → Privacy. Er is geen handmatige microfoonschakelaar vereist."
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在設定 → 隱私中管理指示器偏好。無需手動切換麥克風。"
+          }
         }
       }
     },
@@ -54567,6 +57009,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Beheer de Kloktimer vanuit de Klok-app."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "從時鐘 App 管理時鐘計時器。"
           }
         }
       }
@@ -54711,6 +57159,12 @@
             "state": "translated",
             "value": "Markeer als voltooid"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "標記為完成"
+          }
         }
       }
     },
@@ -54854,6 +57308,12 @@
             "state": "translated",
             "value": "Markeer als onvolledig"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "標記為未完成"
+          }
         }
       }
     },
@@ -54996,6 +57456,12 @@
             "state": "translated",
             "value": "Pas de hoogte van de menubalk aan"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "匹配選單列高度"
+          }
         }
       }
     },
@@ -55137,6 +57603,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Overeenkomen met de echte inkepingsgrootte"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "匹配Notch真實大小"
           }
         }
       }
@@ -55281,6 +57753,12 @@
             "state": "translated",
             "value": "Materiaal"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "材質"
+          }
         }
       }
     },
@@ -55424,6 +57902,12 @@
             "state": "translated",
             "value": "Materiële opties:"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "材質選項："
+          }
         }
       }
     },
@@ -55566,6 +58050,12 @@
             "state": "translated",
             "value": "Maximale capaciteit: %lld%%"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "最大容量：%lld%%"
+          }
         }
       }
     },
@@ -55707,6 +58197,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Media"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "媒體"
           }
         }
       }
@@ -55851,6 +58347,12 @@
             "state": "translated",
             "value": "Mediaverandering met horizontale gebaren"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "橫向手勢改變媒體"
+          }
         }
       }
     },
@@ -55993,6 +58495,12 @@
             "state": "translated",
             "value": "Mediabediening"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "媒體控制"
+          }
         }
       }
     },
@@ -56134,6 +58642,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Time-out voor media-inactiviteit"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "媒體非活動超時"
           }
         }
       }
@@ -56278,6 +58792,12 @@
             "state": "translated",
             "value": "Live activiteit voor media"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "媒體即時動態"
+          }
         }
       }
     },
@@ -56420,6 +58940,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Media-uitvoer"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "媒體輸出"
           }
         }
       }
@@ -56564,6 +59090,12 @@
             "state": "translated",
             "value": "Mediapaneel"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "媒體面板"
+          }
         }
       }
     },
@@ -56706,6 +59238,12 @@
             "state": "translated",
             "value": "Live activiteit voor het afspelen van media"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "媒體播放即時動態"
+          }
         }
       }
     },
@@ -56847,6 +59385,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Mediabron"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "媒體來源"
           }
         }
       }
@@ -56991,6 +59535,12 @@
             "state": "translated",
             "value": "Middelmatig"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "中"
+          }
         }
       }
     },
@@ -57132,6 +59682,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Geheugengebruik"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "記憶體使用情況"
           }
         }
       }
@@ -57276,6 +59832,12 @@
             "state": "translated",
             "value": "Menubalkpictogram"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "選單列圖示"
+          }
         }
       }
     },
@@ -57418,6 +59980,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Microfoon %@"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "麥克風 %@"
           }
         }
       }
@@ -57562,6 +60130,12 @@
             "state": "translated",
             "value": "Microfoon gedempt"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "麥克風已靜音"
+          }
         }
       }
     },
@@ -57704,6 +60278,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Microfoon uitgeschakeld"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "麥克風已取消靜音"
           }
         }
       }
@@ -57848,6 +60428,12 @@
             "state": "translated",
             "value": "Microfoon"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "麥克風"
+          }
         }
       }
     },
@@ -57990,6 +60576,12 @@
             "state": "translated",
             "value": "Microfoon actief"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "麥克風已啟用"
+          }
         }
       }
     },
@@ -58024,6 +60616,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Microfoon wordt gebruikt door een applicatie"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "麥克風正被某個 App 使用"
           }
         }
       }
@@ -58180,6 +60778,12 @@
             "state": "translated",
             "value": "De microfoonprivacy-indicator wordt automatisch uitgevoerd wanneer apps toegang krijgen tot audio."
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "麥克風隱私指示器在 App 存取音訊時自動執行。"
+          }
         }
       }
     },
@@ -58322,6 +60926,12 @@
             "state": "translated",
             "value": "Microfoonstatus"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "麥克風狀態"
+          }
         }
       }
     },
@@ -58463,6 +61073,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "min"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "分鐘"
           }
         }
       }
@@ -58618,6 +61234,12 @@
             "state": "translated",
             "value": "De minimalistische modus richt zich op mediabediening en systeem-HUD's en verbergt alle extra functies voor een heldere, gerichte ervaring. Schakelt automatisch eenvoudigere animaties in."
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "簡約模式專注於媒體控制和系統 HUD，隱藏所有額外功能以提供簡潔、專注的體驗。自動啟用更簡單的動畫。"
+          }
         }
       }
     },
@@ -58759,6 +61381,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Minimale hoverduur"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "懸停最短時長"
           }
         }
       }
@@ -58903,6 +61531,12 @@
             "state": "translated",
             "value": "Minuten"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "分鐘"
+          }
         }
       }
     },
@@ -59044,6 +61678,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Spiegel"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "鏡子"
           }
         }
       }
@@ -59187,6 +61827,12 @@
             "state": "translated",
             "value": "Spiegelvorm"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "鏡子大小"
+          }
         }
       }
     },
@@ -59215,6 +61861,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Spiegelsysteemtimer"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "同步系統計時器"
           }
         }
       }
@@ -59370,6 +62022,12 @@
             "state": "translated",
             "value": "Spiegelt de schakelaar onder de instellingen van het vergrendelscherm, zodat timerspecifieke workflows de widget kunnen in- of uitschakelen zonder van tabblad te wisselen."
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "鏡像鎖定畫面設定中的開關，以便計時器工作流可以無需切換分頁即可啟用或停用小工具。"
+          }
         }
       }
     },
@@ -59524,6 +62182,12 @@
             "state": "translated",
             "value": "Controleer wijzigingen op het klembord en houd een geschiedenis bij van recente kopieën. Gebruik Cmd+Shift+V om snel toegang te krijgen tot de klembordgeschiedenis."
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "監控剪貼簿變化並保留最近複製的歷史記錄。使用 Cmd+Shift+V 快速存取剪貼簿歷史。"
+          }
         }
       }
     },
@@ -59666,6 +62330,12 @@
             "state": "translated",
             "value": "Gedrag monitoren"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "監控行為"
+          }
         }
       }
     },
@@ -59807,6 +62477,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Bewakingsstatus"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "監控狀態"
           }
         }
       }
@@ -59951,6 +62627,12 @@
             "state": "translated",
             "value": "Controle gestopt"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "監控已停止"
+          }
         }
       }
     },
@@ -60092,6 +62774,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Meer"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "更多"
           }
         }
       }
@@ -60236,6 +62924,12 @@
             "state": "translated",
             "value": "Ga naar beneden"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "下移"
+          }
         }
       }
     },
@@ -60379,6 +63073,12 @@
             "state": "translated",
             "value": "Ga omhoog"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "上移"
+          }
         }
       }
     },
@@ -60521,6 +63221,12 @@
             "state": "translated",
             "value": "Muziekbron"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "音樂源"
+          }
         }
       }
     },
@@ -60662,6 +63368,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "gedempt"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "已靜音"
           }
         }
       }
@@ -60806,6 +63518,12 @@
             "state": "translated",
             "value": "Mijn animatie"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "我的動畫"
+          }
         }
       }
     },
@@ -60947,6 +63665,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Naam"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "名稱"
           }
         }
       }
@@ -61090,6 +63814,12 @@
             "state": "translated",
             "value": "Navigatie"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "導航"
+          }
         }
       }
     },
@@ -61231,6 +63961,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Opnieuw opstarten nodig"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "需要重啟"
           }
         }
       }
@@ -61374,6 +64110,12 @@
             "state": "translated",
             "value": "Netwerk downloaden"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "網路下載"
+          }
         }
       }
     },
@@ -61516,6 +64258,12 @@
             "state": "translated",
             "value": "Netwerk uploaden"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "網路上傳"
+          }
         }
       }
     },
@@ -61657,6 +64405,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Nooit verbergen"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "永不隱藏"
           }
         }
       }
@@ -61801,6 +64555,12 @@
             "state": "translated",
             "value": "Nog geen actieve interfaces gedetecteerd."
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "尚未偵測到活躍網路介面。"
+          }
         }
       }
     },
@@ -61944,6 +64704,12 @@
             "state": "translated",
             "value": "Geen audio-uitgangen beschikbaar"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "無可用音訊輸出"
+          }
         }
       }
     },
@@ -62085,6 +64851,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Geen klembordgeschiedenis"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "無剪貼簿歷史"
           }
         }
       }
@@ -62228,6 +65000,12 @@
             "state": "translated",
             "value": "Geen kleuren gevonden"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未找到顏色"
+          }
         }
       }
     },
@@ -62369,6 +65147,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Er komen geen kleuren overeen met '%@'"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "沒有顏色匹配 '%@'"
           }
         }
       }
@@ -62512,6 +65296,12 @@
             "state": "translated",
             "value": "Nog geen kleuren"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "暫無顏色"
+          }
         }
       }
     },
@@ -62654,6 +65444,12 @@
             "state": "translated",
             "value": "Geen aangepaste animatie beschikbaar"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "沒有可用的自訂動畫"
+          }
         }
       }
     },
@@ -62795,6 +65591,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Geen aangepaste visualisatie"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "沒有自訂視覺化器"
           }
         }
       }
@@ -62939,6 +65741,12 @@
             "state": "translated",
             "value": "Geen activiteiten"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "無事件"
+          }
         }
       }
     },
@@ -63081,6 +65889,12 @@
             "state": "translated",
             "value": "Geen activiteiten vandaag"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "今天無日程"
+          }
         }
       }
     },
@@ -63222,6 +66036,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Geen uitgesloten apps"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "無排除的 App"
           }
         }
       }
@@ -63366,6 +66186,12 @@
             "state": "translated",
             "value": "Geen uitsluitingen"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "無排除項"
+          }
         }
       }
     },
@@ -63509,6 +66335,12 @@
             "state": "translated",
             "value": "Geen extensie geïnstalleerd"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "未安裝延伸功能"
+          }
         }
       }
     },
@@ -63650,6 +66482,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Geen favorieten"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "無收藏"
           }
         }
       }
@@ -63793,6 +66631,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Geen grafieken ingeschakeld"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未啟用圖表"
           }
         }
       }
@@ -63949,6 +66793,12 @@
             "state": "translated",
             "value": "Geen voorinstellingen geconfigureerd. Voeg een voorinstelling toe om deze in de timer-popover te laten verschijnen."
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未配置預設組合。新增預設組合使其出現在計時器彈出式視窗中。"
+          }
         }
       }
     },
@@ -64098,6 +66948,12 @@
             "state": "translated",
             "value": "Nog geen procesgegevens. Houd de statistieken even open."
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "尚無程序資料。請保持統計開啟片刻。"
+          }
         }
       }
     },
@@ -64240,6 +67096,12 @@
             "state": "translated",
             "value": "Geen resultaten"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "無結果"
+          }
         }
       }
     },
@@ -64381,6 +67243,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Geen resultaten gevonden"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未找到結果"
           }
         }
       }
@@ -64525,6 +67393,12 @@
             "state": "translated",
             "value": "Nog geen opslagapparaten gedetecteerd."
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "尚未偵測到儲存裝置。"
+          }
         }
       }
     },
@@ -64666,6 +67540,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Weergavehoogte zonder inkeping"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "非Notch顯示高度"
           }
         }
       }
@@ -64810,6 +67690,12 @@
             "state": "translated",
             "value": "Niet actief"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "不活躍"
+          }
         }
       }
     },
@@ -64951,6 +67837,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Niet nu"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "不是現在"
           }
         }
       }
@@ -65094,6 +67986,12 @@
             "state": "translated",
             "value": "Niet ingesteld"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未設定"
+          }
         }
       }
     },
@@ -65235,6 +68133,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Gedrag van inkeping"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Notch行為"
           }
         }
       }
@@ -65378,6 +68282,12 @@
             "state": "translated",
             "value": "Inkeping weergavehoogte"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Notch顯示高度"
+          }
         }
       }
     },
@@ -65519,6 +68429,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Inkeping hoogte"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Notch高度"
           }
         }
       }
@@ -65663,6 +68579,12 @@
             "state": "translated",
             "value": "Inkepingsbreedte"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "瀏海寬度"
+          }
         }
       }
     },
@@ -65806,6 +68728,12 @@
             "state": "translated",
             "value": "Eerder op de hoogte stellen"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "提前通知"
+          }
         }
       }
     },
@@ -65947,6 +68875,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Oké"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "好的"
           }
         }
       }
@@ -66090,6 +69024,12 @@
             "state": "translated",
             "value": "Een of meer bestanden konden niet worden geladen"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "一個或多個檔案載入失敗"
+          }
         }
       }
     },
@@ -66231,6 +69171,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Alleen app-pictogram"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "僅 App 圖示"
           }
         }
       }
@@ -66374,6 +69320,12 @@
             "state": "translated",
             "value": "Alleen downloadpictogram"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "僅下載圖示"
+          }
         }
       }
     },
@@ -66515,6 +69467,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Dekking:"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "透明度："
           }
         }
       }
@@ -66664,6 +69622,12 @@
             "state": "translated",
             "value": "Open Google AI Studio"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "開啟 Google AI Studio"
+          }
         }
       }
     },
@@ -66806,6 +69770,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Openen in agenda"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在行事曆中開啟"
           }
         }
       }
@@ -66955,6 +69925,12 @@
             "state": "translated",
             "value": "Open Modelinstellingen"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "開啟模型設定"
+          }
         }
       }
     },
@@ -66989,6 +69965,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Open noch bij hover"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "懸停時開啟瀏海"
           }
         }
       }
@@ -67132,6 +70114,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Instellingen openen"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "開啟設定"
           }
         }
       }
@@ -67280,6 +70268,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Open Systeeminstellingen"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "開啟系統設定"
           }
         }
       }
@@ -67435,6 +70429,12 @@
             "state": "translated",
             "value": "Opent het AI-assistentpaneel voor bestandsanalyse en conversatie. Standaard is Cmd+Shift+A. Werkt alleen als de schermassistentfunctie is ingeschakeld."
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "開啟 AI 助理面板，進行檔案分析與對話。預設為 Cmd+Shift+A。僅在啟用螢幕助理功能時有效。"
+          }
         }
       }
     },
@@ -67588,6 +70588,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Opent het klembordgeschiedenispaneel. Standaard is Cmd+Shift+V (vergelijkbaar met Windows+V op pc). Werkt alleen als de klembordfunctie is ingeschakeld."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "開啟剪貼簿歷史記錄面板。預設為 Cmd+Shift+V（類似於 PC 上的 Windows+V）。僅在啟用剪貼簿功能時有效。"
           }
         }
       }
@@ -67743,6 +70749,12 @@
             "state": "translated",
             "value": "Opent het kleurkiezerpaneel voor het vastleggen van schermkleuren. Standaard is Cmd+Shift+P. Werkt alleen als de kleurkiezerfunctie is ingeschakeld."
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "開啟取色器面板進行螢幕顏色捕獲。預設為 Cmd+Shift+P。僅在啟用取色器功能時有效。"
+          }
         }
       }
     },
@@ -67886,6 +70898,12 @@
             "state": "translated",
             "value": "Uitvoerapparaten"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "輸出裝置"
+          }
         }
       }
     },
@@ -68028,6 +71046,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Uitvoervolume"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "輸出音量"
           }
         }
       }
@@ -68183,6 +71207,12 @@
             "state": "translated",
             "value": "De paneelmodus toont het klembord in een zwevend venster nabij de inkeping. De popover-modus toont het klembord als een vervolgkeuzelijst die aan de klembordknop is gekoppeld."
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "面板模式會在瀏海附近的浮動視窗中顯示剪貼簿。彈出模式會將剪貼簿顯示為附加在剪貼簿按鈕上的下拉選單。"
+          }
         }
       }
     },
@@ -68336,6 +71366,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Paneelmodus toont de kleurkiezer in een zwevend venster. De popover-modus toont de kleurkiezer als een vervolgkeuzelijst die aan de kleurkiezerknop is gekoppeld."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "面板模式會在浮動視窗中顯示取色器。彈出模式會將取色器顯示為附加在取色器按鈕上的下拉選單。"
           }
         }
       }
@@ -68491,6 +71527,12 @@
             "state": "translated",
             "value": "Paneelmodus toont de assistent in een zwevend venster nabij de inkeping. De popover-modus toont de assistent als een vervolgkeuzelijst die aan de AI-knop is gekoppeld."
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "面板模式會在瀏海附近的浮動視窗中顯示助理。彈出模式會將助理顯示為附加在 AI 按鈕上的下拉選單。"
+          }
         }
       }
     },
@@ -68632,6 +71674,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Pauze"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "暫停"
           }
         }
       }
@@ -68775,6 +71823,12 @@
             "state": "translated",
             "value": "Gepauzeerd"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已暫停"
+          }
         }
       }
     },
@@ -68916,6 +71970,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Percentage"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "百分比"
           }
         }
       }
@@ -69059,6 +72119,12 @@
             "state": "translated",
             "value": "Machtigingen"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "權限"
+          }
         }
       }
     },
@@ -69200,6 +72266,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Kies kleur"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "取色"
           }
         }
       }
@@ -69343,6 +72415,12 @@
             "state": "translated",
             "value": "Gekozen %@"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已選取 %@"
+          }
         }
       }
     },
@@ -69484,6 +72562,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Gekozen kleur"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "拾取的顏色"
           }
         }
       }
@@ -69627,6 +72711,12 @@
             "state": "translated",
             "value": "Pickstatus"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "拾取狀態"
+          }
         }
       }
     },
@@ -69768,6 +72858,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Pin items uit de geschiedenis om ze hier op te slaan"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "從歷史記錄中固定項目以儲存在此處"
           }
         }
       }
@@ -69911,6 +73007,12 @@
             "state": "translated",
             "value": "Zet items vast om favorieten toe te voegen"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "固定項目以新增收藏"
+          }
         }
       }
     },
@@ -70053,6 +73155,12 @@
             "state": "translated",
             "value": "Pin items om ze aan favorieten toe te voegen"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "固定項目以將它們新增到收藏夾"
+          }
         }
       }
     },
@@ -70194,6 +73302,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Vastgezette items"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已固定項目"
           }
         }
       }
@@ -70343,6 +73457,12 @@
             "state": "translated",
             "value": "Configureer je API-sleutel voor de geselecteerde AI-provider in de modelinstellingen."
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "請在模型設定中為所選的 AI 提供商配置你的 API 金鑰。"
+          }
         }
       }
     },
@@ -70485,6 +73605,12 @@
             "state": "translated",
             "value": "Aangesloten"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "已插入"
+          }
         }
       }
     },
@@ -70519,6 +73645,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "plus"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "加"
           }
         }
       }
@@ -70674,6 +73806,12 @@
             "state": "translated",
             "value": "De popover-modus toont het klembord als een vervolgkeuzelijst die aan de klembordknop is gekoppeld. De paneelmodus toont het klembord in een zwevend venster nabij de inkeping."
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "彈出模式會將剪貼簿顯示為附加在剪貼簿按鈕上的下拉選單。面板模式會在瀏海附近的浮動視窗中顯示剪貼簿。"
+          }
         }
       }
     },
@@ -70827,6 +73965,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "De popover-modus toont de kleurkiezer als een vervolgkeuzelijst die aan de kleurkiezerknop is gekoppeld. Paneelmodus toont de kleurkiezer in een zwevend venster."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "彈出模式會將取色器顯示為附加在取色器按鈕上的下拉選單。面板模式會在浮動視窗中顯示取色器。"
           }
         }
       }
@@ -70982,6 +74126,12 @@
             "state": "translated",
             "value": "De popover-modus toont de assistent als een vervolgkeuzelijst die aan de AI-knop is gekoppeld. Paneelmodus toont de assistent in een zwevend venster nabij de inkeping."
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "彈出模式會將助理顯示為附加在 AI 按鈕上的下拉選單。面板模式會在瀏海附近的浮動視窗中顯示助理。"
+          }
         }
       }
     },
@@ -71123,6 +74273,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Positie"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "位置"
           }
         }
       }
@@ -71267,6 +74423,12 @@
             "state": "translated",
             "value": "Vooraf ingestelde naam"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "預設組合名稱"
+          }
         }
       }
     },
@@ -71409,6 +74571,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Voorinstellingen"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "預設組合"
           }
         }
       }
@@ -71565,6 +74733,12 @@
             "state": "translated",
             "value": "Voorinstellingen verschijnen in de timer-popover met de geconfigureerde naam, duur en accentkleur. Herschik ze om de weergavevolgorde te wijzigen."
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "預設組合將顯示在計時器彈出式視窗中，包括配置的名稱、持續時間和重音顏色。重新排序以更改顯示順序。"
+          }
         }
       }
     },
@@ -71708,6 +74882,12 @@
             "state": "translated",
             "value": "Druk"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "氣壓"
+          }
         }
       }
     },
@@ -71850,6 +75030,12 @@
             "state": "translated",
             "value": "Voorbeeld"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "預覽"
+          }
         }
       }
     },
@@ -71991,6 +75177,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Voorbeeldzoom:"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "預覽縮放："
           }
         }
       }
@@ -72135,6 +75327,12 @@
             "state": "translated",
             "value": "Privacy-indicatoren"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "隱私指示器"
+          }
         }
       }
     },
@@ -72278,6 +75476,12 @@
             "state": "translated",
             "value": "Privacybeleid"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "隱私政策"
+          }
         }
       }
     },
@@ -72419,6 +75623,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Voortgangsbalk"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "進度條"
           }
         }
       }
@@ -72562,6 +75772,12 @@
             "state": "translated",
             "value": "Vooruitgangsstijl"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "進度樣式"
+          }
         }
       }
     },
@@ -72703,6 +75919,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Progressbar-stijl"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "進度條樣式"
           }
         }
       }
@@ -72846,6 +76068,12 @@
             "state": "translated",
             "value": "Snelle acties"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "快捷操作"
+          }
         }
       }
     },
@@ -72987,6 +76215,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Snelle voorinstellingen"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "快捷預設組合"
           }
         }
       }
@@ -73131,6 +76365,12 @@
             "state": "translated",
             "value": "Snel beginnen"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "快速開始"
+          }
         }
       }
     },
@@ -73273,6 +76513,12 @@
             "state": "translated",
             "value": "Stoppen"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "退出"
+          }
         }
       }
     },
@@ -73414,6 +76660,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Sluit de app af"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "退出 App"
           }
         }
       }
@@ -73558,6 +76810,12 @@
             "state": "translated",
             "value": "Stop met boring.notch"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "退出 boring.notch"
+          }
         }
       }
     },
@@ -73701,6 +76959,12 @@
             "state": "translated",
             "value": "Lees"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "讀取"
+          }
         }
       }
     },
@@ -73842,6 +77106,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Klaar"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "就緒"
           }
         }
       }
@@ -73985,6 +77255,12 @@
             "state": "translated",
             "value": "Redeneringsmodus"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "推理模式"
+          }
         }
       }
     },
@@ -74127,6 +77403,12 @@
             "state": "translated",
             "value": "Recente kleuren"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "最近顏色"
+          }
         }
       }
     },
@@ -74268,6 +77550,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Opname"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "錄製中"
           }
         }
       }
@@ -74412,6 +77700,12 @@
             "state": "translated",
             "value": "Opname gedetecteerd"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "偵測到錄製"
+          }
         }
       }
     },
@@ -74553,6 +77847,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Opnamestatus"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "錄製狀態"
           }
         }
       }
@@ -74696,6 +77996,12 @@
             "state": "translated",
             "value": "Naam van uitgave"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "版本名稱"
+          }
         }
       }
     },
@@ -74837,6 +78143,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Onthoud het laatste tabblad"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "記住上一個分頁"
           }
         }
       }
@@ -74981,6 +78293,12 @@
             "state": "translated",
             "value": "Live activiteit voor herinneringen"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "提醒即時動態"
+          }
         }
       }
     },
@@ -75122,6 +78440,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Herinneringen"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "提醒事項"
           }
         }
       }
@@ -75272,6 +78596,12 @@
             "state": "translated",
             "value": "Vervangt de HUD van het macOS-systeem door Dynamic Island-schermen voor volume, helderheid en toetsenbordverlichting."
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "使用動態島顯示替換 macOS 系統 HUD 的音量、亮度和鍵盤背光。"
+          }
         }
       }
     },
@@ -75413,6 +78743,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Toegang aanvragen"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "請求存取"
           }
         }
       }
@@ -75556,6 +78892,12 @@
             "state": "translated",
             "value": "Opnieuw instellen"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重置"
+          }
         }
       }
     },
@@ -75698,6 +79040,12 @@
             "state": "translated",
             "value": "Alles resetten"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "全部重置"
+          }
         }
       }
     },
@@ -75733,6 +79081,12 @@
             "state": "translated",
             "value": "Muziek resetten"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重置音樂"
+          }
         }
       }
     },
@@ -75767,6 +79121,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Timer opnieuw instellen"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重置計時器"
           }
         }
       }
@@ -75910,6 +79270,12 @@
             "state": "translated",
             "value": "Terugzetten naar standaard"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "恢復預設"
+          }
         }
       }
     },
@@ -75944,6 +79310,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Weer opnieuw instellen"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重置天氣"
           }
         }
       }
@@ -76088,6 +79460,12 @@
             "state": "translated",
             "value": "Breedte opnieuw instellen"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重置寬度"
+          }
         }
       }
     },
@@ -76231,6 +79609,12 @@
             "state": "translated",
             "value": "Opnieuw opstarten"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "重啟"
+          }
         }
       }
     },
@@ -76372,6 +79756,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Atoll opnieuw starten"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重啟 Atoll"
           }
         }
       }
@@ -76516,6 +79906,12 @@
             "state": "translated",
             "value": "Herstellen"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "恢復"
+          }
         }
       }
     },
@@ -76658,6 +80054,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Standaard timervoorinstellingen herstellen?"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "恢復預設計時器預設組合？"
           }
         }
       }
@@ -76802,6 +80204,12 @@
             "state": "translated",
             "value": "Standaardinstellingen herstellen"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "恢復預設"
+          }
         }
       }
     },
@@ -76943,6 +80351,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Hervatten"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "繼續"
           }
         }
       }
@@ -77086,6 +80500,12 @@
             "state": "translated",
             "value": "Rotatie:"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "旋轉："
+          }
         }
       }
     },
@@ -77222,6 +80642,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Rennen"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "執行中"
           }
         }
       }
@@ -77371,6 +80797,12 @@
             "state": "translated",
             "value": "Het bemonsteren kan doorgaan terwijl de inkeping gesloten is als de time-out is uitgeschakeld."
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "停用超時後，取樣可以在瀏海關閉時繼續。"
+          }
         }
       }
     },
@@ -77512,6 +80944,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Opslaan"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "儲存"
           }
         }
       }
@@ -77655,6 +81093,12 @@
             "state": "translated",
             "value": "Wijzigingen opslaan"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "儲存更改"
+          }
         }
       }
     },
@@ -77796,6 +81240,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Configuratie opslaan"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "儲存配置"
           }
         }
       }
@@ -77939,6 +81389,12 @@
             "state": "translated",
             "value": "Schaal omlaag"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "縮小"
+          }
         }
       }
     },
@@ -78080,6 +81536,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "2x opschalen"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "放大 2x"
           }
         }
       }
@@ -78223,6 +81685,12 @@
             "state": "translated",
             "value": "Schaal:"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "縮放："
+          }
         }
       }
     },
@@ -78365,6 +81833,12 @@
             "state": "translated",
             "value": "Schermassistent"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "螢幕助理"
+          }
         }
       }
     },
@@ -78506,6 +81980,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "De functie Schermassistent is uitgeschakeld"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "螢幕助理功能已停用"
           }
         }
       }
@@ -78651,6 +82131,12 @@
             "state": "translated",
             "value": "Schermassistent:"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "螢幕助理："
+          }
         }
       }
     },
@@ -78679,6 +82165,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Schermopvulling: %@px"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "螢幕邊距：%@畫素"
           }
         }
       }
@@ -78822,6 +82314,12 @@
             "state": "translated",
             "value": "Schermopname"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "螢幕錄製"
+          }
         }
       }
     },
@@ -78963,6 +82461,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Screenshot-opties"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "截圖選項"
           }
         }
       }
@@ -79106,6 +82610,12 @@
             "state": "translated",
             "value": "Schermafdruktype"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "截圖型別"
+          }
         }
       }
     },
@@ -79140,6 +82650,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Blader door de apparaatnaam in HUD"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 HUD 中滾動顯示裝置名稱"
           }
         }
       }
@@ -79283,6 +82799,12 @@
             "state": "translated",
             "value": "Klembord zoeken..."
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "搜尋剪貼簿..."
+          }
         }
       }
     },
@@ -79424,6 +82946,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Kleuren zoeken..."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "搜尋顏色..."
           }
         }
       }
@@ -79568,6 +83096,12 @@
             "state": "translated",
             "value": "Zoek naar instellingen"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "搜尋設定"
+          }
         }
       }
     },
@@ -79709,6 +83243,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Zoeken..."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "搜尋..."
           }
         }
       }
@@ -79852,6 +83392,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "seconden"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "秒"
           }
         }
       }
@@ -79997,6 +83543,12 @@
             "state": "translated",
             "value": "Seconden"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "秒"
+          }
         }
       }
     },
@@ -80139,6 +83691,12 @@
             "state": "translated",
             "value": "Gesegmenteerd"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "分段"
+          }
         }
       }
     },
@@ -80280,6 +83838,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Selecteer een kleur om details te bekijken"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "選擇顏色檢視詳情"
           }
         }
       }
@@ -80430,6 +83994,12 @@
             "state": "translated",
             "value": "Selecteer een aangepast geluid om af te spelen wanneer een timer afloopt. Ondersteunde formaten zijn onder meer MP3, M4A, WAV en AIFF."
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "選擇計時器結束時播放的自訂聲音。支援格式包括 MP3、M4A、WAV 和 AIFF。"
+          }
         }
       }
     },
@@ -80571,6 +84141,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Selecteer agenda's"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "選擇行事曆"
           }
         }
       }
@@ -80715,6 +84291,12 @@
             "state": "translated",
             "value": "Selecteer een of meer profielen om je ervaring aan te passen"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "選擇一個或多個配置檔案以自訂你的體驗"
+          }
         }
       }
     },
@@ -80857,6 +84439,12 @@
             "state": "translated",
             "value": "Selecteer de muziekbron die je wilt gebruiken. Je kunt dit later wijzigen in de app-instellingen."
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "選擇你想要使用的音樂源。你可以稍後在 App 設定中更改此項。"
+          }
         }
       }
     },
@@ -80998,6 +84586,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "geselecteerd"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "已選擇"
           }
         }
       }
@@ -81142,6 +84736,12 @@
             "state": "translated",
             "value": "Geselecteerd"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已選擇"
+          }
         }
       }
     },
@@ -81283,6 +84883,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Geselecteerde animatie"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "所選動畫"
           }
         }
       }
@@ -81427,6 +85033,12 @@
             "state": "translated",
             "value": "Gevoeligheid"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "靈敏度"
+          }
         }
       }
     },
@@ -81570,6 +85182,12 @@
             "state": "translated",
             "value": "Sessie · ↓ %1$@ · ↑ %2$@"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "工作階段 · ↓ %@ · ↑ %@"
+          }
         }
       }
     },
@@ -81711,6 +85329,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Instellen"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "設定"
           }
         }
       }
@@ -81854,6 +85478,12 @@
             "state": "translated",
             "value": "Instellingen"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "設定"
+          }
         }
       }
     },
@@ -81888,6 +85518,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Instellingenpictogram in inkeping"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "瀏海中的設定圖示"
           }
         }
       }
@@ -82032,6 +85668,12 @@
             "state": "translated",
             "value": "Instellingen…"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "設定…"
+          }
         }
       }
     },
@@ -82173,6 +85815,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Plank"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "暫存器"
           }
         }
       }
@@ -82316,6 +85964,12 @@
             "state": "translated",
             "value": "Sneltoetsen"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "快捷方式"
+          }
         }
       }
     },
@@ -82350,6 +86004,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Toon AQI-widget"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "顯示空氣品質小工具"
           }
         }
       }
@@ -82494,6 +86154,12 @@
             "state": "translated",
             "value": "Batterij-indicator weergeven"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "顯示電量"
+          }
         }
       }
     },
@@ -82528,6 +86194,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Toon batterijpercentagetekst in HUD"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 HUD 中顯示電池百分比文字"
           }
         }
       }
@@ -82564,6 +86236,12 @@
             "state": "translated",
             "value": "Toon Bluetooth-batterij"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "顯示藍牙電池"
+          }
         }
       }
     },
@@ -82598,6 +86276,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Bluetooth-apparaatverbindingen weergeven"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "顯示藍牙裝置連線"
           }
         }
       }
@@ -82634,6 +86318,12 @@
             "state": "translated",
             "value": "Agenda weergeven"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "顯示行事曆"
+          }
         }
       }
     },
@@ -82668,6 +86358,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Toon agenda-activiteiten binnen de inkeping"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在瀏海中顯示行事曆事件"
           }
         }
       }
@@ -82812,6 +86508,12 @@
             "state": "translated",
             "value": "Toon oplaadindicator"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "顯示充電指示器"
+          }
         }
       }
     },
@@ -82847,6 +86549,12 @@
             "state": "translated",
             "value": "Toon laadpercentage"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "顯示充電百分比"
+          }
         }
       }
     },
@@ -82881,6 +86589,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Toon oplaadstatus"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "顯示充電狀態"
           }
         }
       }
@@ -83024,6 +86738,12 @@
             "state": "translated",
             "value": "Toon kleurgeschiedenis"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "顯示顏色歷史"
+          }
         }
       }
     },
@@ -83165,6 +86885,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Toon het Kleurkiezerpaneel"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "顯示取色器面板"
           }
         }
       }
@@ -83309,6 +87035,12 @@
             "state": "translated",
             "value": "Toon coole gezichtsanimatie tijdens inactiviteit"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "不活動時顯示動畫"
+          }
         }
       }
     },
@@ -83450,6 +87182,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Aftellen weergeven"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "顯示倒數計時"
           }
         }
       }
@@ -83593,6 +87331,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Toon downloadvoortgang"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "顯示下載進度"
           }
         }
       }
@@ -83742,6 +87486,12 @@
             "state": "translated",
             "value": "Toon zwevende pauze-/stopknoppen"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "顯示浮動暫停/停止控制"
+          }
         }
       }
     },
@@ -83777,6 +87527,12 @@
             "state": "translated",
             "value": "Toon focusindicator"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "顯示專注指示器"
+          }
         }
       }
     },
@@ -83811,6 +87567,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Focuslabel tonen"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "顯示專注標籤"
           }
         }
       }
@@ -83955,6 +87717,12 @@
             "state": "translated",
             "value": "Toon volledige titels van activiteiten"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "顯示完整事件標題"
+          }
         }
       }
     },
@@ -83989,6 +87757,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Toon locatielabel"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "顯示位置標籤"
           }
         }
       }
@@ -84025,6 +87799,12 @@
             "state": "translated",
             "value": "Mediapaneel op vergrendelscherm weergeven"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "顯示鎖定畫面媒體面板"
+          }
         }
       }
     },
@@ -84060,6 +87840,12 @@
             "state": "translated",
             "value": "Toon vergrendelschermtimer"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "顯示鎖定畫面計時器"
+          }
         }
       }
     },
@@ -84094,6 +87880,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Toon het weer op het vergrendelscherm"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "顯示鎖定畫面天氣"
           }
         }
       }
@@ -84238,6 +88030,12 @@
             "state": "translated",
             "value": "Toon media-uitvoercontrole in andere lay-outs"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在其他版面配置中顯示媒體輸出控制"
+          }
         }
       }
     },
@@ -84379,6 +88177,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Weergeven op een specifiek scherm"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "在指定顯示器上顯示"
           }
         }
       }
@@ -84522,6 +88326,12 @@
             "state": "translated",
             "value": "Toon op alle schermen"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "在所有顯示器上顯示"
+          }
         }
       }
     },
@@ -84556,6 +88366,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Paneelrand weergeven"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "顯示面板邊框"
           }
         }
       }
@@ -84699,6 +88515,12 @@
             "state": "translated",
             "value": "Laat de voortgang zien"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "顯示進度"
+          }
         }
       }
     },
@@ -84733,6 +88555,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Opname-indicator weergeven"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "顯示錄製指示器"
           }
         }
       }
@@ -84876,6 +88704,12 @@
             "state": "translated",
             "value": "Toon shuffle- en herhaalknoppen"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "顯示隨機播放和重複按鈕"
+          }
         }
       }
     },
@@ -85017,6 +88851,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Timernaam weergeven"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "顯示計時器名稱"
           }
         }
       }
@@ -85160,6 +89000,12 @@
             "state": "translated",
             "value": "Toont een groen camerapictogram en een geel microfoonpictogram wanneer deze in gebruik is. Maakt gebruik van gebeurtenisgestuurde CoreAudio- en CoreMediaIO-API's."
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "使用時顯示綠色相機圖示和黃色麥克風圖示。使用事件驅動的 CoreAudio 和 CoreMediaIO API。"
+          }
         }
       }
     },
@@ -85301,6 +89147,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Toont het redeneringsproces van het model vóór het definitieve antwoord"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在最終答案之前顯示模型的推理過程"
           }
         }
       }
@@ -85444,6 +89296,12 @@
             "state": "translated",
             "value": "Toont de systeemkloktimer in de inkeping, indien beschikbaar. Vereist toegankelijkheidstoestemming om het statusitem te kunnen lezen."
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在可用時在瀏海中顯示系統時鐘計時器。需要輔助使用權限來讀取狀態項。"
+          }
         }
       }
     },
@@ -85478,6 +89336,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Enkele indicatoren"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "單個指示器"
           }
         }
       }
@@ -85620,6 +89484,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Grootte en schaal"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "大小與縮放"
           }
         }
       }
@@ -85764,6 +89634,12 @@
             "state": "translated",
             "value": "Gedrag overslaan"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "跳過行為"
+          }
         }
       }
     },
@@ -85907,6 +89783,12 @@
             "state": "translated",
             "value": "Knoppen overslaan"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "跳過按鈕"
+          }
         }
       }
     },
@@ -86048,6 +89930,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Kleur schuifregelaar"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "滑桿顏色"
           }
         }
       }
@@ -86192,6 +90080,12 @@
             "state": "translated",
             "value": "Vloeiende overgangen laten groen (0–60%), geel (60–85%) en rood (85–100%) door de gehele vulling lopen."
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "平滑過渡在整個填充中混合綠色（0-60%）、黃色（60-85%）和紅色（85-100%）。"
+          }
         }
       }
     },
@@ -86335,6 +90229,12 @@
             "state": "translated",
             "value": "Sneak peek-duur"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "快速預覽時長"
+          }
         }
       }
     },
@@ -86477,6 +90377,12 @@
             "state": "translated",
             "value": "Sneak Peek toont de mediatitel en artiest een paar seconden onder de inkeping."
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Sneak Peek 在Notch下顯示媒體標題和藝術家幾秒鐘。"
+          }
         }
       }
     },
@@ -86618,6 +90524,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Sneak Peek-stijl"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Sneak Peek 樣式"
           }
         }
       }
@@ -86762,6 +90674,12 @@
             "state": "translated",
             "value": "Sneak peek-stijl is vergrendeld op Standaard in de minimalistische modus"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "簡約模式下快速預覽樣式鎖定為標準"
+          }
         }
       }
     },
@@ -86903,6 +90821,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Software-updates"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "軟體更新"
           }
         }
       }
@@ -87046,6 +90970,12 @@
             "state": "translated",
             "value": "Effen kleur"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "純色"
+          }
         }
       }
     },
@@ -87187,6 +91117,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Snelheid"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "速度"
           }
         }
       }
@@ -87330,6 +91266,12 @@
             "state": "translated",
             "value": "Snelheid:"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "速度："
+          }
         }
       }
     },
@@ -87471,6 +91413,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Vierkant"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "方形"
           }
         }
       }
@@ -87615,6 +91563,12 @@
             "state": "translated",
             "value": "Begin"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "開始"
+          }
         }
       }
     },
@@ -87757,6 +91711,12 @@
             "state": "translated",
             "value": "Start een gesprek om hier je chatgeschiedenis te bekijken"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "開始對話以在此檢視聊天記錄"
+          }
         }
       }
     },
@@ -87898,6 +91858,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Begin met het kiezen van kleuren"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "開始取色"
           }
         }
       }
@@ -88042,6 +92008,12 @@
             "state": "translated",
             "value": "Aangepaste timer starten"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "啟動自訂計時器"
+          }
         }
       }
     },
@@ -88183,6 +92155,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Demotimer starten:"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "啟動演示計時器："
           }
         }
       }
@@ -88326,6 +92304,12 @@
             "state": "translated",
             "value": "Beginnen met monitoren"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "開始監控"
+          }
         }
       }
     },
@@ -88467,6 +92451,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Begin met het kiezen van kleuren om je geschiedenis op te bouwen"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "開始取色以建立歷史記錄"
           }
         }
       }
@@ -88610,6 +92600,12 @@
             "state": "translated",
             "value": "Begin met opnemen"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "開始錄製"
+          }
         }
       }
     },
@@ -88751,6 +92747,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Start een demo-timer van 5 minuten om de functie voor live-activiteit van de timer te testen. Werkt alleen als de timerfunctie is ingeschakeld."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "啟動 5 分鐘演示計時器以測試即時動態功能。僅在啟用計時器功能時有效。"
           }
         }
       }
@@ -88894,6 +92896,12 @@
             "state": "translated",
             "value": "Statistieken"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "統計"
+          }
         }
       }
     },
@@ -89035,6 +93043,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Statistieken uitgeschakeld"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "統計已停用"
           }
         }
       }
@@ -89179,6 +93193,12 @@
             "state": "translated",
             "value": "Statistiekenfunctie uitgeschakeld"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "統計功能已停用"
+          }
         }
       }
     },
@@ -89321,6 +93341,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Statistiekenfunctie is uitgeschakeld"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "統計功能已停用"
           }
         }
       }
@@ -89465,6 +93491,12 @@
             "state": "translated",
             "value": "Statistiekenpaneel is uitgeschakeld"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "統計面板已停用"
+          }
         }
       }
     },
@@ -89608,6 +93640,12 @@
             "state": "translated",
             "value": "Statistiekenpaneel:"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "統計面板："
+          }
         }
       }
     },
@@ -89749,6 +93787,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Interval voor het bijwerken van statistieken"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "統計更新間隔"
           }
         }
       }
@@ -89892,6 +93936,12 @@
             "state": "translated",
             "value": "Status en acties"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "狀態與操作"
+          }
         }
       }
     },
@@ -90027,6 +94077,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "หยุด"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "停止"
           }
         }
       },
@@ -90171,6 +94227,12 @@
             "state": "translated",
             "value": "Stop met monitoren"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "停止監控"
+          }
         }
       }
     },
@@ -90313,6 +94375,12 @@
             "state": "translated",
             "value": "Stop met opnemen"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "停止錄製"
+          }
         }
       }
     },
@@ -90454,6 +94522,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Gestopt"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "已停止"
           }
         }
       }
@@ -90598,6 +94672,12 @@
             "state": "translated",
             "value": "Steun ons"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "支援我們"
+          }
         }
       }
     },
@@ -90739,6 +94819,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Ondersteunt de redeneermodus"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "支援推理模式"
           }
         }
       }
@@ -90883,6 +94969,12 @@
             "state": "translated",
             "value": "Wissel"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "交換空間"
+          }
         }
       }
     },
@@ -91025,6 +95117,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Wisselen is uitgeschakeld op dit systeem."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "此系統已停用交換空間。"
           }
         }
       }
@@ -91169,6 +95267,12 @@
             "state": "translated",
             "value": "Systeem"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "系統"
+          }
         }
       }
     },
@@ -91310,6 +95414,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Systeemfuncties"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "系統功能"
           }
         }
       }
@@ -91454,6 +95564,12 @@
             "state": "translated",
             "value": "Systeemprestatiemonitor"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "系統效能監視器"
+          }
         }
       }
     },
@@ -91596,6 +95712,12 @@
             "state": "translated",
             "value": "Maak een screenshot van het gebied"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "區域截圖"
+          }
         }
       }
     },
@@ -91737,6 +95859,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Temperatuur eenheid"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "溫度單位"
           }
         }
       }
@@ -91881,6 +96009,12 @@
             "state": "translated",
             "value": "Het MacBook-pictogram is alleen beschikbaar in de ronde lay-out."
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MacBook 圖示僅在圓形版面配置中可用。"
+          }
         }
       }
     },
@@ -92016,6 +96150,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "TheDynamicIsland"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "動態島"
           }
         }
       },
@@ -92160,6 +96300,12 @@
             "state": "translated",
             "value": "Deze bedieningselementen weerspiegelen het tabblad Vergrendelscherm, zodat je de media-overlay kunt afstemmen terwijl je je richt op de afspeelinstellingen."
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "這些控制鏡像了鎖定畫面分頁，方便你在關注播放設定的同時調整媒體覆蓋層。"
+          }
         }
       }
     },
@@ -92302,6 +96448,12 @@
             "state": "translated",
             "value": "Deze bedieningselementen zitten naast de inkeping terwijl een timer loopt. Ze vereisen dat de timernaam verborgen blijft vanwege de spatiëring."
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "計時器執行時這些控制位於瀏海旁邊。為了間距需要隱藏計時器名稱。"
+          }
         }
       }
     },
@@ -92443,6 +96595,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Deze indicatoren verschijnen in de inkeping wanneer apps je camera of microfoon gebruiken, wat overeenkomt met de eigen privacy-indicatoren van macOS."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "當 App 使用你的相機或麥克風時，這些指示器會出現在瀏海中，與 macOS 原生隱私指示器一致。"
           }
         }
       }
@@ -92587,6 +96745,12 @@
             "state": "translated",
             "value": "Deze duur activeert de \"Aangepaste\" optie in de timer-popover voor snelle toegang."
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "此時長用於計時器彈出式視窗中的「自訂」選項，方便快速存取。"
+          }
         }
       }
     },
@@ -92621,6 +96785,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Deze duur activeert de optie \\\"Aangepast\\\" in de timer-popover voor snelle toegang."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "此時長用於計時器彈出式視窗中的「自訂」選項，方便快速存取。"
           }
         }
       }
@@ -92765,6 +96935,12 @@
             "state": "translated",
             "value": "Tijdbereik"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "時間範圍"
+          }
         }
       }
     },
@@ -92906,6 +97082,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Tijd tot volledig opladen: %lld min"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "充電時間：%lld 分鐘"
           }
         }
       }
@@ -93049,6 +97231,12 @@
             "state": "translated",
             "value": "Timer"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "計時器"
+          }
         }
       }
     },
@@ -93190,6 +97378,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Timer uitgeschakeld"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "計時器已停用"
           }
         }
       }
@@ -93333,6 +97527,12 @@
             "state": "translated",
             "value": "Timerfunctie"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "計時器功能"
+          }
         }
       }
     },
@@ -93474,6 +97674,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "De timerfunctie is uitgeschakeld"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "計時器功能已停用"
           }
         }
       }
@@ -93618,6 +97824,12 @@
             "state": "translated",
             "value": "Timervoorinstellingen"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "計時器預設組合"
+          }
         }
       }
     },
@@ -93760,6 +97972,12 @@
             "state": "translated",
             "value": "Timergeluid"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "計時器聲音"
+          }
         }
       }
     },
@@ -93901,6 +98119,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Timer tint"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "計時器著色"
           }
         }
       }
@@ -94045,6 +98269,12 @@
             "state": "translated",
             "value": "Timerwidget"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "計時器小工具"
+          }
         }
       }
     },
@@ -94187,6 +98417,12 @@
             "state": "translated",
             "value": "Schakel inkeping open:"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "切換Notch："
+          }
         }
       }
     },
@@ -94328,6 +98564,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Sneak Peek wisselen:"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "切換 Sneak Peek："
           }
         }
       }
@@ -94478,6 +98720,12 @@
             "state": "translated",
             "value": "Open of sluit Dynamic Island overal."
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "從任何位置切換動態島的開啟或關閉。"
+          }
         }
       }
     },
@@ -94621,6 +98869,12 @@
             "state": "translated",
             "value": "Totaal · %@"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "總計 · %@"
+          }
         }
       }
     },
@@ -94762,6 +99016,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Transformeren"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "變換"
           }
         }
       }
@@ -94911,6 +99171,12 @@
             "state": "translated",
             "value": "Maak je inkeping echt van jezelf"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "將瀏海變成真正屬於你的空間"
+          }
         }
       }
     },
@@ -95052,6 +99318,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Probeer je zoektermen aan te passen"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "請嘗試調整搜尋詞"
           }
         }
       }
@@ -95195,6 +99467,12 @@
             "state": "translated",
             "value": "Probeer verschillende zoektermen"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "請嘗試不同的搜尋詞"
+          }
         }
       }
     },
@@ -95229,6 +99507,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Probeer op de volumetoetsen te drukken om de HUD-functionaliteit van het systeem te testen"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "嘗試按音量鍵來測試系統 HUD 功能"
           }
         }
       }
@@ -95379,6 +99663,12 @@
             "state": "translated",
             "value": "Veeg met twee vingers omhoog over de inkeping om te sluiten, veeg met twee vingers omlaag over de inkeping om te openen wanneer de optie **Inkeping openen bij aanwijzen** is uitgeschakeld"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "當**懸停時開啟凹槽**選項關閉時，在凹槽處雙指上滑關閉，雙指下滑開啟"
+          }
         }
       }
     },
@@ -95520,6 +99810,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "UI-modus"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "介面模式"
           }
         }
       }
@@ -95664,6 +99960,12 @@
             "state": "translated",
             "value": "Verwijderen"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "解除安裝"
+          }
         }
       }
     },
@@ -95805,6 +100107,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Ontgrendel geavanceerde functies en verbeter je ervaring. Upgrade nu voor meer aanpassingen!"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "解鎖進階功能並提升你的體驗。現在升級以取得更多自訂功能！"
           }
         }
       }
@@ -95948,6 +100256,12 @@
             "state": "translated",
             "value": "niet gedempt"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "已取消靜音"
+          }
         }
       }
     },
@@ -96089,6 +100403,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Update-interval"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "更新間隔"
           }
         }
       }
@@ -96233,6 +100553,12 @@
             "state": "translated",
             "value": "Update-timer"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "更新計時器"
+          }
         }
       }
     },
@@ -96374,6 +100700,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Upgrade naar Pro"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "升級至 Pro"
           }
         }
       }
@@ -96518,6 +100850,12 @@
             "state": "translated",
             "value": "Uploaden"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "上傳"
+          }
         }
       }
     },
@@ -96660,6 +100998,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Gebruik"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "使用情況"
           }
         }
       }
@@ -96804,6 +101148,12 @@
             "state": "translated",
             "value": "Gebruiksverdeling"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "使用詳情"
+          }
         }
       }
     },
@@ -96838,6 +101188,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "gebruik een ronde batterij-indicator"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "使用圓形電池指示器"
           }
         }
       }
@@ -96874,6 +101230,12 @@
             "state": "translated",
             "value": "Gebruik gesloten meters"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "使用彩色儀表"
+          }
         }
       }
     },
@@ -96908,6 +101270,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Gebruik het MacBook-pictogram wanneer de batterij werkt"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "使用電池時顯示 MacBook 圖示"
           }
         }
       }
@@ -97051,6 +101419,12 @@
             "state": "translated",
             "value": "Gebruik het muziekvisualisatiespectrogram"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "使用音樂視覺化器譜圖"
+          }
         }
       }
     },
@@ -97085,6 +101459,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Gebruik eenvoudigere sluit-animatie"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "使用更簡單的關閉動畫"
           }
         }
       }
@@ -97229,6 +101609,12 @@
             "state": "translated",
             "value": "Gebruik het tabblad Media om sneak peek, songteksten en zwevende mediabedieningen te configureren."
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "使用媒體分頁配置快速預覽、歌詞和浮動媒體控制。"
+          }
         }
       }
     },
@@ -97371,6 +101757,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Gebruikt"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已使用"
           }
         }
       }
@@ -97515,6 +101907,12 @@
             "state": "translated",
             "value": "Gebruikt · %@"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已使用 · %@"
+          }
         }
       }
     },
@@ -97657,6 +102055,12 @@
             "state": "translated",
             "value": "Maakt gebruik van gebeurtenisgestuurde privé-API voor realtime detectie van schermopnamen"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "使用事件驅動的私有 API 進行即時螢幕錄製偵測"
+          }
         }
       }
     },
@@ -97798,6 +102202,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Gebruikt macOS 'Huidig onderdeel' wanneer de Amazon Music-app de actieve mediabron is. De afspeelbedieningen volgen het systeemdoel 'Huidig onderdeel'. Scrubben op de tijdlijn werkt mogelijk niet als de Amazon Music-app zoeken op afstand niet ondersteunt."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "當 Amazon Music App 是活動媒體源時使用 macOS 正在播放。播放控制遵循系統正在播放目標。如果 Amazon Music App 不支援遠端拖移，在時間軸上拖移可能無效。"
           }
         }
       }
@@ -97942,6 +102352,12 @@
             "state": "translated",
             "value": "Gebruik"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "利用率"
+          }
         }
       }
     },
@@ -98083,6 +102499,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Versie"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "版本"
           }
         }
       }
@@ -98226,6 +102648,12 @@
             "state": "translated",
             "value": "Versie-informatie"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "版本資訊"
+          }
         }
       }
     },
@@ -98368,6 +102796,12 @@
             "state": "translated",
             "value": "Verticaal:"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "垂直："
+          }
         }
       }
     },
@@ -98509,6 +102943,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Bekijk op GitHub: th-ch/youtube-music"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "在 GitHub 上檢視：th-ch/youtube-music"
           }
         }
       }
@@ -98653,6 +103093,12 @@
             "state": "translated",
             "value": "Volume"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "音量"
+          }
         }
       }
     },
@@ -98794,6 +103240,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Volume-HUD"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "音量 HUD"
           }
         }
       }
@@ -98938,6 +103390,12 @@
             "state": "translated",
             "value": "Volume-OSD"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "音量 OSD"
+          }
         }
       }
     },
@@ -98978,6 +103436,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "We hebben je camera nodig voor de spiegelmodus"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "鏡像模式需要使用你的相機"
           }
         }
       }
@@ -99122,6 +103586,12 @@
             "state": "translated",
             "value": "Weer"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "天氣"
+          }
         }
       }
     },
@@ -99263,6 +103733,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Leverancier van weergegevens"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "天氣資料來源"
           }
         }
       }
@@ -99407,6 +103883,12 @@
             "state": "translated",
             "value": "Weerwidget"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "天氣小工具"
+          }
         }
       }
     },
@@ -99549,6 +104031,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Weer: %1$@ %2$@"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "天氣：%1$@ %2$@"
           }
         }
       }
@@ -99693,6 +104181,12 @@
             "state": "translated",
             "value": "Weer: %1$@ %2$@ in %3$@"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "天氣：%1$@ %2$@ 在 %3$@"
+          }
         }
       }
     },
@@ -99834,6 +104328,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Welkom"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "歡迎"
           }
         }
       }
@@ -99977,6 +104477,12 @@
             "state": "translated",
             "value": "Wat is er nieuw"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "更新內容"
+          }
         }
       }
     },
@@ -100017,6 +104523,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Indien uitgeschakeld, zijn alle sneltoetsen inactief. Je kunt de UI-bedieningselementen nog steeds gebruiken"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "停用後，所有鍵盤快速鍵將不可用。你仍然可以使用介面控制"
           }
         }
       }
@@ -100166,6 +104678,12 @@
             "state": "translated",
             "value": "Indien uitgeschakeld, zijn alle sneltoetsen inactief. Je kunt de UI-bedieningselementen nog steeds gebruiken."
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "停用後，所有鍵盤快速鍵將不可用。你仍然可以使用介面控制。"
+          }
         }
       }
     },
@@ -100313,6 +104831,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Als deze optie is ingeschakeld, stopt het monitoren van statistieken een paar seconden nadat de inkeping is gesloten."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "啟用後，瀏海關閉幾秒後統計監控將停止。"
           }
         }
       }
@@ -100462,6 +104986,12 @@
             "state": "translated",
             "value": "Als deze optie is ingeschakeld, wordt het Atoll horizontaal uitgevouwen zodat het overeenkomt met de animatiegrootte"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "啟用後，Atoll 將水平延伸功能以匹配動畫大小"
+          }
         }
       }
     },
@@ -100610,6 +105140,12 @@
             "state": "translated",
             "value": "Als deze optie is ingeschakeld, geeft het tabblad Statistieken realtime grafieken van systeemprestaties weer. Voor deze functie zijn systeemmachtigingen vereist en kan extra batterijgebruik worden gebruikt."
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "啟用後，統計分頁將顯示即時系統效能圖表。此功能需要系統權限，可能會消耗額外電量。"
+          }
         }
       }
     },
@@ -100656,6 +105192,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Breedteaanpassingen zijn alleen van toepassing op de standaard inkepingsindeling. Schakel de minimalistische gebruikersinterface uit om deze waarde te bewerken."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "寬度調整僅適用於標準瀏海版面配置。停用簡約介面以編輯此值。"
           }
         }
       }
@@ -100798,6 +105340,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Breedte:"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "寬度："
           }
         }
       }
@@ -100947,6 +105495,12 @@
             "state": "translated",
             "value": "Als %lld grafieken is ingeschakeld, wordt het Dynamic Island horizontaal uitgevouwen zodat alle grafieken in één rij kunnen worden geplaatst."
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "啟用 %lld 個圖表後，動態島將水平延伸功能以在單行中容納所有圖表。"
+          }
         }
       }
     },
@@ -101090,6 +105644,12 @@
             "state": "translated",
             "value": "Schrijf"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "寫入"
+          }
         }
       }
     },
@@ -101231,6 +105791,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Jij"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "你"
           }
         }
       }
@@ -101374,6 +105940,12 @@
             "state": "translated",
             "value": "Je kunt nu van de app genieten. Als je dingen verder wilt aanpassen, kun je altijd naar de instellingen gaan."
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "如果你想進一步調整內容，你可以隨時存取設定。"
+          }
         }
       }
     },
@@ -101515,6 +106087,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Je bent helemaal klaar!"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "一切都準備好了！"
           }
         }
       }
@@ -101658,6 +106236,12 @@
             "state": "translated",
             "value": "Voor YouTube Music moet deze app van derden zijn geïnstalleerd:"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "YouTube Music 需要安裝此第三方 App："
+          }
         }
       }
     },
@@ -101685,6 +106269,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "15 мин"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "15 分鐘"
           }
         }
       }
@@ -101714,6 +106304,12 @@
             "state": "translated",
             "value": "30 мин"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "30 分鐘"
+          }
         }
       }
     },
@@ -101741,6 +106337,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "1 час"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 小時"
           }
         }
       }
@@ -101770,6 +106372,12 @@
             "state": "translated",
             "value": "3 часа"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "3 小時"
+          }
         }
       }
     },
@@ -101797,6 +106405,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "6 часов"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "6 小時"
           }
         }
       }
@@ -101826,6 +106440,12 @@
             "state": "translated",
             "value": "12 часов"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "12 小時"
+          }
         }
       }
     },
@@ -101853,6 +106473,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Остаток дня"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "今天餘下的時間"
           }
         }
       }
@@ -101882,6 +106508,12 @@
             "state": "translated",
             "value": "Всё время"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "所有時間"
+          }
         }
       }
     },
@@ -101904,6 +106536,12 @@
             "state": "translated",
             "value": "Symbool"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "符號"
+          }
         }
       }
     },
@@ -101922,6 +106560,12 @@
           }
         },
         "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "3D"
+          }
+        },
+        "zh-Hant": {
           "stringUnit": {
             "state": "translated",
             "value": "3D"
@@ -101954,6 +106598,12 @@
             "state": "translated",
             "value": "Слева"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "左對齊"
+          }
         }
       }
     },
@@ -101981,6 +106631,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Справа"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "右對齊"
           }
         }
       }
@@ -102010,6 +106666,12 @@
             "state": "translated",
             "value": "Включить минималистичный интерфейс"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "啟用極簡 UI"
+          }
         }
       }
     },
@@ -102037,6 +106699,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Скрывать Dynamic Island на снимках и записях"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "截圖和錄屏時隱藏動態島"
           }
         }
       }
@@ -102066,6 +106734,12 @@
             "state": "translated",
             "value": "Жест закрытия"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "關閉手勢"
+          }
         }
       }
     },
@@ -102093,6 +106767,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Инвертировать жесты смахивания"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "反向滑動"
           }
         }
       }
@@ -102122,6 +106802,12 @@
             "state": "translated",
             "value": "Инвертировать жесты прокрутки"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "反向滾動"
+          }
         }
       }
     },
@@ -102149,6 +106835,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Расширить область наведения"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "延伸功能懸停區域"
           }
         }
       }
@@ -102178,6 +106870,12 @@
             "state": "translated",
             "value": "Стиль внешнего дисплея"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "外接顯示器樣式"
+          }
         }
       }
     },
@@ -102205,6 +106903,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Скрывать до наведения"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "懸停時顯示"
           }
         }
       }
@@ -102234,6 +106938,12 @@
             "state": "translated",
             "value": "Включить обнаружение фокуса"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "啟用專注模式偵測"
+          }
         }
       }
     },
@@ -102261,6 +106971,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Разрешение «Универсальный доступ» позволяет Dynamic Island заменять системные индикаторы громкости, яркости и клавиатуры."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "輔助使用權限允許動態島替換原生的音量、亮度和鍵盤提示框。"
           }
         }
       }
@@ -102290,6 +107006,12 @@
             "state": "translated",
             "value": "Полный доступ к диску для глобального режима"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "全域模式需要完整磁碟取用權"
+          }
         }
       }
     },
@@ -102311,6 +107033,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Zonder volledige schijftoegang kan de plank alleen bestanden uit documenten en downloads lezen. Verleen volledige schijftoegang om de plank overal te laten werken."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "如果沒有完整磁碟取用權，暫存器只能讀取文件和下載目錄的檔案。授予完整磁碟取用權以使暫存器能在全域範圍工作。"
           }
         }
       }
@@ -102340,6 +107068,12 @@
             "state": "translated",
             "value": "Запросить полный доступ к диску"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "請求完整磁碟取用權"
+          }
         }
       }
     },
@@ -102368,6 +107102,12 @@
             "state": "translated",
             "value": "Открыть «Конфиденциальность и безопасность»"
           }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "開啟隱私與安全性"
+          }
         }
       }
     },
@@ -102383,6 +107123,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Полужирный текст вместо ярких цветов"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "粗體文字顯示為亮色"
           }
         }
       }


### PR DESCRIPTION
## Summary

Adds Traditional Chinese (`zh-Hant`) localization to both String Catalogs.

Terminology follows Apple's official Traditional Chinese system vocabulary, so the UI reads consistently with the surrounding macOS interface.

| | `DynamicIsland/Localizable.xcstrings` | `Localizable.xcstrings` |
|---|---|---|
| Translated from `zh-Hans` | 1318 | 790 |
| Translated from English (no `zh-Hans` yet) | 51 | 1 |
| Left to English fallback (symbols / brand names) | 9 | 0 |

## Terminology

Aligned with Apple's macOS Traditional Chinese, not a character-level conversion of the Simplified strings:

| English | zh-Hans | zh-Hant | Notes |
|---|---|---|---|
| Live Activity | 实时活动 | 即時動態 | Apple's term for Live Activities |
| Dynamic Island | 灵动岛 | 動態島 | Apple's term |
| notch | 刘海 | 瀏海 | |
| Widget | 小组件 | 小工具 | |
| lock screen | 锁屏 | 鎖定畫面 | |
| Calendar | 日历 | 行事曆 | app name, users look for this in Settings |
| Reminders | 提醒事项 | 提醒事項 | |
| Accessibility | 辅助功能 | 輔助使用 | the actual System Settings pane name |
| Extensions | 扩展 | 延伸功能 | |
| AirPlay | 隔空播放 | AirPlay | Apple keeps this in English |
| app | 应用 | App | Apple keeps this in English |

`reminder` is disambiguated per string: Reminders-app items become 提醒事項, while the
charging / low-battery notch alerts become 提示.

Typography follows Traditional Chinese convention: 「」 instead of “”, and a space between
CJK and Latin runs.

## Verification

- Every existing language, key, and non-localization field is byte-identical to `dev`; the diff is `zh-Hant` blocks only.
- Format specifiers (`%@`, `%lld`, `%1$d`, `%%`) verified identical between source and translation for all 2160 strings — no crash risk from a mismatched argument list.
- Markdown markers and quote pairing verified balanced.
- Each catalog keeps its own existing serialization style (the two files differ), so no whole-file reformat.

## Notes

- 146 + 159 strings inherit `needs_review` from the `zh-Hans` entries they were derived from, rather than being marked `translated`. Those upstream strings are already flagged in this repo.
- `InfoPlist.strings` is not localized here, matching the current scope of `zh-Hans`.
- No changes to `knownRegions` — consistent with how the existing `zh-Hans`, `ru`, and `ko` localizations are registered.
