### PR TITLE
Fix Codex Today/Week usage totals stuck at zero

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improved the Dutch localization by adding missing translations, corrected terminology, and wording aligned with Apple's Dutch macOS conventions.
 
 ### Fixed
+- Fixed Codex Today and Week usage totals remaining at zero when parsing Codex session logs (#664).
 - Fixed an issue where `BluetoothHUDAnimations` (.mov files) were missing in release builds.
 - Improved the GitHub Actions release workflow to use a monotonic build number allocator and automated patch versioning for stable releases.
 - Fixed Cursor quota parsing and display to show the current Cursor Models and Other Models billing buckets with readable long reset durations.

--- a/DynamicIsland/managers/LLMUsage/JSONLUsageParser.swift
+++ b/DynamicIsland/managers/LLMUsage/JSONLUsageParser.swift
@@ -64,7 +64,7 @@ struct JSONLUsageParser {
         // Token-count events have no stable identifier and are written once per session log.
         let input = usage["input_tokens"] as? Int ?? 0
         let output = usage["output_tokens"] as? Int ?? 0
-        guard input + output > 0 else { return nil }
+        guard input >= 0, output >= 0, (input > 0 || output > 0) else { return nil }
 
         return UsageRecord(
             timestamp: date,

--- a/DynamicIsland/managers/LLMUsage/JSONLUsageParser.swift
+++ b/DynamicIsland/managers/LLMUsage/JSONLUsageParser.swift
@@ -29,6 +29,11 @@ struct JSONLUsageParser {
     static func parseLine(_ line: String) -> UsageRecord? {
         guard let data = line.data(using: .utf8),
               let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else { return nil }
+
+        if let codexRecord = parseCodexTokenCount(obj) {
+            return codexRecord
+        }
+
         let message = obj["message"] as? [String: Any]
         let usage = (message?["usage"] as? [String: Any]) ?? (obj["usage"] as? [String: Any])
         guard let usage else { return nil }
@@ -44,6 +49,30 @@ struct JSONLUsageParser {
         let requestId = (obj["requestId"] as? String) ?? (obj["request_id"] as? String)
         let dedupKey = (messageId != nil || requestId != nil) ? "\(messageId ?? "")-\(requestId ?? "")" : nil
         return UsageRecord(timestamp: ts, model: model, inputTokens: input, outputTokens: output, dedupKey: dedupKey)
+    }
+
+    private static func parseCodexTokenCount(_ obj: [String: Any]) -> UsageRecord? {
+        guard obj["type"] as? String == "event_msg",
+              let payload = obj["payload"] as? [String: Any],
+              payload["type"] as? String == "token_count",
+              let info = payload["info"] as? [String: Any],
+              let usage = info["last_token_usage"] as? [String: Any],
+              let timestamp = obj["timestamp"] as? String,
+              let date = parseDate(timestamp) else { return nil }
+
+        // Codex emits a per-event delta and a session cumulative total. Only the delta is additive.
+        // Token-count events have no stable identifier and are written once per session log.
+        let input = usage["input_tokens"] as? Int ?? 0
+        let output = usage["output_tokens"] as? Int ?? 0
+        guard input + output > 0 else { return nil }
+
+        return UsageRecord(
+            timestamp: date,
+            model: "codex",
+            inputTokens: input,
+            outputTokens: output,
+            dedupKey: nil
+        )
     }
 
     static func aggregate(files: [URL], now: Date) -> UsageSnapshot {


### PR DESCRIPTION
Addresses #664 (part 2: Codex token parsing).

Codex session logs record usage in `event_msg` events with `payload.type` set to `token_count`, while the existing parser only handled top-level and message-level `usage` payloads. As a result, Codex Today and Week totals remained at zero.

This change parses `payload.info.last_token_usage` as per-event token deltas and assigns each record to the existing time windows using its event timestamp. It intentionally does not sum `total_token_usage`, which is cumulative within a session and would overcount usage. `input_tokens` and `output_tokens` are recorded directly; reasoning tokens are already included in `output_tokens`.

Existing Claude and Cursor parsing paths are unchanged.

Verified with a Debug build (`xcodebuild -scheme DynamicIsland -configuration Debug CODE_SIGNING_ALLOWED=NO build`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Codex Today and Week usage totals showing zero when processing Codex session logs.
  * Improved recognition of Codex token-count events, including usage amounts and timestamps.
* **Documentation**
  * Added a changelog entry documenting the Codex usage totals fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->