### PR TITLE
i18n: complete Spanish (es) localization

### DIFF
--- a/Localizable.xcstrings
+++ b/Localizable.xcstrings
@@ -35,7 +35,7 @@
         },
         "es": {
           "stringUnit": {
-            "state": "needs_review",
+            "state": "translated",
             "value": ""
           }
         },
@@ -332,8 +332,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": " %@"
           }
         },
         "fi": {
@@ -483,8 +483,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "-%@"
           }
         },
         "fi": {
@@ -627,8 +627,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "—"
           }
         },
         "fi": {
@@ -1525,8 +1525,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "%@ · %@"
           }
         },
         "fi": {
@@ -1673,8 +1673,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "%@ modelos"
           }
         },
         "fi": {
@@ -1822,8 +1822,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Desplazamiento de %@"
           }
         },
         "fi": {
@@ -1971,8 +1971,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "%@ pt"
           }
         },
         "fi": {
@@ -2115,8 +2115,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "%@°"
           }
         },
         "fi": {
@@ -2406,8 +2406,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "%lld"
           }
         },
         "fi": {
@@ -2550,8 +2550,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "%lld animaciones"
           }
         },
         "fi": {
@@ -2698,8 +2698,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "%lld colores"
           }
         },
         "fi": {
@@ -2847,8 +2847,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "%lld min"
           }
         },
         "fi": {
@@ -2996,8 +2996,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "%lld px"
           }
         },
         "fi": {
@@ -3145,8 +3145,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "%lld s"
           }
         },
         "fi": {
@@ -3436,8 +3436,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "%lldx"
           }
         },
         "fi": {
@@ -3585,8 +3585,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "•"
           }
         },
         "fi": {
@@ -3883,8 +3883,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "• Vidrio esmerilado: efecto de desenfoque translúcido"
           }
         },
         "fi": {
@@ -4192,8 +4192,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "• Vidrio líquido: efecto de vidrio moderno (macOS 26+)"
           }
         },
         "es-419": {
@@ -4507,8 +4507,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "• Sólido oscuro/claro/automático: fondos opacos"
           }
         },
         "es-419": {
@@ -4667,8 +4667,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "• Pensando"
           }
         },
         "es-419": {
@@ -4822,8 +4822,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "• Actualizado %@"
           }
         },
         "es-419": {
@@ -4976,8 +4976,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "••••••••"
           }
         },
         "fi": {
@@ -5119,8 +5119,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "+%lld más"
           }
         },
         "fi": {
@@ -5283,6 +5283,12 @@
             "state": "translated",
             "value": "⚠️ 警告：系統 HUD 可能無法正常工作！"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "⚠️  ADVERTENCIA: es posible que el HUD del sistema no funcione correctamente"
+          }
         }
       }
     },
@@ -5323,6 +5329,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "⚠️ 錯誤："
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "⚠️ Error:"
           }
         }
       }
@@ -5365,6 +5377,12 @@
             "state": "translated",
             "value": "🔋 最大容量"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "🔋 Capacidad máxima"
+          }
         }
       }
     },
@@ -5406,6 +5424,12 @@
             "state": "translated",
             "value": "🕒 充滿所需時間："
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "🕒 Tiempo para carga completa:"
+          }
         }
       }
     },
@@ -5444,8 +5468,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "0"
           }
         },
         "fi": {
@@ -5588,8 +5612,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "00:05:00"
           }
         },
         "fi": {
@@ -5731,8 +5755,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "1x"
           }
         },
         "fi": {
@@ -5879,8 +5903,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "3 elementos"
           }
         },
         "fi": {
@@ -6027,8 +6051,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "5 colores"
           }
         },
         "fi": {
@@ -6175,8 +6199,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "5 elementos"
           }
         },
         "fi": {
@@ -6323,8 +6347,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "7 elementos"
           }
         },
         "fi": {
@@ -6471,8 +6495,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "10 colores"
           }
         },
         "fi": {
@@ -6619,8 +6643,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "10 elementos"
           }
         },
         "fi": {
@@ -6767,8 +6791,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "15 colores"
           }
         },
         "fi": {
@@ -6915,8 +6939,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "20"
           }
         },
         "fi": {
@@ -7058,8 +7082,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "20 colores"
           }
         },
         "fi": {
@@ -7206,8 +7230,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "30"
           }
         },
         "fi": {
@@ -7350,8 +7374,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "100"
           }
         },
         "fi": {
@@ -7493,8 +7517,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "100%"
           }
         },
         "fi": {
@@ -7934,8 +7958,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Color de énfasis"
           }
         },
         "fi": {
@@ -8236,8 +8260,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Accesibilidad"
           }
         },
         "fi": {
@@ -8385,8 +8409,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Se requiere permiso de accesibilidad"
           }
         },
         "es-419": {
@@ -8545,8 +8569,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Acciones"
           }
         },
         "fi": {
@@ -8693,8 +8717,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Activar"
           }
         },
         "fi": {
@@ -8841,8 +8865,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Activa tu licencia"
           }
         },
         "fi": {
@@ -8989,8 +9013,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Activación"
           }
         },
         "fi": {
@@ -9137,8 +9161,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Activo"
           }
         },
         "fi": {
@@ -9285,8 +9309,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Activo - Sin foco"
           }
         },
         "fi": {
@@ -9434,8 +9458,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Activo - Sin grabación"
           }
         },
         "fi": {
@@ -9737,8 +9761,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Añadir animación desde URL"
           }
         },
         "fi": {
@@ -9885,8 +9909,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Añadir archivos"
           }
         },
         "fi": {
@@ -10034,8 +10058,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Añadir desde URL..."
           }
         },
         "fi": {
@@ -10332,8 +10356,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Añadir nueva"
           }
         },
         "fi": {
@@ -10629,8 +10653,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Añadir preajuste"
           }
         },
         "fi": {
@@ -10926,8 +10950,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Ajusta las opciones anteriores para ver los cambios en tiempo real. El OSD real aparece en la parte inferior central de la pantalla."
           }
         },
         "es-419": {
@@ -11086,8 +11110,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Asistente de IA"
           }
         },
         "fi": {
@@ -11234,8 +11258,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "La IA está pensando..."
           }
         },
         "fi": {
@@ -11382,8 +11406,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Selección de modelo de IA"
           }
         },
         "fi": {
@@ -11530,8 +11554,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Proveedor de IA"
           }
         },
         "es-419": {
@@ -11684,8 +11708,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Asistente con IA que puede analizar archivos, imágenes y ofrecer ayuda conversacional. Usa Cmd+Shift+A para acceder rápidamente al asistente."
           }
         },
         "es-419": {
@@ -11845,8 +11869,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Índice de calidad del aire %d, %@"
           }
         },
         "es-419": {
@@ -11999,8 +12023,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "La calidad del aire requiere el proveedor Open Meteo."
           }
         },
         "es-419": {
@@ -12153,8 +12177,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Escala de calidad del aire"
           }
         },
         "es-419": {
@@ -12900,8 +12924,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "ALFA"
           }
         },
         "fi": {
@@ -13044,8 +13068,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Advertencia de función alfa"
           }
         },
         "fi": {
@@ -13488,8 +13512,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Amazon Music"
           }
         },
         "fi": {
@@ -13636,8 +13660,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Animación"
           }
         },
         "fi": {
@@ -13785,8 +13809,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Nombre de la animación"
           }
         },
         "fi": {
@@ -13933,8 +13957,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Configuración de la API"
           }
         },
         "fi": {
@@ -14081,8 +14105,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Se requiere clave de API"
           }
         },
         "fi": {
@@ -14529,6 +14553,12 @@
             "state": "translated",
             "value": "外觀"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "apariencia"
+          }
         }
       }
     },
@@ -14558,6 +14588,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "空氣品質指數"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ICA"
           }
         }
       }
