### PR TITLE
Fix notch top-edge gap and hover-to-open flap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Refreshing the LLM Usage card now skips session logs whose last write predates the seven-day window instead of re-reading the whole log history, and counts a repeated record when the copy inside the window would previously have been suppressed by a copy outside it (#691).
 
 ### Fixed
+- Fixed a hairline gap at the top of the notch during open animation, and hover-to-open flapping when the pointer sits on the top edge, on physical-notch Macs (#681).
 - Fixed lock-screen widget readability on bright wallpapers by adding a Dark/Light appearance mode for widget text and controls.
 - Fixed Codex Today and Week usage totals remaining at zero when parsing Codex session logs (#664).
 - Recover the Claude quota display after Claude Code rotates its OAuth token, instead of showing "quota unavailable" until the app is restarted (#685).

--- a/DynamicIsland/ContentView.swift
+++ b/DynamicIsland/ContentView.swift
@@ -526,6 +526,7 @@ struct ContentView: View {
             .frame(alignment: .top)
             .padding(.horizontal, notchHorizontalPadding)
             .padding([.horizontal, .bottom], vm.notchState == .open ? 12 : 0)
+            .padding(.top, isIslandMode ? 0 : notchTopScreenBleedAmount)
             .background(.black)
             .clipShape(resolvedClipShape)
             .compositingGroup()
@@ -547,7 +548,7 @@ struct ContentView: View {
         mainLayoutBase
             .conditionalModifier(!useModernCloseAnimation) { view in
                 let hoverAnimation = Animation.bouncy.speed(1.2)
-                let notchStateAnimation = Animation.spring.speed(1.2)
+                let notchStateAnimation = Animation.spring(response: 0.42, dampingFraction: 1.0, blendDuration: 0)
                 return view
                     .animation(hoverAnimation, value: isHovering)
                     .animation(notchStateAnimation, value: vm.notchState)
@@ -556,7 +557,7 @@ struct ContentView: View {
             }
             .conditionalModifier(useModernCloseAnimation) { view in
                 let hoverAnimation = Animation.bouncy.speed(1.2)
-                let openAnimation = Animation.spring(response: 0.42, dampingFraction: 0.8, blendDuration: 0)
+                let openAnimation = Animation.spring(response: 0.42, dampingFraction: 1.0, blendDuration: 0)
                 let closeAnimation = Animation.spring(response: 0.45, dampingFraction: 1.0, blendDuration: 0)
                 let notchAnimation = vm.notchState == .open ? openAnimation : closeAnimation
                 return view
@@ -610,9 +611,7 @@ struct ContentView: View {
                 if coordinator.firstLaunch {
                     // Single open during first launch; closeHello() handles the timed close.
                     runAfter(1) {
-                        withAnimation(vm.animation) {
-                            openNotch()
-                        }
+                        openNotch()
                     }
                 }
             })
@@ -722,9 +721,10 @@ struct ContentView: View {
         }
         .frame(
             maxWidth: (dynamicNotchSize.width + (vm.notchState == .open ? 24 : 0) + (isDynamicIslandMode ? dynamicIslandShadowInset * 2 : 0)).rounded(),
-            maxHeight: (dynamicNotchSize.height + (vm.notchState == .open ? 12 : 0) + (isDynamicIslandMode ? dynamicIslandTopOffset + dynamicIslandShadowInset * 2 : currentShadowPadding)).rounded(),
+            maxHeight: (dynamicNotchSize.height + (vm.notchState == .open ? 12 : 0) + (isIslandMode ? 0 : notchTopScreenBleedAmount) + (isDynamicIslandMode ? dynamicIslandTopOffset + dynamicIslandShadowInset * 2 : currentShadowPadding)).rounded(),
             alignment: .top
         )
+        .animation(nil, value: vm.notchState)
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
         .environmentObject(privacyManager)
         .background(dragDetector)
@@ -1182,14 +1182,16 @@ struct ContentView: View {
                 IdleAnimationView()
                     .frame(width: sideSize, height: sideSize)
             }
-        }.frame(height: vm.effectiveClosedNotchHeight + (isHovering ? 8 : 0), alignment: .center)
+        }.frame(height: vm.effectiveClosedNotchHeight + (isHovering ? 8 : 0), alignment: .top)
     }
 
     @ViewBuilder
     private func MusicLiveActivity(secondary preResolvedSecondary: MusicSecondaryLiveActivity? = nil) -> some View {
         let secondary = preResolvedSecondary ?? resolveMusicSecondaryLiveActivity()
-        let notchContentHeight = max(0, vm.effectiveClosedNotchHeight - (isHovering ? 0 : 12))
-        let wingBaseWidth = max(0, vm.effectiveClosedNotchHeight - (isHovering ? 0 : 12) + gestureProgress / 2)
+        let closedHeight = vm.effectiveClosedNotchHeight
+        let outerHeight = closedHeight + (isHovering ? 8 : 0)
+        let notchContentHeight = isHovering ? outerHeight : max(0, closedHeight - 12)
+        let wingBaseWidth = max(0, notchContentHeight + gestureProgress / 2)
         let rawCenterBaseWidth = vm.closedNotchSize.width + (isHovering ? 8 : 0)
         let centerBaseWidth = max(rawCenterBaseWidth, 96)
         let inlineSneakPeekActive = (
@@ -1300,7 +1302,7 @@ struct ContentView: View {
                 .contentTransition(.symbolEffect(.replace))
         }
         .frame(width: notchWidth, height: notchContentHeight)
-        .frame(height: vm.effectiveClosedNotchHeight + (isHovering ? 8 : 0), alignment: .center)
+        .frame(height: outerHeight, alignment: .top)
         .animation(.smooth(duration: 0.25), value: secondary?.id)
     }
 
@@ -1880,9 +1882,7 @@ struct ContentView: View {
 
     // MARK: - Private Methods
     private func openNotch() {
-        withAnimation(.bouncy.speed(1.2)) {
-            vm.open()
-        }
+        vm.open()
     }
 
     private func shouldShowClosedMusicWaveformPlayPauseOverlay(for secondary: MusicSecondaryLiveActivity?) -> Bool {
@@ -1958,6 +1958,15 @@ struct ContentView: View {
                     let hovering = self.hiddenHoverActivationContainsMouse()
                     if hovering != self.isHovering {
                         self.handleHover(hovering)
+                    }
+                } else if self.isHovering && self.interactionsEnabled {
+                    let stillInside = self.vm.notchState == .open
+                        ? self.isPointInsideNotchWindow()
+                        : self.isMouseOverClosedNotchHitArea()
+                    if !stillInside {
+                        self.hoverTask?.cancel()
+                        self.stopHoverClickMonitor()
+                        self.finishHoverExit()
                     }
                 }
 
@@ -2063,6 +2072,11 @@ struct ContentView: View {
     
     /// Handle hover state changes with debouncing
     private func handleHover(_ hovering: Bool) {
+        // Ignore false hover-exit when the cursor is parked on the screen's top pixel.
+        if !hovering, shouldRetainHoverAtScreenTopEdge() {
+            return
+        }
+
         hoverTask?.cancel()
 
         if hovering {
@@ -2116,35 +2130,73 @@ struct ContentView: View {
                 guard !Task.isCancelled else { return }
 
                 await MainActor.run {
-                    withAnimation(.bouncy.speed(1.2)) {
-                        self.isHovering = false
+                    if self.shouldRetainHoverAtScreenTopEdge() {
+                        return
                     }
-
-                    if self.vm.notchState == .open && !self.shouldPreventAutoClose() {
-                        self.vm.close()
-                    } else if self.vm.notchState == .open
-                                && Defaults[.terminalStickyMode]
-                                && self.coordinator.currentView == .terminal {
-                        // Re-sync monitor state through one code path to avoid
-                        // monitor lifecycle races between hover and state updates.
-                        self.syncStickyTerminalOutsideClickMonitor()
-                    }
+                    self.finishHoverExit()
                 }
             }
         }
     }
 
-    private func isPointInsideNotchWindow(_ point: CGPoint) -> Bool {
+    private func finishHoverExit() {
+        withAnimation(.bouncy.speed(1.2)) {
+            isHovering = false
+        }
+
+        if vm.notchState == .open && !shouldPreventAutoClose() {
+            vm.close()
+        } else if vm.notchState == .open
+                    && Defaults[.terminalStickyMode]
+                    && coordinator.currentView == .terminal {
+            // Re-sync monitor state through one code path to avoid
+            // monitor lifecycle races between hover and state updates.
+            syncStickyTerminalOutsideClickMonitor()
+        }
+    }
+
+    private func shouldRetainHoverAtScreenTopEdge(_ location: NSPoint = NSEvent.mouseLocation) -> Bool {
+        guard let screen = NSScreen.screens.first(where: { $0.localizedName == currentScreenName }) else {
+            return false
+        }
+        guard isHovering || vm.notchState == .open else { return false }
+        guard location.y >= screen.frame.maxY - 1.5 else { return false }
+
+        let halfWidth = max(vm.closedNotchSize.width + (isHovering ? 8 : 0), 96) / 2 + 28
+        return abs(location.x - screen.frame.midX) <= halfWidth
+    }
+
+    private func isMouseOverClosedNotchHitArea(_ location: NSPoint = NSEvent.mouseLocation) -> Bool {
+        guard let screen = NSScreen.screens.first(where: { $0.localizedName == currentScreenName }) else {
+            return false
+        }
+
+        let height = vm.effectiveClosedNotchHeight + (isHovering ? 8 : 0) + 6
+        let width = max(vm.closedNotchSize.width + (isHovering ? 8 : 0), 96) + 24
+        let minX = screen.frame.midX - width / 2
+        let minY = screen.frame.maxY - height
+
+        return location.x >= minX && location.x <= minX + width
+            && location.y >= minY && location.y <= screen.frame.maxY
+    }
+
+    private func isPointInsideNotchWindow(_ point: CGPoint = NSEvent.mouseLocation) -> Bool {
         if let appDelegate = AppDelegate.shared {
             if Defaults[.showOnAllDisplays] {
-                return appDelegate.windows.values.contains(where: { $0.frame.contains(point) })
+                return appDelegate.windows.values.contains(where: { frameContainsPointIncludingTopEdge($0.frame, point) })
             }
             if let window = appDelegate.window {
-                return window.frame.contains(point)
+                return frameContainsPointIncludingTopEdge(window.frame, point)
             }
         }
 
-        return NSApp.windows.contains(where: { $0.frame.contains(point) })
+        return NSApp.windows.contains(where: { frameContainsPointIncludingTopEdge($0.frame, point) })
+    }
+
+    /// `CGRect.contains` is half-open on max edges; the top pixel needs inclusive maxY.
+    private func frameContainsPointIncludingTopEdge(_ frame: CGRect, _ point: CGPoint) -> Bool {
+        point.x >= frame.minX && point.x <= frame.maxX
+            && point.y >= frame.minY && point.y <= frame.maxY
     }
     
     // Helper function to check if any popovers are active

--- a/DynamicIsland/ContentView.swift
+++ b/DynamicIsland/ContentView.swift
@@ -2162,8 +2162,10 @@ struct ContentView: View {
         guard isHovering || vm.notchState == .open else { return false }
         guard location.y >= screen.frame.maxY - 1.5 else { return false }
 
-        let halfWidth = max(vm.closedNotchSize.width + (isHovering ? 8 : 0), 96) / 2 + 28
-        return abs(location.x - screen.frame.midX) <= halfWidth
+        if vm.notchState == .open {
+            return isPointInsideNotchWindow(location)
+        }
+        return isMouseOverClosedNotchHitArea(location)
     }
 
     private func isMouseOverClosedNotchHitArea(_ location: NSPoint = NSEvent.mouseLocation) -> Bool {

--- a/DynamicIsland/DynamicIslandApp.swift
+++ b/DynamicIsland/DynamicIslandApp.swift
@@ -436,13 +436,13 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             window.alphaValue = 0
         }
         
-        // Use the same centering logic as updateWindowSizeIfNeeded()
         let screenFrame = screen.frame
+        let topBleed = notchTopScreenBleed(for: screen.localizedName)
         let centerX = screenFrame.origin.x + (screenFrame.width / 2)
         let roundedWidth = window.frame.width.rounded()
         let roundedHeight = window.frame.height.rounded()
         let newX = (centerX - (roundedWidth / 2)).rounded()
-        let newY = (screenFrame.origin.y + screenFrame.height - roundedHeight).rounded()
+        let newY = (screenFrame.maxY + topBleed - roundedHeight).rounded()
 
         window.setFrame(NSRect(
             x: newX,
@@ -557,16 +557,15 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         return result
     }
 
-    /// Adjusts a base notch size for a specific screen by adding Dynamic Island
-    /// shadow insets and top-offset only when the screen lacks a physical notch
-    /// and the user has chosen the Dynamic Island style.
+    /// Adds Dynamic Island shadow/top insets on non-notch screens, or top bleed on physical-notch screens.
     private func adjustedSizeForScreen(_ baseSize: CGSize, screen: NSScreen) -> CGSize {
-        guard shouldUseDynamicIslandMode(for: screen.localizedName) else {
-            return baseSize
-        }
         var adjusted = baseSize
-        adjusted.width += dynamicIslandShadowInset * 2
-        adjusted.height += dynamicIslandTopOffset
+        if shouldUseDynamicIslandMode(for: screen.localizedName) {
+            adjusted.width += dynamicIslandShadowInset * 2
+            adjusted.height += dynamicIslandTopOffset
+        } else {
+            adjusted.height += notchTopScreenBleed(for: screen.localizedName)
+        }
         return adjusted
     }
 
@@ -596,12 +595,14 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     private func resizeWindow(_ window: NSWindow, on screen: NSScreen, to size: CGSize, animated: Bool) {
         let screenFrame = screen.frame
+        let topBleed = notchTopScreenBleed(for: screen.localizedName)
         // Clamp width to screen width so the notch never extends beyond screen edges on scaled displays
         let clampedWidth = min(size.width, screenFrame.width).rounded()
-        let clampedHeight = min(size.height, screenFrame.height).rounded()
+        let maxHeight = screenFrame.height + topBleed
+        let clampedHeight = min(size.height, maxHeight).rounded()
         let centerX = screenFrame.midX
         let newX = (centerX - (clampedWidth / 2)).rounded()
-        let newY = (screenFrame.origin.y + screenFrame.height - clampedHeight).rounded()
+        let newY = (screenFrame.maxY + topBleed - clampedHeight).rounded()
         let targetFrame = NSRect(x: newX, y: newY, width: clampedWidth, height: clampedHeight)
 
         window.setFrame(targetFrame, display: true)

--- a/DynamicIsland/components/MinimalisticMusicView.swift
+++ b/DynamicIsland/components/MinimalisticMusicView.swift
@@ -81,7 +81,7 @@ struct MinimalisticMusicView: View {
             // (lyrics are displayed inline under the artist name)
         }
         // reserve extra height when lyrics are enabled
-        .frame(height: vm.effectiveClosedNotchHeight + (isHovering ? 8 : 0), alignment: .center)
+        .frame(height: vm.effectiveClosedNotchHeight + (isHovering ? 8 : 0), alignment: .top)
         .onHover { hovering in
             isHovering = hovering
         }

--- a/DynamicIsland/components/Timer/TimerLiveActivity.swift
+++ b/DynamicIsland/components/Timer/TimerLiveActivity.swift
@@ -334,7 +334,7 @@ struct TimerLiveActivity: View {
             middleSectionView()
             rightWingView()
         }
-        .frame(height: adjustedNotchHeight, alignment: .center)
+        .frame(height: adjustedNotchHeight, alignment: .top)
         .contentShape(Rectangle())
     }
 

--- a/DynamicIsland/sizing/matters.swift
+++ b/DynamicIsland/sizing/matters.swift
@@ -278,6 +278,13 @@ let dynamicIslandPillCornerRadiusInsets: (opened: CGFloat, closed: (standard: CG
     closed: (standard: 16, minimalistic: 16)
 )
 
+/// Extra window height past `screen.maxY` on physical-notch displays.
+let notchTopScreenBleedAmount: CGFloat = 4
+
+func notchTopScreenBleed(for screenName: String?) -> CGFloat {
+    shouldUseDynamicIslandMode(for: screenName) ? 0 : notchTopScreenBleedAmount
+}
+
 /// Vertical offset from the top screen edge for the Dynamic Island pill.
 /// Creates a visual gap so the pill floats below the menu bar, mimicking
 /// the iPhone's Dynamic Island detachment from the physical screen edge.


### PR DESCRIPTION
## Summary
Fixes the hairline gap at the top of the notch while it opens, and the hover-to-open open/close flap when the pointer sits on the top edge, on physical-notch Macs (#681).

The notch window bleeds a few points past the screen top so the shell stays sealed during the morph. Open uses a critically damped spring, and the root frame no longer springs with notchState. False hover-exit on the top pixel is ignored; a small poll still closes when you actually leave.

Closes #681


https://github.com/user-attachments/assets/02f0e3ad-e9d0-48de-a4bc-6737b5e92659



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed gaps and visual glitches during notch opening and closing animations.
  * Improved hover behavior on physical-notch Macs, preventing unwanted opening and closing near the top edge.
  * Resolved stale hover states after the pointer leaves the notch area.
  * Improved window positioning and sizing on screens with a physical notch.
  * Corrected music and timer layouts to keep content properly aligned during expansion.
  * Improved handling of top-edge hover retention for a smoother interaction experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->