### PR TITLE
Stop camera and microphone monitors when their detection settings are off

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed Open, Open With, Show in Finder, Quick Look, Compress, Copy Path, and the image actions all missing from the Shelf file context menu, caused by `ShelfItem.fileURL` returning a hard-coded `nil` for files (#682).
 - Fixed the notch auto-closing in the middle of a drag and cancelling the session: dragging an item out necessarily takes the cursor off the panel, which tore down the view acting as the drag source (#682).
 - Fixed an issue where scrolling a long note inside the Dynamic Island returned the view to the home view instead of scrolling the note. (`#636`)
+- Turning off Camera or Microphone detection now stops the monitor behind it instead of only hiding its indicator, and turning it back on starts it without relaunching the app (#692).
 
 ### Removed
 

--- a/DynamicIsland/managers/PrivacyIndicatorManager.swift
+++ b/DynamicIsland/managers/PrivacyIndicatorManager.swift
@@ -94,6 +94,12 @@ class PrivacyIndicatorManager: ObservableObject {
     
     // MARK: - Cancellables
     private var cancellables = Set<AnyCancellable>()
+
+    /// Whether the app has asked for monitoring. A settings change picks which
+    /// monitors run inside an active session; it does not open one, so a run that
+    /// never calls `startMonitoring()` — UI testing, for one — stays quiet however
+    /// the settings move.
+    private var monitoringRequested = false
     
     // MARK: - Computed Properties
     
@@ -189,8 +195,24 @@ class PrivacyIndicatorManager: ObservableObject {
                 }
             }
             .store(in: &cancellables)
+
+        // Follow the detection settings. They used to be read only when deciding
+        // what to draw, so switching one off hid its indicator while leaving the
+        // monitor registered and publishing. Reacting to the change here means
+        // the switch also starts and stops the monitor behind it, without a
+        // relaunch. `options: []` so this does not fire before the app has asked
+        // for monitoring to start.
+        Defaults.publisher(.enableCameraDetection, options: [])
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in self?.applyDetectionSettings() }
+            .store(in: &cancellables)
+
+        Defaults.publisher(.enableMicrophoneDetection, options: [])
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in self?.applyDetectionSettings() }
+            .store(in: &cancellables)
     }