@@ -14597,8 +14633,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "¿Seguro que quieres eliminar \"%@\"?"
           }
         },
         "fi": {
@@ -14911,8 +14947,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Pregúntame lo que quieras..."
           }
         },
         "fi": {
@@ -15059,8 +15095,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Atoll"
           }
         },
         "fi": {
@@ -15211,6 +15247,12 @@
             "state": "translated",
             "value": "Atoll 需要權限來儲存和讀取 AI 助理檔案。"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Atoll necesita acceso para guardar y leer archivos del asistente de IA."
+          }
         }
       }
     },
@@ -15251,6 +15293,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Atoll 需要權限將截圖儲存到桌面。"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Atoll necesita acceso para guardar capturas de pantalla en tu escritorio."
           }
         }
       }
@@ -15299,6 +15347,12 @@
             "state": "translated",
             "value": "Atoll 需要藍牙存取權限來偵測音訊裝置連線並在 HUD 中顯示其電池狀態。"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Atoll necesita acceso a Bluetooth para detectar cuándo se conectan dispositivos de audio y mostrar su estado de batería en el HUD."
+          }
         }
       }
     },
@@ -15346,6 +15400,12 @@
             "state": "translated",
             "value": "Atoll 使用 AppleScript 控制 Spotify 和 Apple Music"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Atoll usa AppleScripts para controlar Spotify y Apple Music"
+          }
         }
       }
     },
@@ -15383,8 +15443,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Archivos adjuntos"
           }
         },
         "fi": {
@@ -15532,8 +15592,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Desplazar automáticamente al siguiente evento"
           }
         },
         "fi": {
@@ -15992,6 +16052,12 @@
             "state": "translated",
             "value": "自動切換顯示器"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cambiar de pantalla automáticamente"
+          }
         }
       }
     },
@@ -16030,8 +16096,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Promedios"
           }
         },
         "fi": {
@@ -16179,8 +16245,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Retroiluminación"
           }
         },
         "fi": {
@@ -16476,8 +16542,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Batería al %d por ciento"
           }
         },
         "fi": {
@@ -16625,8 +16691,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Batería cargando"
           }
         },
         "fi": {
@@ -16774,8 +16840,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Cargando batería, quedan %@"
           }
         },
         "fi": {
@@ -16923,8 +16989,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Batería completamente cargada"
           }
         },
         "fi": {
@@ -17664,8 +17730,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Dispositivos de audio Bluetooth"
           }
         },
         "fi": {
@@ -17813,8 +17879,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Dispositivo Bluetooth %@ al %d por ciento"
           }
         },
         "fi": {
@@ -18115,8 +18181,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Ambos"
           }
         },
         "fi": {
@@ -18263,8 +18329,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Relleno inferior:"
           }
         },
         "fi": {
@@ -18412,8 +18478,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Desglose"
           }
         },
         "fi": {
@@ -18561,8 +18627,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Brillo"
           }
         },
         "fi": {
@@ -18709,8 +18775,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "HUD de brillo"
           }
         },
         "fi": {
@@ -18858,8 +18924,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "OSD de brillo"
           }
         },
         "fi": {
@@ -19007,8 +19073,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Integrado"
           }
         },
         "fi": {
@@ -19156,8 +19222,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Monitoreo del sistema integrado"
           }
         },
         "fi": {
@@ -20065,8 +20131,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Calendarios"
           }
         },
         "fi": {
@@ -20214,8 +20280,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Cámara"
           }
         },
         "fi": {
@@ -20362,8 +20428,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Cámara activa"
           }
         },
         "fi": {
@@ -20520,6 +20586,12 @@
             "state": "translated",
             "value": "相機正被某個 App 使用"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Una aplicación está usando la cámara"
+          }
         }
       }
     },
@@ -20557,8 +20629,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Estado de la cámara"
           }
         },
         "fi": {
@@ -20853,8 +20925,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Centro"
           }
         },
         "fi": {
@@ -21001,8 +21073,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Cambiar"
           }
         },
         "fi": {
@@ -21595,8 +21667,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Color del chip"
           }
         },
         "fi": {
@@ -22046,8 +22118,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Elegir modelo de IA"
           }
         },
         "fi": {
@@ -22349,8 +22421,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Elegir archivo"
           }
         },
         "fi": {
@@ -22795,8 +22867,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Elige tu modelo de IA y configuración preferidos"
           }
         },
         "fi": {
@@ -22950,8 +23022,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Elige tu perfil"
           }
         },
         "fi": {
@@ -23247,8 +23319,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Borrar"
           }
         },
         "fi": {
@@ -23395,8 +23467,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Borrar todos los archivos"
           }
         },
         "fi": {
@@ -23691,8 +23763,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Borrar historial del portapapeles"
           }
         },
         "fi": {
@@ -23987,8 +24059,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Borrar historial de colores"
           }
         },
         "fi": {
@@ -24283,8 +24355,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Borrar datos"
           }
         },
         "fi": {
@@ -24431,8 +24503,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Borrar elementos fijados"
           }
         },
         "fi": {
@@ -24580,8 +24652,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Borrar búsqueda"
           }
         },
         "fi": {
@@ -24728,8 +24800,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Haz clic en \"Elegir color\" o usa Cmd+Shift+P para empezar a elegir colores"
           }
         },
         "fi": {
@@ -24877,8 +24949,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Haz clic para más detalles"
           }
         },
         "fi": {
@@ -25025,8 +25097,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Portapapeles"
           }
         },
         "fi": {
@@ -25173,8 +25245,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "La función de portapapeles está desactivada"
           }
         },
         "fi": {
@@ -25321,8 +25393,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Historial del portapapeles"
           }
         },
         "fi": {
@@ -25469,8 +25541,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Historial del portapapeles:"
           }
         },
         "fi": {
@@ -25617,8 +25689,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Administrador del portapapeles"
           }
         },
         "fi": {
@@ -25913,8 +25985,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Cerrar asistente"
           }
         },
         "fi": {
@@ -26065,6 +26137,12 @@
             "state": "translated",
             "value": "關閉手勢"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "gesto para cerrar"
+          }
         }
       }
     },
@@ -26103,8 +26181,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Recopila el último informe de fallos para compartirlo con el desarrollador al reportar problemas de la pantalla de bloqueo o la superposición."
           }
         },
         "fi": {
@@ -26251,8 +26329,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Detalles del color"
           }
         },
         "fi": {
@@ -26399,8 +26477,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Formatos de color"
           }
         },
         "fi": {
@@ -26547,8 +26625,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Historial de colores"
           }
         },
         "fi": {
@@ -26696,8 +26774,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Las opciones de color controlan el aspecto del ícono y la barra de progreso. \"Automático\" se adapta al tema del sistema."
           }
         },
         "fi": {
@@ -26850,8 +26928,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "¡Color elegido!"
           }
         },
         "fi": {
@@ -26998,8 +27076,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Selector de color"
           }
         },
         "fi": {
@@ -27146,8 +27224,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "La función de selector de color está desactivada"
           }
         },
         "fi": {
@@ -27294,8 +27372,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Panel del selector de color:"
           }
         },
         "fi": {
@@ -27445,6 +27523,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "彩色電池顯示"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Indicador de batería con código de colores"
           }
         }
       }
@@ -27645,8 +27729,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Barras de progreso con código de colores"
           }
         },
         "fi": {
@@ -27799,8 +27883,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Selector de color desactivado"
           }
         },
         "fi": {
@@ -28095,8 +28179,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Configuración"
           }
         },
         "fi": {
@@ -28565,8 +28649,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Configura los preajustes en Ajustes"
           }
         },
         "fi": {
@@ -28714,8 +28798,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Conectado"
           }
         },
         "fi": {
@@ -28859,6 +28943,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "容器"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Contenedor"
           }
         }
       }
