### PR TITLE
Reduce idle CPU from hover and OSD watcher polling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The separate-tab clipboard now uses the same card grid (two columns) with drag-out and per-item delete, replacing the single-column list (#698).
 
 ### Fixed
+- Reduced idle CPU from always-on notch hover polling and OSDUIHelper process checks by backing off when the app is idle (#641).
 - Fixed a hairline gap at the top of the notch during open animation, and hover-to-open flapping when the pointer sits on the top edge, on physical-notch Macs (#681).
 - Fixed lock-screen widget readability on bright wallpapers by adding a Dark/Light appearance mode for widget text and controls.
 - Fixed Codex Today and Week usage totals remaining at zero when parsing Codex session logs (#664).

--- a/DynamicIsland/ContentView.swift
+++ b/DynamicIsland/ContentView.swift
@@ -1977,11 +1977,21 @@ struct ContentView: View {
                     }
                 }
 
-                try? await Task.sleep(for: .milliseconds(50))
+                try? await Task.sleep(for: .milliseconds(self.hiddenEdgeHoverPollingIntervalMs()))
             }
 
             self.hiddenEdgeHoverPollingTask = nil
         }
+    }
+
+    private func hiddenEdgeHoverPollingIntervalMs() -> Int {
+        if shouldUseHiddenEdgeHoverPolling {
+            return 50
+        }
+        if isHovering && interactionsEnabled {
+            return 100
+        }
+        return 1_000
     }
 
     private func stopHiddenEdgeHoverPolling() {

--- a/DynamicIsland/managers/SystemOSDManager.swift
+++ b/DynamicIsland/managers/SystemOSDManager.swift
@@ -349,9 +349,8 @@ class SystemOSDManager {
     /// helper after a short idle period (JETSAM_REASON_MEMORY_IDLE_EXIT) and
     /// launchd spins up a brand-new process on the next volume/brightness
     /// keypress — that fresh PID renders the native OSD before any one-shot
-    /// SIGSTOP can hit it. Polling every 150ms is cheap (a single pgrep per
-    /// tick when nothing changed) and shrinks the visible-OSD window enough
-    /// to feel instant.
+    /// SIGSTOP can hit it. Polls at 150ms while catching a new PID, then backs
+    /// off when the helper stays suspended.
     ///
     /// The loop exits immediately when the Mac sleeps (systemSleeping == true)
     /// and is restarted by handleSystemWake() when the machine wakes up again.
@@ -359,6 +358,7 @@ class SystemOSDManager {
     /// accumulate over an 8-hour sleep and exhaust the process table / fd limits.
     private static func startSuppressionWatcher() {
         let newTask = Task.detached(priority: .background) {
+            var stableChecks = 0
             while !Task.isCancelled {
                 // Pause the watcher entirely while the system is asleep.
                 // handleSystemWake() will cancel this task and spawn a fresh one.
@@ -375,8 +375,23 @@ class SystemOSDManager {
                 if let pid = currentPID, pid != lastPID {
                     suspendOSDUIHelper()
                     suppressionState.withLock { $0.lastSuspendedPID = pid }
+                    stableChecks = 0
+                    try? await Task.sleep(nanoseconds: 150_000_000) // 150ms
+                    continue
                 }
-                try? await Task.sleep(nanoseconds: 150_000_000) // 150ms
+
+                stableChecks += 1
+                let intervalNs: UInt64
+                if currentPID == nil {
+                    intervalNs = 1_000_000_000 // 1s — helper not running
+                } else if stableChecks < 5 {
+                    intervalNs = 150_000_000 // 150ms — confirm suspend stuck
+                } else if stableChecks < 20 {
+                    intervalNs = 500_000_000 // 500ms
+                } else {
+                    intervalNs = 1_000_000_000 // 1s — steady state
+                }
+                try? await Task.sleep(nanoseconds: intervalNs)
             }
         }
 


### PR DESCRIPTION
## Summary
Light idle-CPU improvement for the always-on loops that keep running even with Minimal UI and Stats/system monitoring off.

Before this, those loops were honestly pretty brutal in the background: the notch hover watcher woke every **50ms** forever (~20 Hz per window), and the System HUD path spawned **`pgrep OSDUIHelper` about every 150ms** (~6–7 subprocesses/sec) as long as HUD suppression was active. That baseline does not go away when you turn monitoring off — which matches what people reported in #641 / #690.

This PR just backs those loops off when nothing is happening:
- hover polling: **50ms** only when the hidden-edge detector is needed, **100ms** while hovering, **1s** when idle
- OSDUIHelper watcher: **150ms** while catching a new PID, then **500ms → 1s** once the helper is stable / absent

Not claiming this fully closes every high-CPU case (e.g. `sysmond` with Stats off in #690, or a stuck 100% UI-dead process). It’s a small, safe win for the default idle path.

Related: #641, #690

### Idle metrics after the fix (debug build, ~44 min uptime)

```
t+00s  CPU=1.5%  MEM=0.7%  RSS=253104KB
t+05s  CPU=2.0%  MEM=0.7%  RSS=253104KB
t+10s  CPU=3.6%  MEM=0.7%  RSS=253104KB
t+15s  CPU=1.5%  MEM=0.7%  RSS=253120KB
t+20s  CPU=3.8%  MEM=0.7%  RSS=253168KB
t+25s  CPU=3.6%  MEM=0.7%  RSS=253120KB
t+30s  CPU=2.8%  MEM=0.7%  RSS=253120KB
t+35s  CPU=2.0%  MEM=0.7%  RSS=253120KB
t+40s  CPU=1.1%  MEM=0.7%  RSS=253120KB
t+45s  CPU=2.3%  MEM=0.7%  RSS=253136KB
t+50s  CPU=1.9%  MEM=0.7%  RSS=253168KB
t+55s  CPU=1.6%  MEM=0.7%  RSS=253056KB
```

```
PID   %CPU MEM  #TH POWER
7370  0.0  142M 9   0.0
```
<img width="671" height="494" alt="Screenshot 2026-08-10 at 13 25 44" src="https://github.com/user-attachments/assets/97d05e80-c7db-4dac-9e8e-261cd3241b38" />
<img width="671" height="494" alt="Screenshot 2026-08-10 at 13 25 44" src="https://github.com/user-attachments/assets/043039ac-e7fe-461d-a62b-c11e0ca198f6" />
<img width="962" height="628" alt="Screenshot 2026-08-10 at 13 26 17" src="https://github.com/user-attachments/assets/ffe7ca40-3126-43f9-a966-9caacb5742ec" />

Steady idle stayed roughly **1–4% CPU**, Energy Impact **0.0**. Same ballpark with Minimal UI + monitoring off, because those settings never gated these two loops.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Performance**
  * Reduced CPU usage during idle periods by adapting the frequency of background hover detection and display-overlay checks.
  * Preserved fast responsiveness during active hover interactions and when newly opened display overlays require confirmation.
  * Background checks now slow further once system activity is stable.

* **Documentation**
  * Added an unreleased changelog entry describing the improved idle efficiency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->