-    
+
     /// Log layout changes for debugging
     private func logLayoutChange() {
         print("PrivacyIndicatorManager: 🔄 Layout changed to: \(indicatorLayout.description)")
@@ -199,34 +221,51 @@ class PrivacyIndicatorManager: ObservableObject {
     
     // MARK: - Public Methods
     
-    /// Start monitoring all privacy indicators
+    /// Start monitoring the privacy indicators the user has enabled.
+    ///
+    /// Screen recording is already monitored by `ScreenRecordingManager`.
     func startMonitoring() {
-        print("PrivacyIndicatorManager: 🟢 Starting all monitors...")
-        
-        isMonitoring = true
-        
-        // Start camera monitoring
-        if cameraMonitor.isMonitoringAvailable {
-            cameraMonitor.startMonitoring()
+        print("PrivacyIndicatorManager: 🟢 Starting enabled monitors...")
+        monitoringRequested = true
+        applyDetectionSettings()
+        print("PrivacyIndicatorManager: ✅ Enabled monitors started")
+    }
+
+    /// Bring each child monitor in line with its setting.
+    ///
+    /// Both monitors ignore a redundant start or stop and clear their published
+    /// state when stopped, so this is safe to call whenever a setting moves.
+    private func applyDetectionSettings() {
+        guard monitoringRequested else { return }
+
+        if Defaults[.enableCameraDetection] {
+            if cameraMonitor.isMonitoringAvailable {
+                cameraMonitor.startMonitoring()
+            } else {
+                print("PrivacyIndicatorManager: ⚠️ Camera monitoring not available")
+            }
         } else {
-            print("PrivacyIndicatorManager: ⚠️ Camera monitoring not available")
+            cameraMonitor.stopMonitoring()
         }
-        
-        // Start microphone monitoring
-        if microphoneMonitor.isMonitoringAvailable {
-            microphoneMonitor.startMonitoring()
+
+        if Defaults[.enableMicrophoneDetection] {
+            if microphoneMonitor.isMonitoringAvailable {
+                microphoneMonitor.startMonitoring()
+            } else {
+                print("PrivacyIndicatorManager: ⚠️ Microphone monitoring not available")
+            }
         } else {
-            print("PrivacyIndicatorManager: ⚠️ Microphone monitoring not available")
+            microphoneMonitor.stopMonitoring()
         }
-        
-        // Screen recording is already monitored by ScreenRecordingManager
-        print("PrivacyIndicatorManager: ✅ All monitors started")
+
+        isMonitoring = cameraMonitor.isMonitoring || microphoneMonitor.isMonitoring
     }
     
     /// Stop monitoring all privacy indicators
     func stopMonitoring() {
         print("PrivacyIndicatorManager: 🛑 Stopping all monitors...")
-        
+
+        monitoringRequested = false
         isMonitoring = false
         
         cameraMonitor.stopMonitoring()

--- a/DynamicIsland/managers/PrivacyIndicatorManager.swift
+++ b/DynamicIsland/managers/PrivacyIndicatorManager.swift
@@ -275,8 +275,12 @@ class PrivacyIndicatorManager: ObservableObject {
     }
     
     /// Toggle monitoring state
+    ///
+    /// Asked against the request rather than the running monitors: with both
+    /// detection settings off a session is open with nothing in it, and reading
+    /// the monitors there would take the toggle for off and start one.
     func toggleMonitoring() {
-        if cameraMonitor.isMonitoring || microphoneMonitor.isMonitoring {
+        if monitoringRequested {
             stopMonitoring()
         } else {
             startMonitoring()


### PR DESCRIPTION
`enableCameraDetection` and `enableMicrophoneDetection` are only consulted when deciding what to draw — `indicatorLayout` and `hasAnyIndicator` — while `startMonitoring()` starts both child monitors regardless. Switching a detector off therefore hides its indicator but leaves the monitor in place: `CameraMonitor` keeps its CMIO property listener registered, `MicrophoneMonitor` keeps its CoreAudio one, and both keep publishing state changes. Since `PrivacyIndicatorManager` is an `@ObservedObject` on `ContentView`, those publications also keep invalidating the notch view for a feature the user turned off.

`startMonitoring()` now starts only the monitors whose setting is on, and the manager follows both settings so flipping one starts or stops the monitor behind it without a relaunch. Both child monitors already ignore a redundant start or stop and clear their published state when stopped, so reapplying the settings is safe at any point.

A settings change only picks which monitors run inside a session the app has already asked for; it does not open one. `startMonitoring()` records that request and `stopMonitoring()` clears it, so a run that deliberately never starts monitoring — the UI-testing path in `applicationDidFinishLaunching`, for one — stays quiet however the settings move.

`isMonitoring` now reports whether anything is actually being monitored rather than being set to `true` whenever `startMonitoring()` was called. That is what the live "Camera Status" / "Microphone Status" readout in Settings is gated on, so with both detectors off it now disappears instead of reporting on detectors that are switched off.

Nothing outside `PrivacyIndicatorManager.swift` changes, and the defaults are untouched, so a fresh install behaves exactly as before.

Verified with a Debug build (`xcodebuild -scheme DynamicIsland -configuration Debug CODE_SIGNING_ALLOWED=NO build`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Camera and microphone privacy monitoring now responds immediately when detection settings change.
  * Disabling detection stops the corresponding monitor, while re-enabling it restarts monitoring without requiring an app relaunch.
  * Monitoring now starts only for enabled and available camera or microphone features.

* **Documentation**
  * Added an unreleased changelog entry describing the updated monitoring behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->