@@ -29205,8 +29295,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Controles"
           }
         },
         "fi": {
@@ -29835,8 +29925,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Copiar enlace del evento"
           }
         },
         "fi": {
@@ -29983,8 +30073,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Copiar último informe de fallos"
           }
         },
         "fi": {
@@ -30131,8 +30221,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Copia algo para empezar"
           }
         },
         "fi": {
@@ -30279,8 +30369,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Copia algo para empezar"
           }
         },
         "fi": {
@@ -30428,8 +30518,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Núcleo %lld"
           }
         },
         "fi": {
@@ -30579,6 +30669,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "圓角縮放"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Escalado del radio de las esquinas"
           }
         }
       }
@@ -30766,8 +30862,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Uso de CPU"
           }
         },
         "fi": {
@@ -30915,8 +31011,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Temporizador personalizado actual:"
           }
         },
         "fi": {
@@ -31064,8 +31160,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Predeterminado actual:"
           }
         },
         "fi": {
@@ -31212,8 +31308,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Historial actual"
           }
         },
         "fi": {
@@ -31360,8 +31456,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Elementos actuales"
           }
         },
         "fi": {
@@ -31509,8 +31605,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Actualmente activa"
           }
         },
         "fi": {
@@ -31657,8 +31753,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Personalizado"
           }
         },
         "fi": {
@@ -31806,8 +31902,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Color personalizado"
           }
         },
         "fi": {
@@ -32399,8 +32495,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "OSD personalizado"
           }
         },
         "fi": {
@@ -33023,8 +33119,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Temporizador personalizado"
           }
         },
         "fi": {
@@ -33172,8 +33268,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Duración del temporizador personalizado"
           }
         },
         "fi": {
@@ -33468,8 +33564,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Personalizado: %@"
           }
         },
         "fi": {
@@ -33616,8 +33712,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Personalizar animación"
           }
         },
         "fi": {
@@ -34061,8 +34157,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Temporizador personalizado predeterminado"
           }
         },
         "fi": {
@@ -34209,8 +34305,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Predeterminado: dynamic.m4a"
           }
         },
         "fi": {
@@ -34357,8 +34453,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Eliminar"
           }
         },
         "fi": {
@@ -34506,8 +34602,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Eliminar animación"
           }
         },
         "fi": {
@@ -34654,8 +34750,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Eliminar color"
           }
         },
         "fi": {
@@ -34955,6 +35051,12 @@
             "state": "translated",
             "value": "詳細檢視"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vista de detalle"
+          }
         }
       }
     },
@@ -34993,8 +35095,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Estado de detección"
           }
         },
         "fi": {
@@ -35142,8 +35244,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Diagnóstico"
           }
         },
         "fi": {
@@ -35742,8 +35844,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Lectura de disco"
           }
         },
         "fi": {
@@ -35890,8 +35992,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Escritura de disco"
           }
         },
         "fi": {
@@ -36199,8 +36301,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Modo de visualización"
           }
         },
         "fi": {
@@ -36347,8 +36449,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Opciones de visualización"
           }
         },
         "fi": {
@@ -36816,8 +36918,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "No molestar"
           }
         },
         "fi": {
@@ -37112,8 +37214,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Estilo del ícono de descarga"
           }
         },
         "fi": {
@@ -37260,8 +37362,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Estilo del indicador de descarga"
           }
         },
         "fi": {
@@ -37408,8 +37510,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Indicadores de descarga"
           }
         },
         "fi": {
@@ -37559,6 +37661,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "下載"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "descargas"
           }
         }
       }
@@ -38053,8 +38161,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "dynamic.island"
           }
         },
         "fi": {
@@ -38360,6 +38468,12 @@
             "state": "translated",
             "value": "歐洲空氣品質指數"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ICAE"
+          }
         }
       }
     },
@@ -38557,8 +38671,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Editar animación"
           }
         },
         "fi": {
@@ -38853,8 +38967,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Dirección de correo electrónico"
           }
         },
         "fi": {
@@ -39324,8 +39438,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Activar de todos modos"
           }
         },
         "fi": {
@@ -39476,6 +39590,12 @@
             "state": "translated",
             "value": "啟用專輯封面後的模糊效果"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activar efecto de desenfoque detrás de la portada del álbum"
+          }
         }
       }
     },
@@ -39520,8 +39640,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Activar HUD del sistema integrado"
           }
         },
         "fi": {
@@ -39832,6 +39952,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "啟用相機偵測"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activar detección de cámara"
           }
         }
       }
@@ -40168,8 +40294,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Activar OSD personalizado"
           }
         },
         "fi": {
@@ -40320,6 +40446,12 @@
             "state": "translated",
             "value": "啟用動態鏡像"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activar espejo dinámico"
+          }
         }
       }
     },
@@ -40360,6 +40492,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "啟用手勢"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activar gestos"
           }
         }
       }
@@ -40404,8 +40542,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Activa los atajos de teclado globales arriba para personalizarlos."
           }
         },
         "fi": {
@@ -40553,8 +40691,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Activa la visibilidad de gráficos en Ajustes → Estadísticas para ver los datos de rendimiento."
           }
         },
         "fi": {
@@ -41000,8 +41138,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Activar HUDs"
           }
         },
         "fi": {
@@ -41152,6 +41290,12 @@
             "state": "translated",
             "value": "啟用歌詞"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activar letras"
+          }
         }
       }
     },
@@ -41192,6 +41336,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "啟用媒體 "
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activar reproductor multimedia"
           }
         }
       }
@@ -41234,6 +41384,12 @@
             "state": "translated",
             "value": "啟用媒體面板模糊"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activar desenfoque del panel multimedia"
+          }
         }
       }
     },
@@ -41274,6 +41430,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "啟用麥克風偵測"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activar detección de micrófono"
           }
         }
       }
@@ -41463,6 +41625,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "啟用提醒即時動態"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activar actividad en vivo de recordatorios"
           }
         }
       }
@@ -41659,6 +41827,12 @@
             "state": "translated",
             "value": "啟用螢幕錄製偵測"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activar detección de grabación de pantalla"
+          }
         }
       }
     },
@@ -41696,8 +41870,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Activar vista previa rápida"
           }
         },
         "fi": {
@@ -42159,8 +42333,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Activar modo de razonamiento"
           }
         },
         "fi": {
@@ -42311,6 +42485,12 @@
             "state": "translated",
             "value": "啟用計時器模糊"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activar desenfoque del temporizador"
+          }
         }
       }
     },
@@ -42348,8 +42528,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Activa la función de temporizador en Ajustes para usar esta pestaña"
           }
         },
         "fi": {
@@ -42496,8 +42676,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Activar actividad en vivo del temporizador"
           }
         },
         "fi": {
@@ -42648,6 +42828,12 @@
             "state": "translated",
             "value": "啟用視窗陰影"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activar sombra de ventana"
+          }
         }
       }
     },
@@ -42686,8 +42872,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Uso del motor"
           }
         },
         "fi": {
@@ -43130,8 +43316,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Introduce tu clave de API de Gemini"
           }
         },
         "fi": {
@@ -43427,8 +43613,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Lista de eventos"
           }
         },
         "fi": {
@@ -43575,8 +43761,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Excluir aplicaciones"
           }
         },
         "fi": {
@@ -43871,8 +44057,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Expandir el notch con animación"
           }
         },
         "fi": {
@@ -44020,8 +44206,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Ancho del notch expandido"
           }
         },
         "fi": {
@@ -44171,6 +44357,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "延伸功能瀏海範圍，使剪貼簿、取色器和其他尾部圖示在縮放顯示（如更多空間）上保持可見。"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Extiende el ancho del notch para que el portapapeles, el selector de color y otros íconos finales sigan visibles en pantallas con escalado (p. ej. Más espacio)."
           }
         }
       }
@@ -44359,8 +44551,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Externo"
           }
         },
         "fi": {
@@ -44511,6 +44703,12 @@
             "state": "translated",
             "value": "讀取崩潰報告失敗："
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se pudieron leer los informes de fallos:"
+          }
         }
       }
     },
