### PR TITLE
fix(llm-usage): follow Claude Code's hash-suffixed Keychain item for quota

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fixed Codex Today and Week usage totals remaining at zero when parsing Codex session logs (#664).
 - Recover the Claude quota display after Claude Code rotates its OAuth token, instead of showing "quota unavailable" until the app is restarted (#685).
+- Fixed the Claude quota staying "quota unavailable" on recent Claude Code versions, which store the OAuth token under a per-install hash-suffixed Keychain item (`Claude Code-credentials-<hash>`) and no longer update the un-suffixed item the app read; the freshest matching item is now used (#699, follow-up to #685).
 - Normalized Claude model IDs when pricing local usage so newer IDs are costed instead of showing `US$0.00+`, and show an explicit unavailable/partial estimate when a model isn't in the pricing table (#683, #664).
 - Fixed an issue where `BluetoothHUDAnimations` (.mov files) were missing in release builds.
 - Improved the GitHub Actions release workflow to use a monotonic build number allocator and automated patch versioning for stable releases.

--- a/DynamicIsland/managers/LLMUsage/Quota/ClaudeQuotaClient.swift
+++ b/DynamicIsland/managers/LLMUsage/Quota/ClaudeQuotaClient.swift
@@ -128,14 +128,16 @@ struct ClaudeQuotaClient {
         await ClaudeCredentialStore.shared.reload(from: { Self.loadCredentialsFromSource() })
     }
 
-    // File first never prompts; Keychain only as fallback.
+    // File first never prompts; Keychain only as fallback. On the Keychain path, read the
+    // freshest "Claude Code-credentials*" item: newer Claude Code stores its token under a
+    // per-install hash suffix and no longer updates the un-suffixed item.
     private static func loadCredentialsFromSource() -> CredentialFile.OAuth? {
         let path = FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".claude/.credentials.json")
         if let data = try? Data(contentsOf: path),
            let parsed = try? JSONDecoder().decode(CredentialFile.self, from: data) {
             return parsed.claudeAiOauth
         }
-        guard let json = KeychainReader.genericPassword(service: "Claude Code-credentials"),
+        guard let json = KeychainReader.freshestGenericPassword(servicePrefix: "Claude Code-credentials"),
               let parsed = try? JSONDecoder().decode(CredentialFile.self, from: Data(json.utf8)) else { return nil }
         return parsed.claudeAiOauth
     }

--- a/DynamicIsland/managers/LLMUsage/Quota/KeychainReader.swift
+++ b/DynamicIsland/managers/LLMUsage/Quota/KeychainReader.swift
@@ -15,4 +15,34 @@ enum KeychainReader {
         guard status == errSecSuccess, let data = item as? Data else { return nil }
         return String(data: data, encoding: .utf8)
     }
+
+    // Read the secret of the most-recently-modified generic password whose service starts
+    // with `servicePrefix`. Claude Code namespaces its credential item by a per-install hash
+    // ("Claude Code-credentials-<hash>") and rotates it, leaving the un-suffixed item stale;
+    // following the freshest item keeps quota working across that migration without hardcoding
+    // a hash. The enumeration requests attributes only (no kSecReturnData), so decrypting — and
+    // the Keychain access prompt it triggers — happens exactly once, for the chosen item.
+    static func freshestGenericPassword(servicePrefix: String) -> String? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecReturnAttributes as String: true,
+            kSecMatchLimit as String: kSecMatchLimitAll
+        ]
+        var result: CFTypeRef?
+        guard SecItemCopyMatching(query as CFDictionary, &result) == errSecSuccess,
+              let items = result as? [[String: Any]] else { return nil }
+
+        let freshest = items
+            .compactMap { attrs -> (service: String, modified: Date)? in
+                guard let service = attrs[kSecAttrService as String] as? String,
+                      service.hasPrefix(servicePrefix),
+                      let modified = attrs[kSecAttrModificationDate as String] as? Date
+                else { return nil }
+                return (service, modified)
+            }
+            .max { $0.modified < $1.modified }
+
+        guard let freshest else { return nil }
+        return genericPassword(service: freshest.service)
+    }
 }


### PR DESCRIPTION
### Problem
On recent Claude Code versions the Claude card shows "quota unavailable" and never
recovers (even after restarting the app), while `/usage` inside Claude Code reports
fresh numbers.

### Root cause
Claude Code now stores its OAuth token under a per-install, hash-suffixed Keychain
service — `Claude Code-credentials-<hash>`, where the hash is `SHA256(CLAUDE_CONFIG_DIR)`
— and no longer updates the un-suffixed `Claude Code-credentials` item. The quota
reader hardcoded the un-suffixed name, so it kept reading a stale, expired token →
`validAccessToken` returns nil → no quota.

### Fix
- `KeychainReader.freshestGenericPassword(servicePrefix:)` enumerates all
  `Claude Code-credentials*` items by **attributes only** (no `kSecReturnData`, so no
  decrypt and no Keychain prompt), picks the most-recently-modified one, and reads only
  that item's secret (a single prompt).
- `loadCredentialsFromSource` reads via that prefix instead of the fixed name.

Atoll is a GUI process and can't see the shell's `CLAUDE_CONFIG_DIR`, so picking the
freshest item is what tracks whichever config directory Claude Code most recently wrote.

### Scope
- Orthogonal to #685's token-refresh recovery — only the credential *source* changes;
  the refresh path is untouched. Complements #685 for the modern hash-suffixed storage.

### Testing
Debug build; the Claude card's Session/Week gauges now populate and match Claude Code's
`/usage` (e.g. 8% session / 80% week) where it previously showed "quota unavailable".


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Claude quota retrieval for recent Claude Code versions.
  * The app now selects the newest available Claude credential, including credentials stored with versioned service names.
  * File-based credentials remain the preferred source, with Keychain credentials used as a fallback.

* **Documentation**
  * Added a changelog entry describing the Claude quota retrieval fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->