### PR TITLE
feat: add a language picker to General settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Show the current Claude subscription plan (e.g. `Max 5x`) as a badge next to the Claude card title in the LLM Usage view (#684).
 - **AntiGravity Usage Tracking**: Track how much of Antigravity usage is left in the LLM Usage Monitor tab (both Gemini and Claude models)
 - **Shelf item removal**: Hovering a Shelf item now reveals a × button that removes just that item, with a VoiceOver-accessible "Remove from Shelf" action that works without hovering (#461).
+- **Language picker**: choose the app's UI language in Settings → General, independent of the macOS system language (uses the standard per-app `AppleLanguages` mechanism and takes effect after restarting the app).
 
 ### Changed
 - Improved the Dutch localization by adding missing translations, corrected terminology, and wording aligned with Apple's Dutch macOS conventions.

--- a/DynamicIsland/components/Settings/SettingsView.swift
+++ b/DynamicIsland/components/Settings/SettingsView.swift
@@ -1099,15 +1099,15 @@ struct GeneralSettings: View {
         )
     }
 
-    /// Adopts an `AppleLanguages` override set outside the app (System Settings or
-    /// `defaults write`) so the picker reflects it.
+    /// Syncs the picker with an `AppleLanguages` override set outside the app
+    /// (System Settings or `defaults write`), including its later removal.
     private func adoptExternalLanguageOverride() {
-        guard appLanguage == "system",
-              let bundleID = Bundle.main.bundleIdentifier,
-              let override = UserDefaults.standard.persistentDomain(forName: bundleID)?["AppleLanguages"] as? [String],
-              let language = override.first, !language.isEmpty
-        else { return }
-        appLanguage = language
+        let override = Bundle.main.bundleIdentifier
+            .flatMap {
+                UserDefaults.standard.persistentDomain(forName: $0)?["AppleLanguages"] as? [String]
+            }?
+            .first { !$0.isEmpty }
+        appLanguage = override ?? "system"
     }
 
     var body: some View {

--- a/DynamicIsland/components/Settings/SettingsView.swift
+++ b/DynamicIsland/components/Settings/SettingsView.swift
@@ -1065,9 +1065,49 @@ struct GeneralSettings: View {
     @Default(.reverseScrollGestures) var reverseScrollGestures
     @Default(.externalDisplayStyle) var externalDisplayStyle
     @Default(.hideNonNotchUntilHover) var hideNonNotchUntilHover
+    @Default(.appLanguage) var appLanguage
 
     private func highlightID(_ title: String) -> String {
         SettingsTab.general.highlightID(for: title)
+    }
+
+    /// Languages shipped in the app bundle, shown with their native names.
+    private var availableLanguages: [String] {
+        Bundle.main.localizations
+            .filter { $0 != "Base" }
+            .sorted { Self.languageName(for: $0) < Self.languageName(for: $1) }
+    }
+
+    private static func languageName(for code: String) -> String {
+        Locale(identifier: code).localizedString(forLanguageCode: code)?.capitalized ?? code
+    }
+
+    /// Bridges the picker to UserDefaults: anything but "system" is written as the
+    /// app's `AppleLanguages` override (the same mechanism System Settings uses for
+    /// per-app languages) and applies on the next launch.
+    private var languageBinding: Binding<String> {
+        Binding(
+            get: { appLanguage },
+            set: { newValue in
+                appLanguage = newValue
+                if newValue == "system" {
+                    UserDefaults.standard.removeObject(forKey: "AppleLanguages")
+                } else {
+                    UserDefaults.standard.set([newValue], forKey: "AppleLanguages")
+                }
+            }
+        )
+    }
+
+    /// Adopts an `AppleLanguages` override set outside the app (System Settings or
+    /// `defaults write`) so the picker reflects it.
+    private func adoptExternalLanguageOverride() {
+        guard appLanguage == "system",
+              let bundleID = Bundle.main.bundleIdentifier,
+              let override = UserDefaults.standard.persistentDomain(forName: bundleID)?["AppleLanguages"] as? [String],
+              let language = override.first, !language.isEmpty
+        else { return }
+        appLanguage = language
     }
 
     var body: some View {
@@ -1141,6 +1181,19 @@ struct GeneralSettings: View {
                 .settingsHighlight(id: highlightID("Hide Dynamic Island during screenshots & recordings"))
             } header: {
                 Text("System features")
+            }
+
+            Section {
+                Picker("Language", selection: languageBinding) {
+                    Text("System").tag("system")
+                    ForEach(availableLanguages, id: \.self) { code in
+                        Text(Self.languageName(for: code)).tag(code)
+                    }
+                }
+                .onAppear(perform: adoptExternalLanguageOverride)
+                .settingsHighlight(id: highlightID("Language"))
+            } footer: {
+                Text("Language changes take effect after restarting Atoll.")
             }
 
             Section {

--- a/DynamicIsland/models/Constants.swift
+++ b/DynamicIsland/models/Constants.swift
@@ -866,6 +866,9 @@ extension Defaults.Keys {
     static let automaticallySwitchDisplay = Key<Bool>("automaticallySwitchDisplay", default: true)
     static let releaseName = Key<String>("releaseName", default: "Kaafu")
     static let hideDynamicIslandFromScreenCapture = Key<Bool>("hideDynamicIslandFromScreenCapture", default: false)
+    /// UI language override; "system" follows macOS. Anything else is written to
+    /// the app's `AppleLanguages` and takes effect on the next launch.
+    static let appLanguage = Key<String>("appLanguage", default: "system")
     
         // MARK: Behavior
     static let minimumHoverDuration = Key<TimeInterval>("minimumHoverDuration", default: 0.3)


### PR DESCRIPTION
## Summary

Adds a **Language** picker to Settings → General so users can choose the app's UI language independently of the macOS system language.

- `System` (default) follows macOS; any other choice is persisted via the standard per-app `AppleLanguages` mechanism — the same one System Settings' per-app language feature and `defaults write <bundle-id> AppleLanguages` use — so it applies on the next launch.
- An override set externally (System Settings or `defaults write`) is adopted into the picker when it first appears, keeping the UI consistent with the effective setting.
- Languages are enumerated from `Bundle.main.localizations` and shown with their native (endonym) names.
- A section footer notes that the change takes effect after restarting the app.
- CHANGELOG entry added under `[Unreleased]`.

## Test plan

- `xcodebuild build -scheme DynamicIsland` succeeds (macOS 26.5.2).
- Choosing a language writes `AppleLanguages` to the app's defaults; choosing `System` removes the override; an externally set override is reflected in the picker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a language picker under Settings → General.
  - Choose the system language or a specific supported language.
  - Language preferences are remembered between launches.
  - Returning to the system language removes the custom override.
  - Language changes take effect after restarting the app.

- **Documentation**
  - Added changelog information describing the new language selection feature.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->