@@ -44548,8 +44746,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Rellenar el notch"
           }
         },
         "fi": {
@@ -44844,8 +45042,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Ajustar al notch"
           }
         },
         "fi": {
@@ -44992,8 +45190,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Estado del foco"
           }
         },
         "fi": {
@@ -45141,8 +45339,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Libre · %@"
           }
         },
         "fi": {
@@ -45290,8 +45488,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Completamente cargada"
           }
         },
         "fi": {
@@ -45438,8 +45636,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Clave de API de Gemini"
           }
         },
         "fi": {
@@ -46178,8 +46376,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Obtén tu clave de API gratuita en Google AI Studio"
           }
         },
         "fi": {
@@ -46622,8 +46820,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Uso de GPU"
           }
         },
         "fi": {
@@ -47238,8 +47436,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Visibilidad de gráficos"
           }
         },
         "fi": {
@@ -47386,8 +47584,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Altura:"
           }
         },
         "fi": {
@@ -47534,8 +47732,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Ocultar"
           }
         },
         "fi": {
@@ -47683,8 +47881,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Ocultar eventos de todo el día"
           }
         },
         "fi": {
@@ -47832,8 +48030,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Ocultar recordatorios completados"
           }
         },
         "fi": {
@@ -47980,8 +48178,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Ocultar opciones de Dynamic Island"
           }
         },
         "fi": {
@@ -48129,8 +48327,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Ocultar del notch"
           }
         },
         "fi": {
@@ -48870,8 +49068,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Tamaño del historial"
           }
         },
         "fi": {
@@ -49018,8 +49216,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Horizontal:"
           }
         },
         "fi": {
@@ -49167,8 +49365,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "https://ejemplo.com/animacion.json"
           }
         },
         "fi": {
@@ -49916,8 +50114,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Color del ícono y del progreso"
           }
         },
         "fi": {
@@ -50065,8 +50263,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Inactivo"
           }
         },
         "fi": {
@@ -50362,8 +50560,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Importar"
           }
         },
         "fi": {
@@ -50511,8 +50709,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Error de importación"
           }
         },
         "fi": {
@@ -50660,8 +50858,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Importar archivo..."
           }
         },
         "fi": {
@@ -50956,8 +51154,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Inactivo"
           }
         },
         "fi": {
@@ -51252,8 +51450,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Vista previa integrada"
           }
         },
         "fi": {
@@ -51699,8 +51897,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "IPv4 · %@"
           }
         },
         "fi": {
@@ -51843,8 +52041,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "IPv6 · %@"
           }
         },
         "fi": {
@@ -51990,6 +52188,12 @@
             "state": "translated",
             "value": "金鑰"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tecla"
+          }
         }
       }
     },
@@ -52024,6 +52228,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "金鑰 1"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tecla 1"
           }
         }
       }
@@ -52359,8 +52569,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Los atajos de teclado están desactivados"
           }
         },
         "fi": {
@@ -52507,8 +52717,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Última actualización"
           }
         },
         "fi": {
@@ -52807,6 +53017,12 @@
             "state": "translated",
             "value": "登入時啟動"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Iniciar al arrancar sesión"
+          }
         }
       }
     },
@@ -52845,8 +53061,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Diseño"
           }
         },
         "fi": {
@@ -52993,8 +53209,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Clave de licencia"
           }
         },
         "fi": {
@@ -53141,8 +53357,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "LinkedIn"
           }
         },
         "fi": {
@@ -53284,8 +53500,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Vidrio líquido requiere macOS 26 o posterior."
           }
         },
         "fi": {
@@ -53438,8 +53654,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Detecta cambios de sesión de Foco mediante notificaciones distribuidas"
           }
         },
         "fi": {
@@ -53587,8 +53803,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "EN VIVO"
           }
         },
         "fi": {
@@ -53736,8 +53952,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Actividades en vivo"
           }
         },
         "fi": {
@@ -53885,8 +54101,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Actividad en vivo y comentarios"
           }
         },
         "fi": {
@@ -54034,8 +54250,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Monitoreo en vivo"
           }
         },
         "fi": {
@@ -54182,8 +54398,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Datos de rendimiento en vivo"
           }
         },
         "fi": {
@@ -54331,8 +54547,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Vista previa en vivo"
           }
         },
         "fi": {
@@ -54480,8 +54696,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Indicador de transmisión en vivo"
           }
         },
         "fi": {
@@ -54629,8 +54845,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Carga promedio"
           }
         },
         "fi": {
@@ -54777,8 +54993,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Pantalla de bloqueo"
           }
         },
         "fi": {
@@ -54925,8 +55141,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Integración con la pantalla de bloqueo"
           }
         },
         "fi": {
@@ -55074,8 +55290,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Vista previa del panel de la pantalla de bloqueo"
           }
         },
         "fi": {
@@ -55223,8 +55439,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Posicionamiento en la pantalla de bloqueo"
           }
         },
         "fi": {
@@ -55372,8 +55588,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Widget de recordatorios en la pantalla de bloqueo"
           }
         },
         "fi": {
@@ -55513,6 +55729,12 @@
             "state": "translated",
             "value": "鎖定畫面"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "pantallaDeBloqueo"
+          }
         }
       }
     },
@@ -55550,8 +55772,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Modo de repetición"
           }
         },
         "fi": {
@@ -55698,8 +55920,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Modo de repetición:"
           }
         },
         "fi": {
@@ -56292,8 +56514,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Batería del Mac al %d por ciento"
           }
         },
         "fi": {
@@ -56441,8 +56663,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Se requiere macOS 15 o posterior"
           }
         },
         "fi": {
@@ -56596,8 +56818,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Hecho con ❤️ por Ebullioscopic"
           }
         },
         "fi": {
@@ -56751,8 +56973,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Administra las preferencias del indicador desde Ajustes → Privacidad. No es necesario activar el micrófono manualmente."
           }
         },
         "fi": {
@@ -56905,8 +57127,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Administra el temporizador desde la app Reloj."
           }
         },
         "fi": {
@@ -57054,8 +57276,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Marcar como completado"
           }
         },
         "fi": {
@@ -57203,8 +57425,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Marcar como incompleto"
           }
         },
         "fi": {
@@ -57648,8 +57870,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Material"
           }
         },
         "fi": {
@@ -57797,8 +58019,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Opciones de material:"
           }
         },
         "fi": {
@@ -58687,8 +58909,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Actividad en vivo multimedia"
           }
         },
         "fi": {
@@ -58836,8 +59058,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Salida multimedia"
           }
         },
         "fi": {
@@ -58985,8 +59207,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Panel multimedia"
           }
         },
         "fi": {
@@ -59578,8 +59800,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Uso de memoria"
           }
         },
         "fi": {
@@ -60025,8 +60247,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Micrófono silenciado"
           }
         },
         "fi": {
@@ -60174,8 +60396,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Micrófono activado"
           }
         },
         "fi": {
@@ -60323,8 +60545,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Micrófono"
           }
         },
         "fi": {
@@ -60471,8 +60693,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Micrófono activo"
           }
         },
         "fi": {
@@ -60623,6 +60845,12 @@
             "state": "translated",
             "value": "麥克風正被某個 App 使用"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Una aplicación está usando el micrófono"
+          }
         }
       }
     },
@@ -60667,8 +60895,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "El indicador de privacidad del micrófono se activa automáticamente cuando las apps acceden al audio."
           }
         },
         "fi": {
@@ -60821,8 +61049,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Estado del micrófono"
           }
         },
         "fi": {
@@ -60969,8 +61197,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "mín"
           }
         },
         "fi": {
@@ -61123,8 +61351,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "El modo minimalista se centra en los controles multimedia y los HUD del sistema, ocultando todas las funciones adicionales para una experiencia limpia y enfocada. Activa automáticamente animaciones más simples."
           }
         },
         "fi": {
@@ -61426,8 +61654,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Minutos"
           }
         },
         "fi": {
@@ -61868,6 +62096,12 @@
             "state": "translated",
             "value": "同步系統計時器"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reflejar el temporizador del sistema"
+          }
         }
       }
     },
