### PR TITLE
Fix top-edge notch hover flicker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,9 @@ jobs:
       - name: Validate timer lifecycle cleanup
         run: python3 -m unittest tests.test_timer_lifecycle
 
+      - name: Validate notch hover geometry
+        run: python3 -m unittest tests.test_notch_hover_geometry
+
       - name: Download Metal Toolchain
         # The downloadable Metal Toolchain is an Xcode 26+ (macOS 26) component; older Xcode ships metal.
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -141,6 +141,7 @@ PrivateWorks
 *.py
 !tests/test_privacy_configuration.py
 !tests/test_timer_lifecycle.py
+!tests/test_notch_hover_geometry.py
 *.sh
 comparison_report.json
 *.txt

--- a/DynamicIsland/ContentView.swift
+++ b/DynamicIsland/ContentView.swift
@@ -1920,18 +1920,12 @@ struct ContentView: View {
             return false
         }
 
-        let horizontalPadding: CGFloat = 8
-        let activationWidth = vm.closedNotchSize.width + horizontalPadding * 2
-        let activationHeight = max(vm.closedNotchSize.height + zeroHeightHoverPadding, 14)
-
-        let activationRect = CGRect(
-            x: screen.frame.midX - activationWidth / 2,
-            y: screen.frame.maxY - activationHeight,
-            width: activationWidth,
-            height: activationHeight
+        return NotchHoverGeometry.containsActivationPoint(
+            location,
+            screenFrame: screen.frame,
+            closedNotchSize: vm.closedNotchSize,
+            verticalPadding: zeroHeightHoverPadding
         )
-
-        return activationRect.contains(location)
     }
 
     /// Cancels every long-lived task / event monitor this view owns. Called from
