### PR TITLE
Add an option to put the tab bar on the leading edge instead of the header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Draggable clipboard tab**: A `.notchTab` clipboard display mode shows clipboard history as a card grid inside the notch whose text, image, and single-file entries can be dragged straight out to Finder or other apps (drag = copy), with a hover × to delete a single item (#698).
 - **Shelf marquee selection**: Dragging on empty space in the Shelf now draws a rubber-band rectangle that selects every item it touches, matching Finder. Holding Shift unions the marquee with the existing selection instead of replacing it (#682).
 - **Shelf drag-out move toggle**: A new "Allow moving files when dragging out" setting (off by default) keeps drag-out copy-only. Offering a move operation previously let the receiving app relocate the original file out from under the user when the destination was on the same volume (#682).
+- **Tab bar position**: The notch tab switcher can sit as a rail down the leading edge instead of a row in the header, which stops the tab count from widening the open notch, and can optionally switch tabs on hover instead of on click. Both default to the current behaviour (#693).
 
 ### Changed
 - Improved the Dutch localization by adding missing translations, corrected terminology, and wording aligned with Apple's Dutch macOS conventions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Show the current Claude subscription plan (e.g. `Max 5x`) as a badge next to the Claude card title in the LLM Usage view (#684).
 - **AntiGravity Usage Tracking**: Track how much of Antigravity usage is left in the LLM Usage Monitor tab (both Gemini and Claude models)
 - **Shelf item removal**: Hovering a Shelf item now reveals a × button that removes just that item, with a VoiceOver-accessible "Remove from Shelf" action that works without hovering (#461).
+- **Tab bar position**: The notch tab switcher can sit as a rail down the leading edge instead of a row in the header, which stops the tab count from widening the open notch, and can optionally switch tabs on hover instead of on click. Both default to the current behaviour (#693).
 
 ### Changed
 - Improved the Dutch localization by adding missing translations, corrected terminology, and wording aligned with Apple's Dutch macOS conventions.

--- a/DynamicIsland/ContentView.swift
+++ b/DynamicIsland/ContentView.swift
@@ -56,6 +56,7 @@ struct ContentView: View {
     @State private var downloadManager = DownloadManager.shared
     @ObservedObject var shelfState = ShelfStateViewModel.shared
     
+    @Default(.tabBarPosition) var tabBarPosition
     @Default(.enableStatsFeature) var enableStatsFeature
     @Default(.showCpuGraph) var showCpuGraph
     @Default(.showMemoryGraph) var showMemoryGraph
@@ -1087,36 +1088,45 @@ struct ContentView: View {
               
               ZStack {
                   if vm.notchState == .open {
-                      Group {
-                          switch coordinator.currentView {
-                              case .home:
-                                  NotchHomeView(albumArtNamespace: albumArtNamespace)
-                              case .shelf:
-                                  NotchShelfView()
-                              case .timer:
-                                  NotchTimerView()
-                              case .stats:
-                                  NotchStatsView()
-                              case .llmUsage:
-                                  NotchLLMUsageView()
-                              case .colorPicker:
-                                  NotchColorPickerView()
-                            case .notes:
-                                NotchNotesView()
-                            case .clipboard:
-                                NotchClipboardView()
-                            case .terminal:
-                                NotchTerminalView()
-                            case .extensionExperience:
-                                if let payload = currentExtensionTabPayload() {
-                                    ExtensionNotchExperienceTabView(payload: payload)
-                                } else {
-                                    NotchHomeView(albumArtNamespace: albumArtNamespace)
-                                }
+                      HStack(spacing: 0) {
+                          // The tab rail, when the tab bar is set to the leading
+                          // edge rather than the header.
+                          if tabBarPosition == .left {
+                              TabSelectionView()
+                                  .padding(.trailing, 12)
                           }
+
+                          Group {
+                              switch coordinator.currentView {
+                                  case .home:
+                                      NotchHomeView(albumArtNamespace: albumArtNamespace)
+                                  case .shelf:
+                                      NotchShelfView()
+                                  case .timer:
+                                      NotchTimerView()
+                                  case .stats:
+                                      NotchStatsView()
+                                  case .llmUsage:
+                                      NotchLLMUsageView()
+                                  case .colorPicker:
+                                      NotchColorPickerView()
+                                case .notes:
+                                    NotchNotesView()
+                                case .clipboard:
+                                    NotchClipboardView()
+                                case .terminal:
+                                    NotchTerminalView()
+                                case .extensionExperience:
+                                    if let payload = currentExtensionTabPayload() {
+                                        ExtensionNotchExperienceTabView(payload: payload)
+                                    } else {
+                                        NotchHomeView(albumArtNamespace: albumArtNamespace)
+                                    }
+                              }
+                          }
+                          .id(coordinator.currentView)
+                          .transition(tabSwitchTransition)
                       }
-                      .id(coordinator.currentView)
-                      .transition(tabSwitchTransition)
                   }
               }
               .zIndex(1)

--- a/DynamicIsland/ContentView.swift
+++ b/DynamicIsland/ContentView.swift
@@ -56,6 +56,7 @@ struct ContentView: View {
     @State private var downloadManager = DownloadManager.shared
     @ObservedObject var shelfState = ShelfStateViewModel.shared
     
+    @Default(.tabBarPosition) var tabBarPosition
     @Default(.enableStatsFeature) var enableStatsFeature
     @Default(.showCpuGraph) var showCpuGraph
     @Default(.showMemoryGraph) var showMemoryGraph
@@ -1080,36 +1081,45 @@ struct ContentView: View {
               
               ZStack {
                   if vm.notchState == .open {
-                      Group {
-                          switch coordinator.currentView {
-                              case .home:
-                                  NotchHomeView(albumArtNamespace: albumArtNamespace)
-                              case .shelf:
-                                  NotchShelfView()
-                              case .timer:
-                                  NotchTimerView()
-                              case .stats:
-                                  NotchStatsView()
-                              case .llmUsage:
-                                  NotchLLMUsageView()
-                              case .colorPicker:
-                                  NotchColorPickerView()
-                            case .notes:
-                                NotchNotesView()
-                            case .clipboard:
-                                NotchNotesView()
-                            case .terminal:
-                                NotchTerminalView()
-                            case .extensionExperience:
-                                if let payload = currentExtensionTabPayload() {
-                                    ExtensionNotchExperienceTabView(payload: payload)
-                                } else {
-                                    NotchHomeView(albumArtNamespace: albumArtNamespace)
-                                }
+                      HStack(spacing: 0) {
+                          // The tab rail, when the tab bar is set to the leading
+                          // edge rather than the header.
+                          if tabBarPosition == .left {
+                              TabSelectionView()
+                                  .padding(.trailing, 12)
                           }
+
+                          Group {
+                              switch coordinator.currentView {
+                                  case .home:
+                                      NotchHomeView(albumArtNamespace: albumArtNamespace)
+                                  case .shelf:
+                                      NotchShelfView()
+                                  case .timer:
+                                      NotchTimerView()
+                                  case .stats:
+                                      NotchStatsView()
+                                  case .llmUsage:
+                                      NotchLLMUsageView()
+                                  case .colorPicker:
+                                      NotchColorPickerView()
+                                case .notes:
+                                    NotchNotesView()
+                                case .clipboard:
+                                    NotchNotesView()
+                                case .terminal:
+                                    NotchTerminalView()
+                                case .extensionExperience:
+                                    if let payload = currentExtensionTabPayload() {
+                                        ExtensionNotchExperienceTabView(payload: payload)
+                                    } else {
+                                        NotchHomeView(albumArtNamespace: albumArtNamespace)
+                                    }
+                              }
+                          }
+                          .id(coordinator.currentView)
+                          .transition(tabSwitchTransition)
                       }
-                      .id(coordinator.currentView)
-                      .transition(tabSwitchTransition)
                   }
               }
               .zIndex(1)

--- a/DynamicIsland/components/Notch/DynamicIslandHeader.swift
+++ b/DynamicIsland/components/Notch/DynamicIslandHeader.swift
@@ -40,11 +40,14 @@ struct DynamicIslandHeader: View {
     @Default(.showBatteryPercentInside) var showBatteryPercentInside
     @Default(.showMinimalisticBatteryIndicator) var showMinimalisticBatteryIndicator
     @Default(.enableMinimalisticUI) var enableMinimalisticUI
-    
+    @Default(.tabBarPosition) var tabBarPosition
+
     var body: some View {
         HStack(spacing: 0) {
             HStack {
-                if !enableMinimalisticUI {
+                // With the tab bar on the left it is drawn beside the content
+                // instead, so the header keeps only its trailing controls.
+                if !enableMinimalisticUI && tabBarPosition == .top {
                     let shouldShowTabs = coordinator.alwaysShowTabs || vm.notchState == .open || !shelfState.items.isEmpty
                     if shouldShowTabs {
                         TabSelectionView()

--- a/DynamicIsland/components/Settings/SettingsView.swift
+++ b/DynamicIsland/components/Settings/SettingsView.swift
@@ -4297,6 +4297,7 @@ struct Appearance: View {
     @Default(.enableLockScreenMediaWidget) private var enableLockScreenMediaWidget
     @Default(.enableLockScreenTimerWidget) private var enableLockScreenTimerWidget
     @Default(.externalDisplayStyle) private var externalDisplayStyle
+    @Default(.tabBarPosition) private var tabBarPosition
     @State private var selectedListVisualizer: CustomVisualizer? = nil
 
     @State private var isIconImporterPresented = false
@@ -4402,6 +4403,8 @@ struct Appearance: View {
                     Text("Display Style")
                 }
             }
+
+            tabBarControls()
 
             notchWidthControls()
 
@@ -4920,6 +4923,35 @@ struct Appearance: View {
         }
 
         return false
+    }
+
+    @ViewBuilder
+    private func tabBarControls() -> some View {
+        Section {
+            Picker("Position", selection: $tabBarPosition) {
+                ForEach(TabBarPosition.allCases, id: \.self) { position in
+                    Text(position.displayName).tag(position)
+                }
+            }
+            .settingsHighlight(id: highlightID("Tab bar position"))
+            Text(tabBarPosition.description)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            Defaults.Toggle(key: .tabSwitchOnHover) {
+                Text("Switch tabs on hover")
+            }
+            .settingsHighlight(id: highlightID("Switch tabs on hover"))
+            Text("Resting the pointer on a tab selects it, without a click.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        } header: {
+            Text("Tab Bar")
+        }
+        .onChange(of: tabBarPosition) { _, _ in
+            // The leading rail and the header row need different widths.
+            enforceMinimumNotchWidth()
+        }
     }
 
     @ViewBuilder

--- a/DynamicIsland/components/Settings/SettingsView.swift
+++ b/DynamicIsland/components/Settings/SettingsView.swift
@@ -4290,6 +4290,7 @@ struct Appearance: View {
     @Default(.enableLockScreenMediaWidget) private var enableLockScreenMediaWidget
     @Default(.enableLockScreenTimerWidget) private var enableLockScreenTimerWidget
     @Default(.externalDisplayStyle) private var externalDisplayStyle
+    @Default(.tabBarPosition) private var tabBarPosition
     @State private var selectedListVisualizer: CustomVisualizer? = nil
 
     @State private var isIconImporterPresented = false
@@ -4395,6 +4396,8 @@ struct Appearance: View {
                     Text("Display Style")
                 }
             }
+
+            tabBarControls()
 
             notchWidthControls()
 
@@ -4913,6 +4916,35 @@ struct Appearance: View {
         }
 
         return false
+    }
+
+    @ViewBuilder
+    private func tabBarControls() -> some View {
+        Section {
+            Picker("Position", selection: $tabBarPosition) {
+                ForEach(TabBarPosition.allCases, id: \.self) { position in
+                    Text(position.displayName).tag(position)
+                }
+            }
+            .settingsHighlight(id: highlightID("Tab bar position"))
+            Text(tabBarPosition.description)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            Defaults.Toggle(key: .tabSwitchOnHover) {
+                Text("Switch tabs on hover")
+            }
+            .settingsHighlight(id: highlightID("Switch tabs on hover"))
+            Text("Resting the pointer on a tab selects it, without a click.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        } header: {
+            Text("Tab Bar")
+        }
+        .onChange(of: tabBarPosition) { _, _ in
+            // The leading rail and the header row need different widths.
+            enforceMinimumNotchWidth()
+        }
     }
 
     @ViewBuilder

--- a/DynamicIsland/components/Tabs/TabSelectionView.swift
+++ b/DynamicIsland/components/Tabs/TabSelectionView.swift
@@ -67,10 +67,19 @@ struct TabSelectionView: View {
     /// Which tab the pointer is currently resting on, when hover switching is on.
     @State private var hoveredTabID: String?
 
+    /// Whether hover switching may act yet. The tab bar is built when the notch
+    /// opens, and the notch opens under a pointer that is already sitting there,
+    /// so the first hover it reports belongs to the pointer that opened the notch
+    /// rather than to a choice. Acting on that switches tabs on its own.
+    @State private var hoverArmed = false
+
     /// Long enough that a pointer crossing the rail on its way elsewhere does not
     /// drag the selection with it, short enough that a deliberate hover still
     /// feels immediate.
     private let hoverDwell = Duration.milliseconds(150)
+
+    /// Time the notch is given to finish opening before a hover counts as intent.
+    private let hoverArmingDelay = Duration.milliseconds(500)
     
     private var tabs: [TabModel] {
         var tabsArray: [TabModel] = []
@@ -194,8 +203,16 @@ struct TabSelectionView: View {
         }
         // Moving on to another icon cancels the pending switch along with the
         // task, so only the icon actually rested on ever wins.
+        // Arms hover switching once, a beat after the bar appears.
+        .task {
+            hoverArmed = false
+            try? await Task.sleep(for: hoverArmingDelay)
+            guard !Task.isCancelled else { return }
+            hoverArmed = true
+        }
         .task(id: hoveredTabID) {
             guard tabSwitchOnHover,
+                  hoverArmed,
                   let hoveredTabID,
                   let tab = tabs.first(where: { $0.id == hoveredTabID }),
                   !isSelected(tab)

--- a/DynamicIsland/components/Tabs/TabSelectionView.swift
+++ b/DynamicIsland/components/Tabs/TabSelectionView.swift
@@ -60,7 +60,17 @@ struct TabSelectionView: View {
     @Default(.showMirror) private var showMirror
     @Default(.showStandardMediaControls) private var showStandardMediaControls
     @Default(.enableMinimalisticUI) private var enableMinimalisticUI
+    @Default(.tabBarPosition) private var tabBarPosition
+    @Default(.tabSwitchOnHover) private var tabSwitchOnHover
     @Namespace var animation
+
+    /// Which tab the pointer is currently resting on, when hover switching is on.
+    @State private var hoveredTabID: String?
+
+    /// Long enough that a pointer crossing the rail on its way elsewhere does not
+    /// drag the selection with it, short enough that a deliberate hover still
+    /// feels immediate.
+    private let hoverDwell = Duration.milliseconds(150)
     
     private var tabs: [TabModel] {
         var tabsArray: [TabModel] = []
@@ -113,20 +123,35 @@ struct TabSelectionView: View {
         }
         return tabsArray
     }
+    @ViewBuilder
     var body: some View {
-        HStack(spacing: 24) {
+        if tabBarPosition == .left {
+            tabStack(vertical: true)
+        } else {
+            // Clipping a column to a capsule would cut the first and last icon,
+            // so the shape stays with the row it was drawn for.
+            tabStack(vertical: false)
+                .clipShape(Capsule())
+        }
+    }
+
+    private func tabStack(vertical: Bool) -> some View {
+        // A layout rather than two stacks, so switching position moves the
+        // icons instead of tearing the view down and building it again.
+        let layout = vertical
+            ? AnyLayout(VStackLayout(spacing: 4))
+            : AnyLayout(HStackLayout(spacing: 24))
+
+        let stack = layout {
             ForEach(Array(tabs.enumerated()), id: \.element.id) { idx, tab in
                 let isSelected = isSelected(tab)
                 let activeAccent = tab.accentColor ?? .white
 
                 // Render the tab button
                 TabButton(label: tab.label, icon: tab.icon, selected: isSelected) {
-                    if tab.view == .extensionExperience {
-                        coordinator.selectedExtensionExperienceID = tab.experienceID
-                    }
-                    coordinator.currentView = tab.view
+                    select(tab)
                 }
-                .frame(height: 26)
+                .frame(width: vertical ? 30 : nil, height: 26)
                 .foregroundStyle(isSelected ? activeAccent : .gray)
                 .background {
                     if isSelected {
@@ -141,14 +166,52 @@ struct TabSelectionView: View {
                             .hidden()
                     }
                 }
-
-                
+                .onHover { inside in
+                    guard tabSwitchOnHover else { return }
+                    if inside {
+                        hoveredTabID = tab.id
+                    } else if hoveredTabID == tab.id {
+                        hoveredTabID = nil
+                    }
+                }
             }
         }
-        .clipShape(Capsule())
+
+        return Group {
+            if vertical {
+                // Enough tabs to outrun the open notch's height would otherwise
+                // be clipped; scrolling keeps the last of them reachable, and
+                // stays inert while they all fit.
+                ScrollView(.vertical, showsIndicators: false) { stack }
+                    .scrollBounceBehavior(.basedOnSize)
+                    .frame(width: 30)
+            } else {
+                stack
+            }
+        }
         .onAppear {
             ensureValidSelection(with: tabs)
         }
+        // Moving on to another icon cancels the pending switch along with the
+        // task, so only the icon actually rested on ever wins.
+        .task(id: hoveredTabID) {
+            guard tabSwitchOnHover,
+                  let hoveredTabID,
+                  let tab = tabs.first(where: { $0.id == hoveredTabID }),
+                  !isSelected(tab)
+            else { return }
+
+            try? await Task.sleep(for: hoverDwell)
+            guard !Task.isCancelled else { return }
+            select(tab)
+        }
+    }
+
+    private func select(_ tab: TabModel) {
+        if tab.view == .extensionExperience {
+            coordinator.selectedExtensionExperienceID = tab.experienceID
+        }
+        coordinator.currentView = tab.view
     }
 
     private var extensionTabsEnabled: Bool {

--- a/DynamicIsland/models/Constants.swift
+++ b/DynamicIsland/models/Constants.swift
@@ -137,6 +137,28 @@ enum AnimationSource: Codable, Hashable, Equatable {
     }
 }
 
+// MARK: - Tab Bar Models
+
+/// Where the notch tab switcher sits once the notch is open.
+enum TabBarPosition: String, CaseIterable, Codable, Defaults.Serializable {
+    case top = "top"   // A row in the header, beside the notch cutout
+    case left = "left" // A rail down the leading edge, beside the content
+
+    var displayName: String {
+        switch self {
+        case .top: return String(localized: "Top")
+        case .left: return String(localized: "Left")
+        }
+    }
+
+    var description: String {
+        switch self {
+        case .top: return String(localized: "Icons sit in a row above the content")
+        case .left: return String(localized: "Icons sit in a column beside the content, leaving the notch narrower")
+        }
+    }
+}
+
 // MARK: - Extension Authorization Models
 
 enum ExtensionPermissionScope: String, CaseIterable, Codable, Defaults.Serializable {
@@ -1164,6 +1186,10 @@ extension Defaults.Keys {
     static let terminalCursorColor = Key<Color>("terminalCursorColor", default: Color(.selectedControlColor))
     static let terminalStickyMode = Key<Bool>("terminalStickyMode", default: false)
     
+    // MARK: Tab Bar
+    static let tabBarPosition = Key<TabBarPosition>("tabBarPosition", default: .top)
+    static let tabSwitchOnHover = Key<Bool>("tabSwitchOnHover", default: false)
+
     // MARK: Timer Feature
     static let enableTimerFeature = Key<Bool>("enableTimerFeature", default: true)
     static let timerDisplayMode = Key<TimerDisplayMode>("timerDisplayMode", default: .tab)

--- a/DynamicIsland/models/Constants.swift
+++ b/DynamicIsland/models/Constants.swift
@@ -137,6 +137,28 @@ enum AnimationSource: Codable, Hashable, Equatable {
     }
 }
 
+// MARK: - Tab Bar Models
+
+/// Where the notch tab switcher sits once the notch is open.
+enum TabBarPosition: String, CaseIterable, Codable, Defaults.Serializable {
+    case top = "top"   // A row in the header, beside the notch cutout
+    case left = "left" // A rail down the leading edge, beside the content
+
+    var displayName: String {
+        switch self {
+        case .top: return String(localized: "Top")
+        case .left: return String(localized: "Left")
+        }
+    }
+
+    var description: String {
+        switch self {
+        case .top: return String(localized: "Icons sit in a row above the content")
+        case .left: return String(localized: "Icons sit in a column beside the content, leaving the notch narrower")
+        }
+    }
+}
+
 // MARK: - Extension Authorization Models
 
 enum ExtensionPermissionScope: String, CaseIterable, Codable, Defaults.Serializable {
@@ -1150,6 +1172,10 @@ extension Defaults.Keys {
     static let terminalCursorColor = Key<Color>("terminalCursorColor", default: Color(.selectedControlColor))
     static let terminalStickyMode = Key<Bool>("terminalStickyMode", default: false)
     
+    // MARK: Tab Bar
+    static let tabBarPosition = Key<TabBarPosition>("tabBarPosition", default: .top)
+    static let tabSwitchOnHover = Key<Bool>("tabSwitchOnHover", default: false)
+
     // MARK: Timer Feature
     static let enableTimerFeature = Key<Bool>("enableTimerFeature", default: true)
     static let timerDisplayMode = Key<TimerDisplayMode>("timerDisplayMode", default: .tab)

--- a/DynamicIsland/sizing/matters.swift
+++ b/DynamicIsland/sizing/matters.swift
@@ -100,9 +100,11 @@ let tabRailWidth: CGFloat = 42
 
 /// Returns the recommended minimum notch width for the given tab count.
 func recommendedMinimumNotchWidth(forTabCount count: Int) -> CGFloat {
-    // A rail spends height per tab rather than width, so the count stops driving
-    // how wide the notch has to be — only the rail itself does. That is why the
-    // leading position leaves the notch narrower once there are five or more tabs.
+    // A rail spends height per tab rather than width, so the tab count stops
+    // driving the width. What the leading position still needs is the 640pt of
+    // content a header of up to four tabs leaves, plus the width the rail takes
+    // out of it — a constant 682pt, under the 690 and 770 a header row asks for
+    // at five and six tabs.
     if Defaults[.tabBarPosition] == .left { return 640 + tabRailWidth }
     if count >= 6 { return 770 }
     if count >= 5 { return 690 }

--- a/DynamicIsland/sizing/matters.swift
+++ b/DynamicIsland/sizing/matters.swift
@@ -95,8 +95,15 @@ func enabledStandardTabCount() -> Int {
     return count
 }
 
+/// Width the leading tab rail occupies: the icons plus the gap to the content.
+let tabRailWidth: CGFloat = 42
+
 /// Returns the recommended minimum notch width for the given tab count.
 func recommendedMinimumNotchWidth(forTabCount count: Int) -> CGFloat {
+    // A rail spends height per tab rather than width, so the count stops driving
+    // how wide the notch has to be — only the rail itself does. That is why the
+    // leading position leaves the notch narrower once there are five or more tabs.
+    if Defaults[.tabBarPosition] == .left { return 640 + tabRailWidth }
     if count >= 6 { return 770 }
     if count >= 5 { return 690 }
     return 640


### PR DESCRIPTION
The tab switcher is a row in the header beside the notch cutout, and that row has to fit across the width of the notch. `recommendedMinimumNotchWidth` grows the open notch as tabs are enabled to make room for it — 640pt up to four tabs, 690pt at five, 770pt at six — so enabling Stats, Usage, Terminal and the rest widens the notch by a fifth for reasons that have nothing to do with what the tabs display.

This adds `tabBarPosition`, which can put the switcher in a column down the leading edge of the content instead. A rail spends height per tab rather than width, so the tab count stops driving the notch width: the leading position keeps the 640pt of content a header of up to four tabs leaves and adds the 42pt the rail takes out of it, so the minimum is a constant 682pt however many tabs are on, against the 690 and 770 a header row asks for at five and six.

It also adds `tabSwitchOnHover`, where resting the pointer on a tab selects it. The 150 ms before it commits is what separates a pointer that came to choose from one crossing the rail on its way somewhere else, and moving on to another icon cancels the pending switch along with its task, so only the icon actually rested on wins.

Both settings default to today's behaviour — `.top` and off — so a fresh install is unchanged and the feature is entirely opt-in from Appearance settings.

`TabSelectionView` switches between `HStackLayout` and `VStackLayout` through `AnyLayout` rather than branching into two separate stacks, so changing the position moves the icons instead of tearing them down and rebuilding them, and the `matchedGeometryEffect` on the selection capsule survives the change. The capsule clip stays with the row it was drawn for, since clipping a column to a capsule would cut the first and last icon. In the column the tabs sit in a `ScrollView` with `.scrollBounceBehavior(.basedOnSize)`: the rail sits beside the content rather than above it, so it gets what the header leaves — about 150pt — and at 26pt per tab with 4pt of spacing that is five icons before the sixth needs scrolling to, as the screenshot below shows. A rail whose tabs all fit behaves exactly like a plain column.

In `ContentView` the rail is added inside the existing `ZStack` rather than around it, so the surrounding modifiers are untouched and the default path renders the same view tree it does today. `DynamicIslandHeader` simply stops drawing the switcher when the position is leading.

Verified with a Debug build (`xcodebuild -scheme DynamicIsland -configuration Debug CODE_SIGNING_ALLOWED=NO build`).

Both shots below have the same six tabs on — Home, Shelf, Timer, Stats, Notes and Terminal — so the only difference is where the switcher sits.

Today, a row in the header. Six tabs put the minimum at 770pt:

![Tab bar in the header](https://raw.githubusercontent.com/vlnd0/Atoll/assets/pr-693/docs/screenshots/tabbar-top.png)

With the rail, a constant 682pt whatever the tab count. Five icons show and the sixth is a scroll away:

![Tab bar as a leading rail](https://raw.githubusercontent.com/vlnd0/Atoll/assets/pr-693/docs/screenshots/tabbar-left.png)

Happy to adjust the rail's width, spacing or the dwell interval if you would rather they were different.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an option to position the tab bar along the left side as a vertical rail or keep it at the top.
  * Added optional hover-based tab switching with a brief hover delay.
  * Added appearance settings for tab-bar placement and hover switching, including localized descriptions.
  * Updated layout sizing automatically when using the left-side tab rail.
* **Documentation**
  * Documented the new tab-bar positioning and hover-switching options in the unreleased changelog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