@@ -61911,8 +62145,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Refleja el interruptor de los ajustes de la pantalla de bloqueo, para que los flujos específicos del temporizador puedan activar o desactivar el widget sin cambiar de pestaña."
           }
         },
         "fi": {
@@ -62225,8 +62459,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Comportamiento del monitoreo"
           }
         },
         "fi": {
@@ -62373,8 +62607,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Estado del monitoreo"
           }
         },
         "fi": {
@@ -62522,8 +62756,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Monitoreo detenido"
           }
         },
         "fi": {
@@ -62819,8 +63053,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Mover hacia abajo"
           }
         },
         "fi": {
@@ -62968,8 +63202,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Mover hacia arriba"
           }
         },
         "fi": {
@@ -63413,8 +63647,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Mi animación"
           }
         },
         "fi": {
@@ -63709,8 +63943,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Navegación"
           }
         },
         "fi": {
@@ -64005,8 +64239,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Descarga de red"
           }
         },
         "fi": {
@@ -64153,8 +64387,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Subida de red"
           }
         },
         "fi": {
@@ -64450,8 +64684,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Aún no se detectan interfaces activas."
           }
         },
         "fi": {
@@ -64599,8 +64833,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "No hay salidas de audio disponibles"
           }
         },
         "fi": {
@@ -64747,8 +64981,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Sin historial del portapapeles"
           }
         },
         "fi": {
@@ -64895,8 +65129,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "No se encontraron colores"
           }
         },
         "fi": {
@@ -65043,8 +65277,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Ningún color coincide con '%@'"
           }
         },
         "fi": {
@@ -65191,8 +65425,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Aún no hay colores"
           }
         },
         "fi": {
@@ -65636,8 +65870,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Sin eventos"
           }
         },
         "fi": {
@@ -65932,8 +66166,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "No hay aplicaciones excluidas"
           }
         },
         "fi": {
@@ -66081,8 +66315,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Sin exclusiones"
           }
         },
         "fi": {
@@ -66378,8 +66612,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Sin favoritos"
           }
         },
         "fi": {
@@ -66527,8 +66761,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "No hay gráficos activados"
           }
         },
         "fi": {
@@ -66682,8 +66916,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "No hay preajustes configurados. Añade uno para que aparezca en el menú del temporizador."
           }
         },
         "fi": {
@@ -66843,8 +67077,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Aún no hay datos de procesos. Mantén las estadísticas abiertas un momento."
           }
         },
         "fi": {
@@ -66991,8 +67225,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Sin resultados"
           }
         },
         "fi": {
@@ -67139,8 +67373,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "No se encontraron resultados"
           }
         },
         "fi": {
@@ -67288,8 +67522,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Aún no se detectan dispositivos de almacenamiento."
           }
         },
         "fi": {
@@ -67585,8 +67819,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "No activa"
           }
         },
         "fi": {
@@ -67881,8 +68115,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Sin configurar"
           }
         },
         "fi": {
@@ -68474,8 +68708,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Ancho del notch"
           }
         },
         "fi": {
@@ -68623,8 +68857,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Avisar con antelación"
           }
         },
         "fi": {
@@ -69067,8 +69301,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Solo el ícono de la app"
           }
         },
         "fi": {
@@ -69215,8 +69449,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Solo el ícono de descarga"
           }
         },
         "fi": {
@@ -69363,8 +69597,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Opacidad:"
           }
         },
         "fi": {
@@ -69511,8 +69745,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Abrir Google AI Studio"
           }
         },
         "fi": {
@@ -69666,8 +69900,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Abrir en Calendario"
           }
         },
         "fi": {
@@ -69814,8 +70048,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Abrir ajustes del modelo"
           }
         },
         "fi": {
@@ -69972,6 +70206,12 @@
             "state": "translated",
             "value": "懸停時開啟瀏海"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abrir el notch al pasar el cursor"
+          }
         }
       }
     },
@@ -70010,8 +70250,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Abrir ajustes"
           }
         },
         "fi": {
@@ -70158,8 +70398,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Abrir ajustes del sistema"
           }
         },
         "fi": {
@@ -70318,8 +70558,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Abre el panel del asistente de IA para analizar archivos y conversar. El atajo predeterminado es Cmd+Shift+A. Solo funciona si la función de asistente en pantalla está activada."
           }
         },
         "fi": {
@@ -70478,8 +70718,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Abre el panel de historial del portapapeles. El atajo predeterminado es Cmd+Shift+V (similar a Windows+V en PC). Solo funciona si la función de portapapeles está activada."
           }
         },
         "fi": {
@@ -70638,8 +70878,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Abre el panel del selector de color para capturar colores de la pantalla. El atajo predeterminado es Cmd+Shift+P. Solo funciona si la función de selector de color está activada."
           }
         },
         "fi": {
@@ -70793,8 +71033,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Dispositivos de salida"
           }
         },
         "fi": {
@@ -70942,8 +71182,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Volumen de salida"
           }
         },
         "fi": {
@@ -71096,8 +71336,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "El modo panel muestra el portapapeles en una ventana flotante cerca del notch. El modo menú emergente lo muestra como un desplegable adjunto al botón del portapapeles."
           }
         },
         "fi": {
@@ -71256,8 +71496,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "El modo panel muestra el selector de color en una ventana flotante. El modo menú emergente lo muestra como un desplegable adjunto al botón del selector de color."
           }
         },
         "fi": {
@@ -71416,8 +71656,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "El modo panel muestra el asistente en una ventana flotante cerca del notch. El modo menú emergente lo muestra como un desplegable adjunto al botón de IA."
           }
         },
         "fi": {
@@ -71570,8 +71810,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Pausar"
           }
         },
         "fi": {
@@ -71718,8 +71958,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Pausado"
           }
         },
         "fi": {
@@ -71866,8 +72106,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Porcentaje"
           }
         },
         "fi": {
@@ -72014,8 +72254,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Permisos"
           }
         },
         "fi": {
@@ -72162,8 +72402,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Elegir color"
           }
         },
         "fi": {
@@ -72310,8 +72550,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Elegido %@"
           }
         },
         "fi": {
@@ -72458,8 +72698,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Color elegido"
           }
         },
         "fi": {
@@ -72606,8 +72846,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Estado de selección"
           }
         },
         "fi": {
@@ -72902,8 +73142,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Fija elementos para añadirlos a favoritos"
           }
         },
         "fi": {
@@ -73050,8 +73290,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Fija elementos para añadirlos a favoritos"
           }
         },
         "fi": {
@@ -73198,8 +73438,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Elementos fijados"
           }
         },
         "fi": {
@@ -73651,6 +73891,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "加"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "más"
           }
         }
       }