@@ -2111,40 +2105,59 @@ struct ContentView: View {
                 }
             }
         } else {
-            hoverTask = Task {
+            hoverTask = Task { @MainActor in
                 try? await Task.sleep(for: .milliseconds(100))
                 guard !Task.isCancelled else { return }
 
-                await MainActor.run {
-                    withAnimation(.bouncy.speed(1.2)) {
-                        self.isHovering = false
-                    }
+                // SwiftUI can emit a transient hover exit while the notch window
+                // resizes under a fast cursor at the top screen edge. Keep checking
+                // the real pointer position until it actually leaves; a matching
+                // hover-enter event cancels this task immediately.
+                if self.shouldKeepNotchOpen(at: NSEvent.mouseLocation) {
+                    self.startHoverClickMonitor()
+                }
+                while self.shouldKeepNotchOpen(at: NSEvent.mouseLocation) {
+                    try? await Task.sleep(for: .milliseconds(50))
+                    guard !Task.isCancelled else { return }
+                }
+                self.stopHoverClickMonitor()
 
-                    if self.vm.notchState == .open && !self.shouldPreventAutoClose() {
-                        self.vm.close()
-                    } else if self.vm.notchState == .open
-                                && Defaults[.terminalStickyMode]
-                                && self.coordinator.currentView == .terminal {
-                        // Re-sync monitor state through one code path to avoid
-                        // monitor lifecycle races between hover and state updates.
-                        self.syncStickyTerminalOutsideClickMonitor()
-                    }
+                withAnimation(.bouncy.speed(1.2)) {
+                    self.isHovering = false
+                }
+
+                if self.vm.notchState == .open && !self.shouldPreventAutoClose() {
+                    self.vm.close()
+                } else if self.vm.notchState == .open
+                            && Defaults[.terminalStickyMode]
+                            && self.coordinator.currentView == .terminal {
+                    // Re-sync monitor state through one code path to avoid
+                    // monitor lifecycle races between hover and state updates.
+                    self.syncStickyTerminalOutsideClickMonitor()
                 }
             }
         }
     }
 
+    private func shouldKeepNotchOpen(at point: CGPoint) -> Bool {
+        hiddenHoverActivationContainsMouse(point) || isPointInsideNotchWindow(point)
+    }
+
     private func isPointInsideNotchWindow(_ point: CGPoint) -> Bool {
         if let appDelegate = AppDelegate.shared {
             if Defaults[.showOnAllDisplays] {
-                return appDelegate.windows.values.contains(where: { $0.frame.contains(point) })
+                return appDelegate.windows.values.contains(where: {
+                    NotchHoverGeometry.containsInclusive(point, in: $0.frame)
+                })
             }
             if let window = appDelegate.window {
-                return window.frame.contains(point)
+                return NotchHoverGeometry.containsInclusive(point, in: window.frame)
             }
         }
 
-        return NSApp.windows.contains(where: { $0.frame.contains(point) })
+        return NSApp.windows.contains(where: {
+            NotchHoverGeometry.containsInclusive(point, in: $0.frame)
+        })
     }
     
     // Helper function to check if any popovers are active

--- a/DynamicIsland/utilities/NotchHoverGeometry.swift
+++ b/DynamicIsland/utilities/NotchHoverGeometry.swift
@@ -1,0 +1,43 @@
+/*
+ * Atoll (DynamicIsland)
+ * Copyright (C) 2024-2026 Atoll Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+import CoreGraphics
+
+enum NotchHoverGeometry {
+    static func containsActivationPoint(
+        _ point: CGPoint,
+        screenFrame: CGRect,
+        closedNotchSize: CGSize,
+        horizontalPadding: CGFloat = 8,
+        verticalPadding: CGFloat = 10,
+        minimumActivationHeight: CGFloat = 14
+    ) -> Bool {
+        let activationWidth = closedNotchSize.width + horizontalPadding * 2
+        let activationHeight = max(
+            closedNotchSize.height + verticalPadding,
+            minimumActivationHeight
+        )
+        let activationRect = CGRect(
+            x: screenFrame.midX - activationWidth / 2,
+            y: screenFrame.maxY - activationHeight,
+            width: activationWidth,
+            height: activationHeight
+        )
+
+        return containsInclusive(point, in: activationRect)
+    }
+
+    static func containsInclusive(_ point: CGPoint, in rect: CGRect) -> Bool {
+        point.x >= rect.minX
+            && point.x <= rect.maxX
+            && point.y >= rect.minY
+            && point.y <= rect.maxY
+    }
+}

--- a/tests/NotchHoverGeometryRegression.swift
+++ b/tests/NotchHoverGeometryRegression.swift
@@ -1,0 +1,45 @@
+import CoreGraphics
+
+@main
+enum NotchHoverGeometryRegression {
+    static func main() {
+        let screenFrame = CGRect(x: 0, y: 0, width: 1512, height: 982)
+        let closedNotchSize = CGSize(width: 180, height: 36)
+
+        precondition(
+            NotchHoverGeometry.containsActivationPoint(
+                CGPoint(x: screenFrame.midX, y: screenFrame.maxY),
+                screenFrame: screenFrame,
+                closedNotchSize: closedNotchSize
+            ),
+            "The exact top screen edge must remain inside the notch activation area"
+        )
+
+        precondition(
+            NotchHoverGeometry.containsActivationPoint(
+                CGPoint(x: screenFrame.midX, y: screenFrame.maxY - 20),
+                screenFrame: screenFrame,
+                closedNotchSize: closedNotchSize
+            ),
+            "A point inside the closed notch must remain active"
+        )
+
+        precondition(
+            !NotchHoverGeometry.containsActivationPoint(
+                CGPoint(x: screenFrame.midX + closedNotchSize.width, y: screenFrame.maxY),
+                screenFrame: screenFrame,
+                closedNotchSize: closedNotchSize
+            ),
+            "A point beyond the horizontal activation buffer must be rejected"
+        )
+
+        precondition(
+            !NotchHoverGeometry.containsActivationPoint(
+                CGPoint(x: screenFrame.midX, y: screenFrame.maxY - closedNotchSize.height - 20),
+                screenFrame: screenFrame,
+                closedNotchSize: closedNotchSize
+            ),
+            "A point below the activation buffer must be rejected"
+        )
+    }
+}

--- a/tests/test_notch_hover_geometry.py
+++ b/tests/test_notch_hover_geometry.py
@@ -1,0 +1,35 @@
+import os
+import pathlib
+import subprocess
+import tempfile
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+
+class NotchHoverGeometryTests(unittest.TestCase):
+    def test_top_screen_edge_remains_in_notch_activation_area(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            temporary_path = pathlib.Path(temporary_directory)
+            executable = temporary_path / "notch-hover-geometry-regression"
+            environment = os.environ.copy()
+            environment["CLANG_MODULE_CACHE_PATH"] = str(temporary_path / "module-cache")
+            environment["SWIFT_MODULECACHE_PATH"] = str(temporary_path / "module-cache")
+            subprocess.run(
+                [
+                    "swiftc",
+                    str(ROOT / "DynamicIsland/utilities/NotchHoverGeometry.swift"),
+                    str(ROOT / "tests/NotchHoverGeometryRegression.swift"),
+                    "-o",
+                    str(executable),
+                ],
+                check=True,
+                cwd=ROOT,
+                env=environment,
+            )
+            subprocess.run([str(executable)], check=True, cwd=ROOT)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Ignore transient SwiftUI hover-exit events while the pointer is still inside the notch activation area or an Atoll notch window.
- Treat the exact top-screen boundary as part of the activation region.
- Add a regression test for top-edge hover geometry and run it in CI.

## Root cause

During the notch opening animation, the SwiftUI view and window resize underneath the pointer. A fast upward pointer movement can therefore produce a transient `hover = false`. The existing 100 ms delayed close accepted that event without checking the current pointer position, causing repeated open/close animation at the top edge.

The close path now checks `NSEvent.mouseLocation` until the pointer actually leaves the stable activation/window region. A matching hover-enter event still cancels the pending task immediately.

## User impact

Rapidly moving the pointer from below the notch to the top screen edge no longer makes the notch repeatedly open and close. Normal close behavior after the pointer leaves is preserved.

## Validation

- `python3 -m unittest discover -s tests -p 'test_*.py'` — 8 tests passed.
- Full unsigned macOS build with Xcode — `BUILD SUCCEEDED`.
- Manually verified against the reported rapid upward pointer movement on a notched Mac.

Fixes #681.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved notch hover detection near screen edges and activation boundaries.
  * Prevented the Dynamic Island from closing prematurely while the pointer moves through transient resize areas.
  * Improved hit testing for notch-related interactions.

* **Tests**
  * Added regression coverage for notch hover geometry and boundary conditions.
  * Added automated validation for hover behavior in continuous integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->