### PR TITLE
fix: identify the preferred display by stable CGDirectDisplayID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improved the Dutch localization by adding missing translations, corrected terminology, and wording aligned with Apple's Dutch macOS conventions.
 - Refreshing the LLM Usage card now skips session logs whose last write predates the seven-day window instead of re-reading the whole log history, and counts a repeated record when the copy inside the window would previously have been suppressed by a copy outside it (#691).
 - The separate-tab clipboard now uses the same card grid (two columns) with drag-out and per-item delete, replacing the single-column list (#698).
+- Display selection ("Show on a specific display") now identifies displays by their stable `CGDirectDisplayID` instead of their localized name, so identical monitors can be told apart and the choice survives display renames; duplicate names are suffixed in the picker.
 
 ### Fixed
 - Reduced idle CPU from always-on notch hover polling and OSDUIHelper process checks by backing off when the app is idle (#641).

--- a/DynamicIsland/DynamicIslandApp.swift
+++ b/DynamicIsland/DynamicIslandApp.swift
@@ -1475,10 +1475,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         } else {
             let selectedScreen: NSScreen
 
-            if let preferredScreen = NSScreen.screens.first(where: {
-                $0.localizedName == coordinator.preferredScreen
-            }) {
-                coordinator.selectedScreen = coordinator.preferredScreen
+            if let preferredScreen = coordinator.preferredNSScreen() {
+                coordinator.selectedScreen = preferredScreen.localizedName
                 selectedScreen = preferredScreen
             } else if Defaults[.automaticallySwitchDisplay], let mainScreen = NSScreen.main {
                 coordinator.selectedScreen = mainScreen.localizedName

--- a/DynamicIsland/DynamicIslandViewCoordinator.swift
+++ b/DynamicIsland/DynamicIslandViewCoordinator.swift
@@ -164,14 +164,45 @@ class DynamicIslandViewCoordinator: ObservableObject {
             NotificationCenter.default.post(name: Notification.Name.selectedScreenChanged, object: nil)
         }
     }
-    
+
+    /// `CGDirectDisplayID` of the preferred display. Unlike `preferredScreen` (the
+    /// display's localized name), the ID tells identical monitors apart and survives
+    /// display renames. `0` means "not set" (legacy installs only stored the name).
+    @AppStorage("preferred_screen_id") var preferredScreenID: Int = 0 {
+        didSet {
+            NotificationCenter.default.post(name: Notification.Name.selectedScreenChanged, object: nil)
+        }
+    }
+
     @Published var selectedScreen: String = NSScreen.main?.localizedName ?? "Unknown"
+
+    /// The display the user picked in Settings, matched by stable display ID first
+    /// (identical monitors share a localized name), falling back to the legacy name.
+    func preferredNSScreen() -> NSScreen? {
+        if preferredScreenID != 0,
+           let match = NSScreen.screens.first(where: {
+               $0.displayID == CGDirectDisplayID(preferredScreenID)
+           }) {
+            return match
+        }
+        return NSScreen.screens.first(where: { $0.localizedName == preferredScreen })
+    }
+
+    /// Legacy installs only stored the preferred display's name; backfill its ID.
+    private func migratePreferredScreenIDIfNeeded() {
+        guard preferredScreenID == 0,
+              let match = NSScreen.screens.first(where: { $0.localizedName == preferredScreen }),
+              let id = match.displayID
+        else { return }
+        preferredScreenID = Int(id)
+    }
 
     @Published var optionKeyPressed: Bool = true
     private let extensionNotchExperienceManager = ExtensionNotchExperienceManager.shared
     
     private init() {
         selectedScreen = preferredScreen
+        migratePreferredScreenIDIfNeeded()
         Defaults.publisher(.timerDisplayMode)
             .receive(on: DispatchQueue.main)
             .sink { [weak self] change in

--- a/DynamicIsland/DynamicIslandViewCoordinator.swift
+++ b/DynamicIsland/DynamicIslandViewCoordinator.swift
@@ -176,16 +176,17 @@ class DynamicIslandViewCoordinator: ObservableObject {
 
     @Published var selectedScreen: String = NSScreen.main?.localizedName ?? "Unknown"
 
-    /// The display the user picked in Settings, matched by stable display ID first
-    /// (identical monitors share a localized name), falling back to the legacy name.
+    /// The display the user picked in Settings, matched by stable display ID
+    /// (identical monitors share a localized name). The legacy name lookup only
+    /// applies when no ID was stored yet — with an ID set, falling back to the
+    /// name could silently pick the wrong one of two identical displays.
     func preferredNSScreen() -> NSScreen? {
-        if preferredScreenID != 0,
-           let match = NSScreen.screens.first(where: {
-               $0.displayID == CGDirectDisplayID(preferredScreenID)
-           }) {
-            return match
+        guard preferredScreenID != 0 else {
+            return NSScreen.screens.first(where: { $0.localizedName == preferredScreen })
         }
-        return NSScreen.screens.first(where: { $0.localizedName == preferredScreen })
+        return NSScreen.screens.first(where: {
+            $0.displayID == CGDirectDisplayID(preferredScreenID)
+        })
     }
 
     /// Legacy installs only stored the preferred display's name; backfill its ID.

--- a/DynamicIsland/components/Settings/SettingsView.swift
+++ b/DynamicIsland/components/Settings/SettingsView.swift
@@ -1041,7 +1041,7 @@ struct SettingsView: View {
 }
 
 struct GeneralSettings: View {
-    @State private var screens: [String] = NSScreen.screens.compactMap { $0.localizedName }
+    @State private var screens: [(id: CGDirectDisplayID, label: String)] = NSScreen.displayPickerItems()
     @EnvironmentObject var vm: DynamicIslandViewModel
     @ObservedObject var coordinator = DynamicIslandViewCoordinator.shared
     @Default(.mirrorShape) var mirrorShape
@@ -1069,6 +1069,20 @@ struct GeneralSettings: View {
 
     private func highlightID(_ title: String) -> String {
         SettingsTab.general.highlightID(for: title)
+    }
+
+    /// Bridges the picker to the coordinator: persists the stable display ID and
+    /// keeps the legacy display-name preference in sync for downstream consumers.
+    private var preferredDisplayBinding: Binding<CGDirectDisplayID> {
+        Binding(
+            get: { CGDirectDisplayID(coordinator.preferredScreenID) },
+            set: { newID in
+                if let screen = NSScreen.screens.first(where: { $0.displayID == newID }) {
+                    coordinator.preferredScreen = screen.localizedName
+                }
+                coordinator.preferredScreenID = Int(newID)
+            }
+        )
     }
 
     var body: some View {
@@ -1118,13 +1132,13 @@ struct GeneralSettings: View {
                     NotificationCenter.default.post(name: Notification.Name.showOnAllDisplaysChanged, object: nil)
                 }
                 .settingsHighlight(id: highlightID("Show on all displays"))
-                Picker("Show on a specific display", selection: $coordinator.preferredScreen) {
-                    ForEach(screens, id: \.self) { screen in
-                        Text(screen)
+                Picker("Show on a specific display", selection: preferredDisplayBinding) {
+                    ForEach(screens, id: \.id) { screen in
+                        Text(screen.label).tag(screen.id)
                     }
                 }
                 .onChange(of: NSScreen.screens) {
-                    screens =  NSScreen.screens.compactMap({$0.localizedName})
+                    screens = NSScreen.displayPickerItems()
                 }
                 .disabled(showOnAllDisplays)
                 .settingsHighlight(id: highlightID("Show on a specific display"))

--- a/DynamicIsland/extensions/NSScreen+DisplayID.swift
+++ b/DynamicIsland/extensions/NSScreen+DisplayID.swift
@@ -1,0 +1,46 @@
+/*
+ * Atoll (DynamicIsland)
+ * Copyright (C) 2024-2026 Atoll Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import AppKit
+
+extension NSScreen {
+    /// Stable identifier of the underlying physical display (its `CGDirectDisplayID`).
+    ///
+    /// Unlike `localizedName`, the display ID tells identical monitors apart and
+    /// does not change when the display is renamed or the system locale changes.
+    var displayID: CGDirectDisplayID? {
+        (deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? NSNumber)?.uint32Value
+    }
+
+    /// `(id, label)` rows for display pickers.
+    ///
+    /// When several connected displays share a localized name (e.g. two identical
+    /// external monitors), a `" (n)"` suffix is appended so they stay distinguishable.
+    static func displayPickerItems() -> [(id: CGDirectDisplayID, label: String)] {
+        let screens = NSScreen.screens
+        var seen: [String: Int] = [:]
+        return screens.compactMap { screen in
+            guard let id = screen.displayID else { return nil }
+            let name = screen.localizedName
+            seen[name, default: 0] += 1
+            let isDuplicated = screens.contains { $0 != screen && $0.localizedName == name }
+            let label = isDuplicated ? "\(name) (\(seen[name, default: 1]))" : name
+            return (id, label)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

The **Show on a specific display** picker stored and matched displays by `localizedName`, which breaks down in multi-display setups:

- two identical monitors share the same localized name, so they cannot be told apart (and produce duplicate `ForEach` ids in the picker);
- the stored name does not survive display renames.

Changes:

- Add `NSScreen.displayID` (via `NSScreenNumber`) and `NSScreen.displayPickerItems()`, which suffixes duplicate names with `" (n)"` so identical monitors stay distinguishable in the picker.
- Persist `preferred_screen_id` alongside the legacy name preference; the preferred screen is resolved by ID first, falling back to the legacy name match. Legacy installs backfill the ID from the stored name on first launch.
- Bind the settings picker to the stable display ID, keeping the name preference in sync for downstream consumers.

The name-based plumbing downstream (view models, HUD targeting, sizing helpers) is intentionally unchanged, keeping the diff minimal.

- CHANGELOG entry added under `[Unreleased]`.

## Test plan

- `xcodebuild build -scheme DynamicIsland` succeeds (macOS 26.5.2, Xcode with Metal Toolchain).
- Existing behavior preserved for single-display setups and for the "Show on all displays" / "Automatically switch displays" toggles.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added reliable preferred-display selection that persists across display renames.
  - Improved display settings with stable display identification and automatic refresh when screens change.
  - Disambiguated duplicate display names in the display picker.

- **Bug Fixes**
  - Preserved selected-display settings when multiple screens share the same name.
  - Migrated existing name-based display preferences automatically.
  - Omitted displays that cannot be uniquely identified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->