@@ -74169,8 +74415,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Posición"
           }
         },
         "fi": {
@@ -74318,8 +74564,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Nombre del preajuste"
           }
         },
         "fi": {
@@ -74467,8 +74713,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Preajustes"
           }
         },
         "fi": {
@@ -74777,8 +75023,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Presión"
           }
         },
         "fi": {
@@ -74925,8 +75171,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Vista previa"
           }
         },
         "fi": {
@@ -75073,8 +75319,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Zoom de la vista previa:"
           }
         },
         "fi": {
@@ -75222,8 +75468,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Indicadores de privacidad"
           }
         },
         "fi": {
@@ -75371,8 +75617,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Política de privacidad"
           }
         },
         "fi": {
@@ -75519,8 +75765,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Barra de progreso"
           }
         },
         "fi": {
@@ -75667,8 +75913,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Estilo de progreso"
           }
         },
         "fi": {
@@ -75963,8 +76209,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Acciones rápidas"
           }
         },
         "fi": {
@@ -76111,8 +76357,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Preajustes rápidos"
           }
         },
         "fi": {
@@ -76260,8 +76506,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Inicio rápido"
           }
         },
         "fi": {
@@ -76705,8 +76951,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Salir de boring.notch"
           }
         },
         "fi": {
@@ -76854,8 +77100,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Lectura"
           }
         },
         "fi": {
@@ -77002,8 +77248,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Listo"
           }
         },
         "fi": {
@@ -77150,8 +77396,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Modo de razonamiento"
           }
         },
         "fi": {
@@ -77298,8 +77544,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Colores recientes"
           }
         },
         "fi": {
@@ -77446,8 +77692,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Grabando"
           }
         },
         "fi": {
@@ -77595,8 +77841,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Grabación detectada"
           }
         },
         "fi": {
@@ -77743,8 +77989,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Estado de grabación"
           }
         },
         "fi": {
@@ -78188,8 +78434,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Actividad en vivo de recordatorios"
           }
         },
         "fi": {
@@ -78336,8 +78582,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Recordatorios"
           }
         },
         "fi": {
@@ -78639,8 +78885,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Solicitar acceso"
           }
         },
         "fi": {
@@ -78787,8 +79033,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Restablecer"
           }
         },
         "fi": {
@@ -78935,8 +79181,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Restablecer todo"
           }
         },
         "fi": {
@@ -79087,6 +79333,12 @@
             "state": "translated",
             "value": "重置音樂"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restablecer música"
+          }
         }
       }
     },
@@ -79128,6 +79380,12 @@
             "state": "translated",
             "value": "重置計時器"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restablecer temporizador"
+          }
         }
       }
     },
@@ -79165,8 +79423,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Restablecer al valor predeterminado"
           }
         },
         "fi": {
@@ -79317,6 +79575,12 @@
             "state": "translated",
             "value": "重置天氣"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restablecer clima"
+          }
         }
       }
     },
@@ -79355,8 +79619,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Restablecer ancho"
           }
         },
         "fi": {
@@ -79652,8 +79916,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Reiniciar Atoll"
           }
         },
         "fi": {
@@ -79801,8 +80065,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Restaurar"
           }
         },
         "fi": {
@@ -80099,8 +80363,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Restaurar valores predeterminados"
           }
         },
         "fi": {
@@ -80247,8 +80511,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Reanudar"
           }
         },
         "fi": {
@@ -80395,8 +80659,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Rotación:"
           }
         },
         "fi": {
@@ -80840,8 +81104,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Guardar"
           }
         },
         "fi": {
@@ -80988,8 +81252,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Guardar cambios"
           }
         },
         "fi": {
@@ -81136,8 +81400,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Guardar configuración"
           }
         },
         "fi": {
@@ -81284,8 +81548,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Reducir escala"
           }
         },
         "fi": {
@@ -81432,8 +81696,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Aumentar escala 2x"
           }
         },
         "fi": {
@@ -81580,8 +81844,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Escala:"
           }
         },
         "fi": {
@@ -81728,8 +81992,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Asistente en pantalla"
           }
         },
         "fi": {
@@ -81876,8 +82140,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "La función de asistente en pantalla está desactivada"
           }
         },
         "fi": {
@@ -82026,8 +82290,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Asistente en pantalla:"
           }
         },
         "fi": {
@@ -82172,6 +82436,12 @@
             "state": "translated",
             "value": "螢幕邊距：%@畫素"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Relleno de pantalla: %@px"
+          }
         }
       }
     },
@@ -82209,8 +82479,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Grabación de pantalla"
           }
         },
         "fi": {
@@ -82357,8 +82627,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Opciones de captura de pantalla"
           }
         },
         "fi": {
@@ -82505,8 +82775,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Tipo de captura de pantalla"
           }
         },
         "fi": {
@@ -82657,6 +82927,12 @@
             "state": "translated",
             "value": "在 HUD 中滾動顯示裝置名稱"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desplazar el nombre del dispositivo en el HUD"
+          }
         }
       }
     },
@@ -82694,8 +82970,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Buscar en el portapapeles..."
           }
         },
         "fi": {
@@ -82842,8 +83118,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Buscar colores..."
           }
         },
         "fi": {
@@ -82991,8 +83267,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Buscar en ajustes"
           }
         },
         "fi": {
@@ -83139,8 +83415,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Buscar..."
           }
         },
         "fi": {
@@ -83288,8 +83564,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "segundos"
           }
         },
         "fi": {
@@ -83438,8 +83714,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Segundos"
           }
         },
         "fi": {
@@ -83586,8 +83862,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Segmentado"
           }
         },
         "fi": {
@@ -83734,8 +84010,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Selecciona un color para ver los detalles"
           }
         },
         "fi": {
@@ -84037,8 +84313,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Seleccionar calendarios"
           }
         },
         "fi": {
@@ -84631,8 +84907,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Seleccionada"
           }
         },
         "fi": {
@@ -84928,8 +85204,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Sensibilidad"
           }
         },
         "fi": {
@@ -85077,8 +85353,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Sesión · ↓ %@ · ↑ %@"
           }
         },
         "fi": {
@@ -85225,8 +85501,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Establecer"
           }
         },
         "fi": {
@@ -85525,6 +85801,12 @@
             "state": "translated",
             "value": "瀏海中的設定圖示"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ícono de ajustes en el notch"
+          }
         }
       }
     },
@@ -85563,8 +85845,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Ajustes…"
           }
         },
         "fi": {
@@ -86011,6 +86293,12 @@
             "state": "translated",
             "value": "顯示空氣品質小工具"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mostrar widget del ICA"
+          }
         }
       }
     },
@@ -86201,6 +86489,12 @@
             "state": "translated",
             "value": "在 HUD 中顯示電池百分比文字"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mostrar porcentaje de batería en el HUD"
+          }
         }
       }
     },
@@ -86241,6 +86535,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "顯示藍牙電池"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mostrar batería de Bluetooth"
           }
         }
       }
@@ -86283,6 +86583,12 @@
             "state": "translated",
             "value": "顯示藍牙裝置連線"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "mostrar conexiones de dispositivos Bluetooth"
+          }
         }
       }
     },
@@ -86323,6 +86629,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "顯示行事曆"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mostrar calendario"
           }
         }
       }
@@ -86365,6 +86677,12 @@
             "state": "translated",
             "value": "在瀏海中顯示行事曆事件"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mostrar eventos del calendario dentro del notch"
+          }
         }
       }
     },
@@ -86403,8 +86721,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Mostrar indicador de carga"
           }
         },
         "fi": {
@@ -86555,6 +86873,12 @@
             "state": "translated",
             "value": "顯示充電百分比"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mostrar porcentaje de carga"
+          }
         }
       }
     },
@@ -86596,6 +86920,12 @@
             "state": "translated",
             "value": "顯示充電狀態"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mostrar estado de carga"
+          }
         }
       }
     },
@@ -86633,8 +86963,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Mostrar historial de colores"
           }
         },
         "fi": {
@@ -86781,8 +87111,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Mostrar panel del selector de color"
           }
         },
         "fi": {
@@ -87078,8 +87408,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Mostrar cuenta regresiva"
           }
         },
         "fi": {
@@ -87227,8 +87557,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Mostrar progreso de descarga"
           }
         },
         "fi": {
@@ -87375,8 +87705,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Mostrar controles flotantes de pausa/detención"
           }
         },
         "es-419": {
@@ -87533,6 +87863,12 @@
             "state": "translated",
             "value": "顯示專注指示器"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mostrar indicador de foco"
+          }
         }
       }
     },
@@ -87574,6 +87910,12 @@
             "state": "translated",
             "value": "顯示專注標籤"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mostrar etiqueta de foco"
+          }
         }
       }
     },
@@ -87612,8 +87954,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Mostrar títulos completos de eventos"
           }
         },
         "fi": {
@@ -87764,6 +88106,12 @@
             "state": "translated",
             "value": "顯示位置標籤"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mostrar etiqueta de ubicación"
+          }
         }
       }
     },
