### PR TITLE
Skip session logs outside the usage window instead of re-parsing the whole history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Improved the Dutch localization by adding missing translations, corrected terminology, and wording aligned with Apple's Dutch macOS conventions.
+- Refreshing the LLM Usage card now skips session logs whose last write predates the seven-day window instead of re-reading the whole log history, and counts a repeated record when the copy inside the window would previously have been suppressed by a copy outside it (#691).
 
 ### Fixed
 - Fixed Codex Today and Week usage totals remaining at zero when parsing Codex session logs (#664).

--- a/DynamicIsland/managers/LLMUsage/JSONLUsageParser.swift
+++ b/DynamicIsland/managers/LLMUsage/JSONLUsageParser.swift
@@ -75,6 +75,17 @@ struct JSONLUsageParser {
         )
     }
 
+    /// Session logs are append-only, so a file whose last write predates the
+    /// window cannot contain a record inside it. Returns `true` when the date is
+    /// unreadable, so an unexpected filesystem keeps the file rather than
+    /// silently dropping its records.
+    private static func mayContainRecords(after cutoff: Date, _ file: URL) -> Bool {
+        guard let modified = try? file.resourceValues(forKeys: [.contentModificationDateKey])
+            .contentModificationDate
+        else { return true }
+        return modified >= cutoff
+    }
+
     static func aggregate(files: [URL], now: Date) -> UsageSnapshot {
         var snapshot = UsageSnapshot()
         var perModel: [String: UsageTotals] = [:]
@@ -83,15 +94,19 @@ struct JSONLUsageParser {
         let sessionStart = now.addingTimeInterval(-5 * 3600)
         let weekStart = now.addingTimeInterval(-7 * 86400)
 
-        for file in files {
+        for file in files where mayContainRecords(after: weekStart, file) {
             guard let content = try? String(contentsOf: file, encoding: .utf8) else { continue }
             for line in content.split(separator: "\n") {
                 guard let rec = parseLine(String(line)) else { continue }
+                // Window first, then dedup: a record outside the window can no
+                // longer claim a key and suppress an in-window record that
+                // repeats it. That also makes the totals independent of which
+                // files were read, which is what lets the skip above be sound.
+                guard rec.timestamp >= weekStart else { continue }
                 if let key = rec.dedupKey {
                     if seen.contains(key) { continue }
                     seen.insert(key)
                 }
-                guard rec.timestamp >= weekStart else { continue }
                 let cost = ModelPricing.cost(model: rec.model, inputTokens: rec.inputTokens, outputTokens: rec.outputTokens)
                 func add(_ t: inout UsageTotals) {
                     t.inputTokens += rec.inputTokens


### PR DESCRIPTION
`JSONLUsageParser.aggregate` reads every `.jsonl` under `~/.claude/projects` (and `~/.codex/sessions`) in full on each refresh — `String(contentsOf:)` per file, `JSONSerialization` per line — and only afterwards discards the records that fall outside the seven-day window the card reports on. On a long-running Claude Code install almost all of that work is spent decoding records that are then thrown away: on this machine 41 of 72 session logs were last written before the window, and one refresh read 89 MB of logs to report on a few days of activity. `LLMUsageManager` throttles to one refresh a minute, so this repeats for as long as the Usage tab is open.

Session logs are append-only, so a file whose content modification date precedes the window cannot hold a record inside it. `aggregate` now skips those files before opening them. When the modification date cannot be read the file is kept, so an unusual filesystem costs a little work rather than silently dropping records.

Skipping whole files is only sound if nothing inside them can affect the result, and one thing could. The dedup set was filled before the window check, so a record outside the window claimed its `messageId`/`requestId` key and suppressed any in-window record that repeated it — leaving genuinely in-window tokens uncounted, and making the totals depend on which files were read and in what order, which `FileManager.enumerator` does not promise. The window check now runs first, so the set only ever holds keys belonging to records that are actually counted. Dedup among in-window records is unchanged.

Verified against the real logs on this machine (72 files, 89 MB). Totals are identical to the current code — 1397 records, 224,155,863 input and 1,261,955 output tokens, same per-model breakdown — and a full aggregate over a frozen copy of those logs drops from 2328 ms to 916 ms (median of 5 runs, page cache warm for both). A first attempt also skipped lines with no `usage` substring before decoding them; that turned out to be slower than not doing it, because `String.contains` on a `Substring` goes through Unicode-aware search and cost more than the JSON decoding it avoided, so it is not part of this change.

Verified with a Debug build (`xcodebuild -scheme DynamicIsland -configuration Debug CODE_SIGNING_ALLOWED=NO build`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved LLM Usage refresh behavior by skipping session logs older than seven days.
  * Ensured repeated records within the active window are counted when earlier copies were previously suppressed.
  * Prevented outdated records from affecting duplicate detection.
  * Retained files when modification dates cannot be read, ensuring their data is still considered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->