### PR TITLE
Normalize Claude model IDs for pricing; show explicit unavailable estimate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improved the Dutch localization by adding missing translations, corrected terminology, and wording aligned with Apple's Dutch macOS conventions.
 
 ### Fixed
+- Normalized Claude model IDs when pricing local usage so newer IDs are costed instead of showing `US$0.00+`, and show an explicit unavailable/partial estimate when a model isn't in the pricing table (#683, #664).
 - Fixed an issue where `BluetoothHUDAnimations` (.mov files) were missing in release builds.
 - Improved the GitHub Actions release workflow to use a monotonic build number allocator and automated patch versioning for stable releases.
 - Fixed Cursor quota parsing and display to show the current Cursor Models and Other Models billing buckets with readable long reset durations.

--- a/DynamicIsland/components/Notch/NotchLLMUsageView.swift
+++ b/DynamicIsland/components/Notch/NotchLLMUsageView.swift
@@ -217,7 +217,7 @@ struct NotchLLMUsageView: View {
 
     private func costHelp(_ totals: UsageTotals) -> String {
         if totals.hasUnpricedModel {
-            return "Estimated API-equivalent cost from local token counts (not your subscription bill). Some models used aren't in the pricing table, so this is partial or unavailable."
+            return "Estimated API-equivalent cost from local token counts (not your subscription bill). Some models used do not have usable pricing, so this is partial or unavailable."
         }
         return "Estimated API-equivalent cost from local token counts, not your subscription bill."
     }

--- a/DynamicIsland/components/Notch/NotchLLMUsageView.swift
+++ b/DynamicIsland/components/Notch/NotchLLMUsageView.swift
@@ -200,9 +200,26 @@ struct NotchLLMUsageView: View {
                 .font(.system(size: compact ? 11 : (prominent ? 17 : 13), weight: prominent ? .bold : .semibold, design: .rounded))
                 .monospacedDigit()
             Spacer(minLength: 4)
-            Text(totals.hasUnpricedModel ? money(totals.costUSD) + "+" : money(totals.costUSD))
+            Text(costLabel(totals))
                 .font(.caption2).foregroundStyle(.secondary).monospacedDigit()
+                .help(costHelp(totals))
         }
+    }
+
+    /// Cost is an estimate computed from local token counts against the API price
+    /// table — not a subscription bill. When some models used have no entry in the
+    /// table we cannot price them: show "\(money)+" when a partial amount is known,
+    /// and an explicit "est. n/a" instead of a misleading "$0.00+" when nothing is.
+    private func costLabel(_ totals: UsageTotals) -> String {
+        guard totals.hasUnpricedModel else { return money(totals.costUSD) }
+        return totals.costUSD > 0 ? money(totals.costUSD) + "+" : "est. n/a"
+    }
+
+    private func costHelp(_ totals: UsageTotals) -> String {
+        if totals.hasUnpricedModel {
+            return "Estimated API-equivalent cost from local token counts (not your subscription bill). Some models used aren't in the pricing table, so this is partial or unavailable."
+        }
+        return "Estimated API-equivalent cost from local token counts, not your subscription bill."
     }
 
     private func tokens(_ n: Int) -> String {

--- a/DynamicIsland/managers/LLMUsage/ModelPricingManager.swift
+++ b/DynamicIsland/managers/LLMUsage/ModelPricingManager.swift
@@ -133,10 +133,12 @@ class ModelPricingManager: ObservableObject {
             guard let model = models.first(where: { $0.id.lowercased() == key }) else { continue }
             let prompt = model.pricing.promptPrice
             let completion = model.pricing.completionPrice
-            // Skip placeholder rows whose rates are blank/zero (present in the sparse
-            // bundled fallback): a genuine Claude price is never 0 for both fields, and
-            // treating them as priced would report a false "$0.00".
-            if prompt > 0 || completion > 0 { return (prompt, completion) }
+            // Skip placeholder/incomplete rows (present in the sparse bundled fallback):
+            // a genuine Claude price has both a prompt and a completion rate, so require
+            // both to be positive. A row with only one side set is treated as unpriced —
+            // keep scanning candidates rather than report a half or false "$0.00" price.
+            guard prompt > 0, completion > 0 else { continue }
+            return (prompt, completion)
         }
         return nil
     }

--- a/DynamicIsland/managers/LLMUsage/ModelPricingManager.swift
+++ b/DynamicIsland/managers/LLMUsage/ModelPricingManager.swift
@@ -114,11 +114,68 @@ class ModelPricingManager: ObservableObject {
         }
     }
     
