### PR TITLE
Recover Claude quota fetch after OAuth token rotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improved the Dutch localization by adding missing translations, corrected terminology, and wording aligned with Apple's Dutch macOS conventions.
 
 ### Fixed
+- Recover the Claude quota display after Claude Code rotates its OAuth token, instead of showing "quota unavailable" until the app is restarted (#685).
 - Fixed an issue where `BluetoothHUDAnimations` (.mov files) were missing in release builds.
 - Improved the GitHub Actions release workflow to use a monotonic build number allocator and automated patch versioning for stable releases.
 - Fixed Cursor quota parsing and display to show the current Cursor Models and Other Models billing buckets with readable long reset durations.

--- a/DynamicIsland/managers/LLMUsage/Quota/ClaudeQuotaClient.swift
+++ b/DynamicIsland/managers/LLMUsage/Quota/ClaudeQuotaClient.swift
@@ -6,6 +6,7 @@ actor ClaudeCredentialStore {
 
     fileprivate func get() -> ClaudeQuotaClient.CredentialFile.OAuth? { cached }
     fileprivate func set(_ creds: ClaudeQuotaClient.CredentialFile.OAuth) { cached = creds }
+    fileprivate func clear() { cached = nil }
 }
 
 struct ClaudeQuotaClient {
@@ -57,9 +58,32 @@ struct ClaudeQuotaClient {
         let sevenDay: Window?
     }
 
+    private enum FetchOutcome {
+        case success((session: UsageLimit?, week: UsageLimit?))
+        case authFailure // 401/403: the access token is no longer accepted.
+        case otherFailure // network/decoding/5xx: reloading credentials would not help.
+    }
+
     func fetchLimits() async -> (session: UsageLimit?, week: UsageLimit?) {
         guard let creds = await currentCredentials() else { return (nil, nil) }
-        guard let token = await validAccessToken(creds) else { return (nil, nil) }
+        switch await attemptFetch(creds) {
+        case .success(let limits):
+            return limits
+        case .authFailure:
+            // Claude Code likely rotated the OAuth token out from under our cache
+            // (revoked access token, or a refresh token it already consumed). Drop the
+            // cached copy, re-read from source (file → Keychain, which CC has updated),
+            // and retry exactly once. No retry on non-auth failures.
+            guard let fresh = await reloadCredentials() else { return (nil, nil) }
+            if case .success(let limits) = await attemptFetch(fresh) { return limits }
+            return (nil, nil)
+        case .otherFailure:
+            return (nil, nil)
+        }
+    }
+
+    private func attemptFetch(_ creds: CredentialFile.OAuth) async -> FetchOutcome {
+        guard let token = await validAccessToken(creds) else { return .authFailure }
         var request = URLRequest(url: URL(string: "https://api.anthropic.com/api/oauth/usage")!)
         request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
         request.setValue("application/json", forHTTPHeaderField: "Accept")
@@ -68,20 +92,31 @@ struct ClaudeQuotaClient {
         request.setValue("claude-code/2.1.69", forHTTPHeaderField: "User-Agent")
         do {
             let (data, response) = try await session.data(for: request)
-            guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) else { return (nil, nil) }
+            guard let http = response as? HTTPURLResponse else { return .otherFailure }
+            if http.statusCode == 401 || http.statusCode == 403 { return .authFailure }
+            guard (200..<300).contains(http.statusCode) else { return .otherFailure }
             let decoder = JSONDecoder()
             decoder.keyDecodingStrategy = .convertFromSnakeCase
             let decoded = try decoder.decode(UsageResponse.self, from: data)
             let sessionLimit = decoded.fiveHour.map { UsageLimit(used: $0.utilization, limit: 100, resetsAt: $0.resetsAt.date) }
             let weekLimit = decoded.sevenDay.map { UsageLimit(used: $0.utilization, limit: 100, resetsAt: $0.resetsAt.date) }
-            return (sessionLimit, weekLimit)
+            return .success((sessionLimit, weekLimit))
         } catch {
-            return (nil, nil)
+            return .otherFailure
         }
     }
 
     private func currentCredentials() async -> CredentialFile.OAuth? {
         if let cached = await ClaudeCredentialStore.shared.get() { return cached }
+        guard let loaded = Self.loadCredentialsFromSource() else { return nil }
+        await ClaudeCredentialStore.shared.set(loaded)
+        return loaded
+    }
+
+    // Force a re-read from source, bypassing the in-memory cache. Called after an auth
+    // failure so a token rotated by Claude Code is picked up without an app restart.
+    private func reloadCredentials() async -> CredentialFile.OAuth? {
+        await ClaudeCredentialStore.shared.clear()
         guard let loaded = Self.loadCredentialsFromSource() else { return nil }
         await ClaudeCredentialStore.shared.set(loaded)
         return loaded

--- a/DynamicIsland/managers/LLMUsage/Quota/ClaudeQuotaClient.swift
+++ b/DynamicIsland/managers/LLMUsage/Quota/ClaudeQuotaClient.swift
@@ -7,6 +7,14 @@ actor ClaudeCredentialStore {
     fileprivate func get() -> ClaudeQuotaClient.CredentialFile.OAuth? { cached }
     fileprivate func set(_ creds: ClaudeQuotaClient.CredentialFile.OAuth) { cached = creds }
     fileprivate func clear() { cached = nil }
+
+    // Atomically replace the cache with a fresh load from source. Running the load
+    // inside the actor closes the window where a concurrent reader could slot a stale
+    // credential in between a separate clear() and set().
+    fileprivate func reload(from load: @Sendable () -> ClaudeQuotaClient.CredentialFile.OAuth?) -> ClaudeQuotaClient.CredentialFile.OAuth? {
+        cached = load()
+        return cached
+    }
 }
 
 struct ClaudeQuotaClient {
@@ -115,11 +123,9 @@ struct ClaudeQuotaClient {
 
     // Force a re-read from source, bypassing the in-memory cache. Called after an auth
     // failure so a token rotated by Claude Code is picked up without an app restart.
+    // The invalidate-and-reload is a single atomic actor operation (see reload(from:)).
     private func reloadCredentials() async -> CredentialFile.OAuth? {
-        await ClaudeCredentialStore.shared.clear()
-        guard let loaded = Self.loadCredentialsFromSource() else { return nil }
-        await ClaudeCredentialStore.shared.set(loaded)
-        return loaded
+        await ClaudeCredentialStore.shared.reload(from: { Self.loadCredentialsFromSource() })
     }
 
     // File first never prompts; Keychain only as fallback.
@@ -149,11 +155,14 @@ struct ClaudeQuotaClient {
         request.httpBody = try? JSONSerialization.data(withJSONObject: body)
         guard let (data, response) = try? await session.data(for: request),
               let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) else {
-            return creds.accessToken
+            // Refresh failed. Report the token as invalid (nil) so the caller classifies
+            // this as an auth failure and reloads credentials from source, instead of
+            // proceeding with an access token we already know is stale.
+            return nil
         }
         let decoder = JSONDecoder()
         decoder.keyDecodingStrategy = .convertFromSnakeCase
-        guard let refreshed = try? decoder.decode(RefreshResponse.self, from: data) else { return creds.accessToken }
+        guard let refreshed = try? decoder.decode(RefreshResponse.self, from: data) else { return nil }
         let expiresAt = nowMs + Int64(refreshed.expiresIn) * 1000
         let updated = CredentialFile.OAuth(accessToken: refreshed.accessToken, refreshToken: refreshed.refreshToken, expiresAt: expiresAt)
         await ClaudeCredentialStore.shared.set(updated)


### PR DESCRIPTION
`ClaudeCredentialStore` cached the OAuth credentials on first read and never re-read the source, so when Claude Code rotated the token (revoking the old access token, or consuming the refresh token we still held) the usage API started returning 401 and the quota gauges fell back to `quota unavailable` until the app was restarted.

This distinguishes auth failures (401/403, or a refresh that no longer works) from other failures, and on an auth failure invalidates the cached credentials, re-reads from source (file → Keychain, which Claude Code has updated), and retries the usage request exactly once. Non-auth failures (network/5xx/decode) do not retry, since reloading credentials would not help. The retry is bounded to one attempt, the actor keeps credential access serialized, and no tokens are logged.

Verified with a Debug build (`xcodebuild -scheme DynamicIsland -configuration Debug CODE_SIGNING_ALLOWED=NO build`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Claude quota retrieval reliability by distinguishing authentication failures from other errors.
  * Automatically refreshes credentials and retries once after authentication failures.
  * Handles HTTP 401 and 403 responses as authentication failures.
  * Prevents unnecessary retries for network, decoding, invalid-response, and other non-authentication errors.
  * Restores Claude quota display after OAuth token rotation.

* **Documentation**
  * Added an unreleased changelog entry documenting improved quota recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->