@@ -87804,6 +88152,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "顯示鎖定畫面媒體面板"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mostrar panel multimedia en la pantalla de bloqueo"
           }
         }
       }
@@ -87846,6 +88200,12 @@
             "state": "translated",
             "value": "顯示鎖定畫面計時器"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mostrar temporizador en la pantalla de bloqueo"
+          }
         }
       }
     },
@@ -87887,6 +88247,12 @@
             "state": "translated",
             "value": "顯示鎖定畫面天氣"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mostrar clima en la pantalla de bloqueo"
+          }
         }
       }
     },
@@ -87925,8 +88291,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Mostrar el control de salida multimedia en otros diseños"
           }
         },
         "fi": {
@@ -88373,6 +88739,12 @@
             "state": "translated",
             "value": "顯示面板邊框"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mostrar borde del panel"
+          }
         }
       }
     },
@@ -88410,8 +88782,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Mostrar progreso"
           }
         },
         "fi": {
@@ -88561,6 +88933,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "顯示錄製指示器"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mostrar indicador de grabación"
           }
         }
       }
@@ -88747,8 +89125,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Mostrar nombre del temporizador"
           }
         },
         "fi": {
@@ -88895,8 +89273,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Muestra el ícono de cámara en verde y el de micrófono en amarillo mientras están en uso. Usa las APIs CoreAudio y CoreMediaIO basadas en eventos."
           }
         },
         "fi": {
@@ -89043,8 +89421,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Muestra el proceso de razonamiento del modelo antes de la respuesta final"
           }
         },
         "fi": {
@@ -89191,8 +89569,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Muestra el temporizador del sistema (app Reloj) en el notch cuando está disponible. Requiere permiso de accesibilidad para leer el ítem de estado."
           }
         },
         "fi": {
@@ -89343,6 +89721,12 @@
             "state": "translated",
             "value": "單個指示器"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Indicadores individuales"
+          }
         }
       }
     },
@@ -89380,8 +89764,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Tamaño y escala"
           }
         },
         "fi": {
@@ -89529,8 +89913,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Comportamiento de salto"
           }
         },
         "fi": {
@@ -89678,8 +90062,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Botones de salto"
           }
         },
         "fi": {
@@ -89975,8 +90359,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Las transiciones suaves combinan verde (0–60 %), amarillo (60–85 %) y rojo (85–100 %) a lo largo de todo el relleno."
           }
         },
         "fi": {
@@ -90124,8 +90508,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Duración de la vista previa rápida"
           }
         },
         "fi": {
@@ -90569,8 +90953,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "El estilo de vista previa rápida está fijado en Estándar en el modo minimalista"
           }
         },
         "fi": {
@@ -90865,8 +91249,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Color sólido"
           }
         },
         "fi": {
@@ -91161,8 +91545,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Velocidad:"
           }
         },
         "fi": {
@@ -91458,8 +91842,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Iniciar"
           }
         },
         "fi": {
@@ -91606,8 +91990,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Inicia una conversación para ver aquí tu historial de chat"
           }
         },
         "fi": {
@@ -91754,8 +92138,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Empezar a elegir colores"
           }
         },
         "fi": {
@@ -91903,8 +92287,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Iniciar temporizador personalizado"
           }
         },
         "fi": {
@@ -92051,8 +92435,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Iniciar temporizador de demostración:"
           }
         },
         "fi": {
@@ -92199,8 +92583,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Iniciar monitoreo"
           }
         },
         "fi": {
@@ -92347,8 +92731,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Empieza a elegir colores para construir tu historial"
           }
         },
         "fi": {
@@ -92495,8 +92879,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Iniciar grabación"
           }
         },
         "fi": {
@@ -92791,8 +93175,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Estadísticas"
           }
         },
         "fi": {
@@ -93088,8 +93472,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Función de estadísticas desactivada"
           }
         },
         "fi": {
@@ -93237,8 +93621,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "La función de estadísticas está desactivada"
           }
         },
         "fi": {
@@ -93386,8 +93770,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "El panel de estadísticas está desactivado"
           }
         },
         "fi": {
@@ -93535,8 +93919,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Panel de estadísticas:"
           }
         },
         "fi": {
@@ -93683,8 +94067,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Intervalo de actualización de estadísticas"
           }
         },
         "fi": {
@@ -93831,8 +94215,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Estado y acciones"
           }
         },
         "fi": {
@@ -93979,8 +94363,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Detener"
           }
         },
         "fi": {
@@ -94122,8 +94506,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Detener monitoreo"
           }
         },
         "fi": {
@@ -94270,8 +94654,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Detener grabación"
           }
         },
         "fi": {
@@ -94715,8 +95099,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Admite el modo de razonamiento"
           }
         },
         "fi": {
@@ -94864,8 +95248,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Memoria de intercambio"
           }
         },
         "fi": {
@@ -95013,8 +95397,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "La memoria de intercambio está desactivada en este sistema."
           }
         },
         "fi": {
@@ -95162,8 +95546,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Sistema"
           }
         },
         "fi": {
@@ -95459,8 +95843,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Monitor de rendimiento del sistema"
           }
         },
         "fi": {
@@ -95607,8 +95991,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Capturar un área de la pantalla"
           }
         },
         "fi": {
@@ -95755,8 +96139,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Unidad de temperatura"
           }
         },
         "fi": {
@@ -96052,8 +96436,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "TheDynamicIsland"
           }
         },
         "fi": {
@@ -96792,6 +97176,12 @@
             "state": "translated",
             "value": "此時長用於計時器彈出式視窗中的「自訂」選項，方便快速存取。"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esta duración alimenta la opción \"Personalizado\" dentro del menú del temporizador para un acceso rápido."
+          }
         }
       }
     },
@@ -96830,8 +97220,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Intervalo de tiempo"
           }
         },
         "fi": {
@@ -97126,8 +97516,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Temporizador"
           }
         },
         "fi": {
@@ -97274,8 +97664,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Temporizador desactivado"
           }
         },
         "fi": {
@@ -97422,8 +97812,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Función de temporizador"
           }
         },
         "fi": {
@@ -97570,8 +97960,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "La función de temporizador está desactivada"
           }
         },
         "fi": {
@@ -97719,8 +98109,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Preajustes de temporizador"
           }
         },
         "fi": {
@@ -97867,8 +98257,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Sonido del temporizador"
           }
         },
         "fi": {
@@ -98015,8 +98405,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Color del temporizador"
           }
         },
         "fi": {
@@ -98164,8 +98554,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Widget de temporizador"
           }
         },
         "fi": {
@@ -98609,8 +98999,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Abre o cierra Dynamic Island desde cualquier lugar."
           }
         },
         "fi": {
@@ -98764,8 +99154,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Total · %@"
           }
         },
         "fi": {
@@ -98912,8 +99302,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Transformar"
           }
         },
         "fi": {
@@ -99060,8 +99450,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Transforma tu notch a tu manera"
           }
         },
         "fi": {
@@ -99214,8 +99604,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Prueba ajustando los términos de búsqueda"
           }
         },
         "fi": {
@@ -99362,8 +99752,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Prueba con otros términos de búsqueda"
           }
         },
         "fi": {
@@ -99513,6 +99903,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "嘗試按音量鍵來測試系統 HUD 功能"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Prueba presionar las teclas de volumen para comprobar el funcionamiento del HUD del sistema"
           }
         }
       }
@@ -99706,8 +100102,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Modo de interfaz"
           }
         },
         "fi": {
@@ -100299,8 +100695,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Intervalo de actualización"
           }
         },
         "fi": {
@@ -100448,8 +100844,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Actualizar temporizador"
           }
         },
         "fi": {
@@ -100745,8 +101141,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Subida"
           }
         },
         "fi": {
@@ -100894,8 +101290,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Uso"
           }
         },
         "fi": {
@@ -101043,8 +101439,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Desglose de uso"
           }
         },
         "fi": {
@@ -101195,6 +101591,12 @@
             "state": "translated",
             "value": "使用圓形電池指示器"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "usar un indicador de batería circular"
+          }
         }
       }
     },
