### PR TITLE
Show Claude subscription plan badge in the usage card

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Show the current Claude subscription plan (e.g. `Max 5x`) as a badge next to the Claude card title in the LLM Usage view (#684).
 - **AntiGravity Usage Tracking**: Track how much of Antigravity usage is left in the LLM Usage Monitor tab (both Gemini and Claude models)
 - **Shelf item removal**: Hovering a Shelf item now reveals a × button that removes just that item, with a VoiceOver-accessible "Remove from Shelf" action that works without hovering (#461).
 

--- a/DynamicIsland/components/Notch/NotchLLMUsageView.swift
+++ b/DynamicIsland/components/Notch/NotchLLMUsageView.swift
@@ -44,8 +44,17 @@ struct NotchLLMUsageView: View {
     @ViewBuilder
     private func card(for provider: ProviderID) -> some View {
         VStack(alignment: .leading, spacing: 6) {
-            HStack {
+            HStack(spacing: 6) {
                 Text(provider.displayName).font(.headline)
+                // Subscription plan badge (e.g. "Max 5x"). Only set for Claude; nil elsewhere.
+                if case .success(let snap) = manager.results[provider] ?? .loading, let plan = snap.plan {
+                    Text(plan)
+                        .font(.caption2.weight(.semibold))
+                        .padding(.horizontal, 5)
+                        .padding(.vertical, 1)
+                        .background(.white.opacity(0.12), in: Capsule())
+                        .foregroundStyle(.secondary)
+                }
                 Spacer()
                 if provider == .antigravity {
                     Picker("", selection: $antigravityPool) {

--- a/DynamicIsland/managers/LLMUsage/ClaudeUsageProvider.swift
+++ b/DynamicIsland/managers/LLMUsage/ClaudeUsageProvider.swift
@@ -20,12 +20,42 @@ struct ClaudeUsageProvider: UsageProvider {
         let quota = await quotaClient.fetchLimits()
         snapshot.sessionLimit = quota.session
         snapshot.weekLimit = quota.week
+        snapshot.plan = Self.readPlanLabel()
         return snapshot
     }
 
     private func jsonlFiles(under dir: URL) -> [URL] {
         guard let en = FileManager.default.enumerator(at: dir, includingPropertiesForKeys: nil) else { return [] }
         return en.compactMap { $0 as? URL }.filter { $0.pathExtension == "jsonl" }
+    }
+
+    /// Reads the subscription plan from the plaintext `oauthAccount` fields in `~/.claude.json`
+    /// (not a credential, no token). Prefers `organizationRateLimitTier` (distinguishes Max 5x / 20x),
+    /// falling back to `organizationType`. Returns nil if the file is missing or malformed, so the
+    /// badge simply does not render — this is best-effort and never fails the snapshot.
+    private static func readPlanLabel() -> String? {
+        let url = FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".claude.json")
+        guard let data = try? Data(contentsOf: url),
+              let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let account = obj["oauthAccount"] as? [String: Any] else { return nil }
+        let raw = (account["organizationRateLimitTier"] as? String)
+            ?? (account["organizationType"] as? String)
+        return raw.map(prettyPlan)
+    }
+
+    /// "default_claude_max_5x" → "Max 5x"; "claude_max" → "Max"; "claude_pro" → "Pro".
+    private static func prettyPlan(_ raw: String) -> String {
+        var s = raw
+        for prefix in ["default_claude_", "claude_", "default_"] where s.hasPrefix(prefix) {
+            s.removeFirst(prefix.count)
+            break
+        }
+        let parts = s.split(separator: "_").map { seg -> String in
+            // Keep multiplier tokens like "5x" / "20x" as-is; capitalize the rest.
+            if seg.range(of: "^[0-9]+x$", options: .regularExpression) != nil { return String(seg) }
+            return seg.prefix(1).uppercased() + seg.dropFirst()
+        }
+        return parts.joined(separator: " ")
     }
 }
 

--- a/DynamicIsland/managers/LLMUsage/ClaudeUsageProvider.swift
+++ b/DynamicIsland/managers/LLMUsage/ClaudeUsageProvider.swift
@@ -38,9 +38,16 @@ struct ClaudeUsageProvider: UsageProvider {
         guard let data = try? Data(contentsOf: url),
               let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
               let account = obj["oauthAccount"] as? [String: Any] else { return nil }
-        let raw = (account["organizationRateLimitTier"] as? String)
-            ?? (account["organizationType"] as? String)
-        return raw.map(prettyPlan)
+        // Prefer the rate-limit tier, but fall back to organizationType when it is
+        // absent OR blank/whitespace (a present-but-empty string must not short-circuit
+        // the fallback). Return nil if neither yields a non-empty label so the badge
+        // isn't rendered as an empty capsule.
+        let raw = [account["organizationRateLimitTier"], account["organizationType"]]
+            .compactMap { ($0 as? String)?.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .first { !$0.isEmpty }
+        guard let raw else { return nil }
+        let label = prettyPlan(raw)
+        return label.isEmpty ? nil : label
     }
 
     /// "default_claude_max_5x" → "Max 5x"; "claude_max" → "Max"; "claude_pro" → "Pro".

--- a/DynamicIsland/managers/LLMUsage/UsageProvider.swift
+++ b/DynamicIsland/managers/LLMUsage/UsageProvider.swift
@@ -52,6 +52,7 @@ struct UsageSnapshot: Equatable {
     var sessionLimit: UsageLimit? = nil // 5h window quota
     var weekLimit: UsageLimit? = nil // 7d window quota
     var models: [ModelUsage] = []
+    var plan: String? = nil // Subscription plan label (e.g. "Max 5x"); provided by Claude only, nil otherwise.
     var lastUpdated: Date = .distantPast
 }
 


### PR DESCRIPTION
Reads the current user’s own subscription tier string from the plaintext `oauthAccount` fields in `~/.claude.json` (`organizationRateLimitTier`, falling back to `organizationType`) and renders it as a small capsule badge next to the Claude card title.

This is best-effort and optional: only the tier string is read (no credentials/tokens), and if the file is missing or malformed `readPlanLabel()` returns nil so no badge shows and the snapshot is unaffected. The `plan` field is Claude-only; other providers leave it nil and are not touched.

Why read `~/.claude.json`: it is the only local place the running user’s plan tier is exposed, and it is plaintext (not a credential). Happy to gate this behind a setting if maintainers prefer not to couple to a Claude Code file.

Verified with a Debug build (`xcodebuild -scheme DynamicIsland -configuration Debug CODE_SIGNING_ALLOWED=NO build`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added subscription plan details to Claude usage information when available.
  * Displays plans as readable badges in the provider card header, such as “Max 5x.”
  * Hides the badge when plan information is unavailable.

* **Bug Fixes**
  * Missing, blank, or malformed plan information no longer prevents usage details from loading.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->