-    /// Resolves pricing for a specific model ID
+    /// Resolves pricing for a specific model ID.
+    ///
+    /// Usage logs from Claude Code carry native Anthropic ids such as
+    /// "claude-opus-4-8", "claude-sonnet-5", "claude-haiku-4-5-20251001", or
+    /// occasionally a provider-prefixed "anthropic/claude-4.8-opus-20260528". The
+    /// dynamic pricing table, however, is keyed OpenRouter-style
+    /// ("anthropic/claude-3-5-sonnet"). A strict `id == modelId` compare therefore
+    /// misses models that ARE in the table but written in a different form, leaving
+    /// their cost at 0. We reconcile the purely cosmetic differences — provider
+    /// prefix, trailing date stamp, family/version word order, and dot-vs-dash minor
+    /// versions — before giving up. This never fabricates a price for a model the
+    /// table has no entry for; those stay unpriced and are surfaced explicitly in the
+    /// UI rather than shown as a misleading "$0.00".
     func getPricing(for modelId: String) -> (prompt: Double, completion: Double)? {
-        guard let model = pricingData?.models.first(where: { $0.id == modelId }) else {
-            return nil
+        guard let models = pricingData?.models else { return nil }
+        for key in Self.pricingKeyCandidates(for: modelId) {
+            guard let model = models.first(where: { $0.id.lowercased() == key }) else { continue }
+            let prompt = model.pricing.promptPrice
+            let completion = model.pricing.completionPrice
+            // Skip placeholder rows whose rates are blank/zero (present in the sparse
+            // bundled fallback): a genuine Claude price is never 0 for both fields, and
+            // treating them as priced would report a false "$0.00".
+            if prompt > 0 || completion > 0 { return (prompt, completion) }
         }
-        return (model.pricing.promptPrice, model.pricing.completionPrice)
+        return nil
+    }
+
+    /// Ordered, de-duplicated list of lower-cased table keys to try for a raw log id.
+    /// OpenRouter's own Claude naming is inconsistent (version-first "claude-3-5-sonnet"
+    /// for 3.x, family-first "claude-opus-4" for 4.x), so rather than assume one canonical
+    /// form we emit both word orders, each with and without the "anthropic/" prefix, and
+    /// let the first that exists in the table win.
+    static func pricingKeyCandidates(for raw: String) -> [String] {
+        var out: [String] = []
+        func push(_ s: String) {
+            guard !s.isEmpty else { return }
+            for form in [s, "anthropic/\(s)"] where !out.contains(form) { out.append(form) }
+        }
+
+        var s = raw.lowercased()
+        if let slash = s.lastIndex(of: "/") { s = String(s[s.index(after: slash)...]) } // drop provider prefix
+        push(s)
+
+        // Drop a trailing date stamp like "-20260528".
+        let noDate = s.replacingOccurrences(of: #"-\d{6,}$"#, with: "", options: .regularExpression)
+        push(noDate)
+
+        // Treat dotted minor versions ("4.8") the same as dashed ("4-8").
+        let dashed = noDate.replacingOccurrences(of: ".", with: "-")
+        push(dashed)
+
+        // Reconcile family/version word order around the "claude-" stem.
+        let families = ["opus", "sonnet", "haiku"]
+        var tokens = dashed.split(separator: "-").map(String.init)
+        if tokens.first == "claude", let famIdx = tokens.firstIndex(where: { families.contains($0) }) {
+            let family = tokens.remove(at: famIdx)
+            let version = Array(tokens.dropFirst()) // everything after "claude" minus the family token
+            if !version.isEmpty {
+                push((["claude", family] + version).joined(separator: "-")) // family-first
+                push((["claude"] + version + [family]).joined(separator: "-")) // version-first
+            }
+        }
+        return out
     }
 }


### PR DESCRIPTION
Addresses #664 (part 1: Claude cost/pricing).

Cost was matched by exact model id against the pricing table, but Claude Code logs native Anthropic ids (`claude-opus-4-8`, `claude-sonnet-5`, `claude-haiku-4-5-20251001`, sometimes a provider-prefixed `anthropic/claude-4.8-opus-20260528`) while the table is keyed OpenRouter-style (`anthropic/claude-3-5-sonnet`). Every miss set `hasUnpricedModel` and left the total at 0, so a card with millions of tokens showed a misleading `US$0.00+`.

`getPricing` now tries a small ladder of normalized candidate keys before giving up: it strips the provider prefix and any trailing date stamp, treats dotted minor versions the same as dashed, and emits both family-first and version-first word orders (OpenRouter’s own Claude naming uses both), each with and without the `anthropic/` prefix. This does not touch `pricing.json` — that file is maintained by the dynamic-pricing workflow/bot, and normalization lives entirely in code. Placeholder rows whose rates are blank/zero are skipped so they do not report a false `$0.00`.

When a model genuinely has no table entry the cost stays unpriced, and the card now shows an explicit `est. n/a` (or `$X.XX+` when a partial amount is known) instead of a misleading `US$0.00+`, with a tooltip clarifying the figure is an API-equivalent estimate from local token counts, not a subscription bill.

Scope note: the fix stays out of `JSONLUsageParser.swift`, so it does not overlap the Codex Today/Week counting fix (#664 part 2).

Verified with a Debug build (`xcodebuild -scheme DynamicIsland -configuration Debug CODE_SIGNING_ALLOWED=NO build`) and a standalone check of the normalization candidate generation against sample logged IDs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added contextual help explaining that displayed AI usage costs are estimates and may be partial or unavailable.
  * Improved cost labels to distinguish known, partial, and unavailable pricing.

* **Bug Fixes**
  * Improved model pricing recognition across provider prefixes, version formats, date suffixes, and Claude model variants.
  * Prevented unavailable zero-rate pricing entries from being shown as valid costs.

* **Documentation**
  * Added an unreleased changelog entry describing improved model pricing and estimate handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->