@@ -101236,6 +101638,12 @@
             "state": "translated",
             "value": "使用彩色儀表"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Usar medidores con color"
+          }
         }
       }
     },
@@ -101276,6 +101684,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "使用電池時顯示 MacBook 圖示"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Usar el ícono de MacBook cuando funciona con batería"
           }
         }
       }
@@ -101466,6 +101880,12 @@
             "state": "translated",
             "value": "使用更簡單的關閉動畫"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Usar una animación de cierre más simple"
+          }
         }
       }
     },
@@ -101653,8 +102073,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Usado"
           }
         },
         "fi": {
@@ -101802,8 +102222,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Usado · %@"
           }
         },
         "fi": {
@@ -102098,8 +102518,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Usa \"Reproduciendo\" de macOS cuando Amazon Music es la fuente multimedia activa. Los controles de reproducción siguen al destino del sistema \"Reproduciendo\". Es posible que desplazar la línea de tiempo no funcione si Amazon Music no admite búsqueda remota."
           }
         },
         "fi": {
@@ -102247,8 +102667,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Uso"
           }
         },
         "fi": {
@@ -102691,8 +103111,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Vertical:"
           }
         },
         "fi": {
@@ -102988,8 +103408,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Volumen"
           }
         },
         "fi": {
@@ -103136,8 +103556,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "HUD de volumen"
           }
         },
         "fi": {
@@ -103285,8 +103705,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "OSD de volumen"
           }
         },
         "fi": {
@@ -103443,6 +103863,12 @@
             "state": "translated",
             "value": "鏡像模式需要使用你的相機"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Necesitamos tu cámara para el modo espejo"
+          }
         }
       }
     },
@@ -103481,8 +103907,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Clima"
           }
         },
         "fi": {
@@ -103778,8 +104204,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Widget del clima"
           }
         },
         "fi": {
@@ -103927,8 +104353,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Clima: %@ %@"
           }
         },
         "fi": {
@@ -104076,8 +104502,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Clima: %@ %@ en %@"
           }
         },
         "fi": {
@@ -104529,6 +104955,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "停用後，所有鍵盤快速鍵將不可用。你仍然可以使用介面控制"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cuando está desactivado, todos los atajos de teclado quedan inactivos. Aun así puedes usar los controles de la interfaz"
           }
         }
       }
@@ -105199,6 +105631,12 @@
             "state": "translated",
             "value": "寬度調整僅適用於標準瀏海版面配置。停用簡約介面以編輯此值。"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Los ajustes de ancho solo se aplican al diseño estándar del notch. Desactiva la interfaz minimalista para editar este valor."
+          }
         }
       }
     },
@@ -105236,8 +105674,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Ancho:"
           }
         },
         "fi": {
@@ -105384,8 +105822,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Con %lld gráficos activados, Dynamic Island se expandirá horizontalmente para mostrarlos todos en una sola fila."
           }
         },
         "fi": {
@@ -105539,8 +105977,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Escritura"
           }
         },
         "fi": {
@@ -105687,8 +106125,8 @@
         },
         "es": {
           "stringUnit": {
-            "state": "new",
-            "value": ""
+            "state": "translated",
+            "value": "Tú"
           }
         },
         "fi": {
@@ -106276,6 +106714,12 @@
             "state": "translated",
             "value": "15 分鐘"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "15 min"
+          }
         }
       }
     },
@@ -106309,6 +106753,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "30 分鐘"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "30 min"
           }
         }
       }
@@ -106344,6 +106794,12 @@
             "state": "translated",
             "value": "1 小時"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 hora"
+          }
         }
       }
     },
@@ -106377,6 +106833,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "3 小時"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "3 horas"
           }
         }
       }
@@ -106412,6 +106874,12 @@
             "state": "translated",
             "value": "6 小時"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "6 horas"
+          }
         }
       }
     },
@@ -106445,6 +106913,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "12 小時"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "12 horas"
           }
         }
       }
@@ -106480,6 +106954,12 @@
             "state": "translated",
             "value": "今天餘下的時間"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Resto del día"
+          }
         }
       }
     },
@@ -106514,6 +106994,12 @@
             "state": "translated",
             "value": "所有時間"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Todo el tiempo"
+          }
         }
       }
     },
@@ -106542,6 +107028,12 @@
             "state": "translated",
             "value": "符號"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Símbolo"
+          }
         }
       }
     },
@@ -106566,6 +107058,12 @@
           }
         },
         "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "3D"
+          }
+        },
+        "es": {
           "stringUnit": {
             "state": "translated",
             "value": "3D"
@@ -106604,6 +107102,12 @@
             "state": "translated",
             "value": "左對齊"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Izquierda"
+          }
         }
       }
     },
@@ -106637,6 +107141,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "右對齊"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Derecha"
           }
         }
       }
@@ -106672,6 +107182,12 @@
             "state": "translated",
             "value": "啟用極簡 UI"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activar interfaz minimalista"
+          }
         }
       }
     },
@@ -106705,6 +107221,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "截圖和錄屏時隱藏動態島"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ocultar Dynamic Island durante capturas y grabaciones"
           }
         }
       }
@@ -106740,6 +107262,12 @@
             "state": "translated",
             "value": "關閉手勢"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gesto para cerrar"
+          }
         }
       }
     },
@@ -106773,6 +107301,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "反向滑動"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Invertir gestos de deslizamiento"
           }
         }
       }
@@ -106808,6 +107342,12 @@
             "state": "translated",
             "value": "反向滾動"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Invertir gestos de desplazamiento"
+          }
         }
       }
     },
@@ -106841,6 +107381,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "延伸功能懸停區域"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ampliar el área de detección del cursor"
           }
         }
       }
@@ -106876,6 +107422,12 @@
             "state": "translated",
             "value": "外接顯示器樣式"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Estilo en pantalla externa"
+          }
         }
       }
     },
@@ -106909,6 +107461,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "懸停時顯示"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ocultar hasta pasar el cursor"
           }
         }
       }
@@ -106944,6 +107502,12 @@
             "state": "translated",
             "value": "啟用專注模式偵測"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activar detección de foco"
+          }
         }
       }
     },
@@ -106977,6 +107541,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "輔助使用權限允許動態島替換原生的音量、亮度和鍵盤提示框。"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "El permiso de accesibilidad permite que Dynamic Island reemplace los HUD nativos de volumen, brillo y teclado."
           }
         }
       }
@@ -107012,6 +107582,12 @@
             "state": "translated",
             "value": "全域模式需要完整磁碟取用權"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Acceso completo al disco para el modo global"
+          }
         }
       }
     },
@@ -107039,6 +107615,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "如果沒有完整磁碟取用權，暫存器只能讀取文件和下載目錄的檔案。授予完整磁碟取用權以使暫存器能在全域範圍工作。"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sin acceso completo al disco, Shelf solo puede leer archivos de Documentos y Descargas. Concede acceso completo al disco para que Shelf funcione globalmente."
           }
         }
       }
@@ -107074,6 +107656,12 @@
             "state": "translated",
             "value": "請求完整磁碟取用權"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Solicitar acceso completo al disco"
+          }
         }
       }
     },
@@ -107108,6 +107696,12 @@
             "state": "translated",
             "value": "開啟隱私與安全性"
           }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abrir Privacidad y seguridad"
+          }
         }
       }
     },
@@ -107129,6 +107723,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "粗體文字顯示為亮色"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Texto en negrita con colores brillantes"
           }
         }
       }


### PR DESCRIPTION
Completa las 556 cadenas de Localizable.xcstrings que estaban vacías o sin entrada en español, dejando la cobertura de `es` al 100%.