### PR TITLE
Do not query LRCLIB while lyrics are switched off

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed the AirPods pause gesture opening Siri instead of pausing Spotify: the real-time waveform no longer process-taps Spotify while a Bluetooth output route is active, and the tap is rebuilt whenever the output route changes.
 - Fixed Noise Cancellation, Adaptive Audio, and Conversation Awareness labels being clipped behind the notch in the AirPods listening-mode HUD; every mode is now trailing-aligned and scales down instead of scrolling.
 - Fix crash when Apple Notes sync encounters duplicate remote note IDs
+- Stopped sending the track title and artist to LRCLIB on every track change while lyrics are switched off; the setting now gates the request, not just the placeholder text (#694).
 
 ### Removed
 

--- a/DynamicIsland/managers/MusicManager.swift
+++ b/DynamicIsland/managers/MusicManager.swift
@@ -1333,22 +1333,35 @@ class MusicManager: ObservableObject {
         }
     }
 
+    /// Drops any lyrics state and stops an in-flight fetch.
+    private func discardLyrics() {
+        activeLyricsKey = nil
+        lyricsFetchKey = nil
+        lyricsFetchTask?.cancel()
+        lyricsFetchTask = nil
+        syncedLyrics = []
+        currentLyrics = ""
+        currentLyricIndex = -1
+        stopLyricSync()
+    }
+
     private func prepareLyricsForCurrentTrack(forceFetch: Bool = false, prioritizeVisibleResult: Bool = false) {
+        // `enableLyrics` reached only as far as the display: with lyrics switched
+        // off the placeholder was suppressed, but the track title and artist were
+        // still sent to LRCLIB on every track change, and nothing consumed the
+        // reply. Stop before the request rather than after it.
+        guard Defaults[.enableLyrics] else {
+            discardLyrics()
+            return
+        }
+
         guard let lookup = currentLyricsLookupContext() else {
-            activeLyricsKey = nil
-            lyricsFetchKey = nil
-            lyricsFetchTask?.cancel()
-            lyricsFetchTask = nil
-            syncedLyrics = []
-            currentLyrics = ""
-            currentLyricIndex = -1
-            stopLyricSync()
+            discardLyrics()
             return
         }
 
         let key = lookup.key
-        let lyricsEnabled = Defaults[.enableLyrics]
-        let shouldShowLoading = lyricsEnabled && prioritizeVisibleResult
+        let shouldShowLoading = prioritizeVisibleResult
         let trackChanged = activeLyricsKey != key
         activeLyricsKey = key
 
@@ -1374,7 +1387,7 @@ class MusicManager: ObservableObject {
         lyricsFetchTask?.cancel()
         lyricsFetchKey = key
 
-        if shouldShowLoading || (lyricsEnabled && syncedLyrics.isEmpty) {
+        if shouldShowLoading || syncedLyrics.isEmpty {
             currentLyrics = "Loading lyrics..."
         }
 
@@ -1408,7 +1421,7 @@ class MusicManager: ObservableObject {
                     self.lyricsFetchTask = nil
                     self.syncedLyrics = []
                     self.currentLyricIndex = -1
-                    self.currentLyrics = lyricsEnabled ? "No lyrics found" : ""
+                    self.currentLyrics = "No lyrics found"
                     self.stopLyricSync()
                 }
             }

--- a/DynamicIsland/managers/MusicManager.swift
+++ b/DynamicIsland/managers/MusicManager.swift
@@ -514,6 +514,10 @@ class MusicManager: ObservableObject {
     private var lyricSyncTask: Task<Void, Never>?
     private var lyricsFetchTask: Task<Void, Never>?
     private var lyricsFetchKey: LyricsLookupKey?
+    // Identity of the fetch that is allowed to write lyrics state. A cancelled
+    // task can still reach its completion handler, and the key alone does not
+    // tell it apart from a newer fetch for the same track.
+    private var lyricsFetchID: UUID?
     private var activeLyricsKey: LyricsLookupKey?
     private var lyricsCache: [LyricsLookupKey: [LyricLine]] = [:]
     // Bounded, insertion-order eviction so the cache cannot grow unboundedly.
@@ -1329,7 +1333,7 @@ class MusicManager: ObservableObject {
         if isEnabled {
             prepareLyricsForCurrentTrack(prioritizeVisibleResult: true)
         } else {
-            stopLyricSync()
+            discardLyrics()
         }
     }
 
@@ -1337,6 +1341,7 @@ class MusicManager: ObservableObject {
     private func discardLyrics() {
         activeLyricsKey = nil
         lyricsFetchKey = nil
+        lyricsFetchID = nil
         lyricsFetchTask?.cancel()
         lyricsFetchTask = nil
         syncedLyrics = []
@@ -1386,6 +1391,8 @@ class MusicManager: ObservableObject {
 
         lyricsFetchTask?.cancel()
         lyricsFetchKey = key
+        let fetchID = UUID()
+        lyricsFetchID = fetchID
 
         if shouldShowLoading || syncedLyrics.isEmpty {
             currentLyrics = "Loading lyrics..."
@@ -1407,17 +1414,19 @@ class MusicManager: ObservableObject {
                 guard !Task.isCancelled else { return }
 
                 await MainActor.run {
-                    guard self.activeLyricsKey == key else { return }
+                    guard self.lyricsFetchID == fetchID, self.activeLyricsKey == key else { return }
                     self.storeLyricsInCache(lyrics, for: key)
                     self.lyricsFetchKey = nil
+                    self.lyricsFetchID = nil
                     self.lyricsFetchTask = nil
                     self.applyLyricsToDisplay(lyrics)
                 }
             } catch {
                 print("Failed to fetch lyrics: \(error)")
                 await MainActor.run {
-                    guard self.activeLyricsKey == key else { return }
+                    guard self.lyricsFetchID == fetchID, self.activeLyricsKey == key else { return }
                     self.lyricsFetchKey = nil
+                    self.lyricsFetchID = nil
                     self.lyricsFetchTask = nil
                     self.syncedLyrics = []
                     self.currentLyricIndex = -1


### PR DESCRIPTION
With lyrics switched off, changing tracks still sends the track title and artist to `https://lrclib.net/api/search`. `prepareLyricsForCurrentTrack` reads `Defaults[.enableLyrics]`, but only to decide whether to put "Loading lyrics…" on screen and what to say when the lookup fails; the fetch task below runs either way. Its one caller on the playback path — the artwork/state handler in `MusicManager` — is unconditional, so the request goes out on every track change whether or not anything will display the result.

That makes the setting look like it turns the feature off while a third party keeps receiving a running list of what the user is playing, and it spends a request and a JSON decode per track on a result that is then dropped.

`prepareLyricsForCurrentTrack` now returns before the fetch when lyrics are disabled, clearing any lyrics state and cancelling a fetch already in flight. Turning the setting back on goes through `handleLyricsPreferenceChange`, which asks for the current track again, so the lyrics appear without waiting for the next one. The other caller — the branch in the view model that fills an empty lyrics panel — was already behind `showLyrics` and is untouched.

Past the new guard `enableLyrics` is true by construction, so the two conditions that tested it again have been simplified rather than left to read as if the state were still in question. The shared clean-up used by both early exits is now one small method instead of the same eight lines twice.

Verified with a Debug build (`xcodebuild -scheme DynamicIsland -configuration Debug CODE_SIGNING_ALLOWED=NO build`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Disabled lyrics no longer trigger unnecessary lyric requests.
  * Lyrics state is cleared when the feature is turned off, preventing previously displayed lyrics from lingering.
  * Loading and empty-result messages now display correctly based on visible results.
  * Cancelled or outdated lyric requests can no longer overwrite newer lyrics results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->