### PR TITLE
fix(extensions): the RPC port was open to the local network

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed Open, Open With, Show in Finder, Quick Look, Compress, Copy Path, and the image actions all missing from the Shelf file context menu, caused by `ShelfItem.fileURL` returning a hard-coded `nil` for files (#682).
 - Fixed the notch auto-closing in the middle of a drag and cancelling the session: dragging an item out necessarily takes the cursor off the panel, which tore down the view acting as the drag source (#682).
 - Fixed an issue where scrolling a long note inside the Dynamic Island returned the view to the home view instead of scrolling the note. (`#636`)
+- Closed the extension RPC port to the local network. It was documented as listening on localhost but bound the wildcard address, so anything on the same Wi-Fi could reach port 9020 and drive the extension API — a client identifies itself simply by stating a bundle identifier. It now binds the loopback address of each family, and any connection from elsewhere is refused before it can send anything.
 
 ### Removed
 

--- a/DynamicIsland.xcodeproj/project.pbxproj
+++ b/DynamicIsland.xcodeproj/project.pbxproj
@@ -31,6 +31,7 @@
 		7EF19C172F577040005B9929 /* SwiftTerm in Frameworks */ = {isa = PBXBuildFile; productRef = 7EF19C162F577040005B9929 /* SwiftTerm */; };
 		A3C83CAF84544DCE386C3BB8 /* DynamicIslandUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54078F29304A9DBBEFBDF932 /* DynamicIslandUITests.swift */; };
 		B4777BB9FE29243B253B8306 /* SpotifyLibraryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFA269966BB987D4A1B411A2 /* SpotifyLibraryTests.swift */; };
+		A1B2C3D4E5F60718293A4B5C /* ExtensionRPCServerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60718293A4B5D /* ExtensionRPCServerTests.swift */; };
 		F1E2D3C4B5A6E7F8A9B0C1D2 /* JSONLUsageParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1F2A3B4C5D6E7F8A9B0C1D2 /* JSONLUsageParserTests.swift */; };
 		F3E4D5C6B7A8E9F0A1B2C3D4 /* NowPlayingTestClient in CopyFiles */ = {isa = PBXBuildFile; fileRef = F2E3D4C5B6A7E8F9A0B1C2D3 /* NowPlayingTestClient */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		F910B9C812C7AEFE2293F7D2 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 47C39E67B09152F6665ED683 /* Cocoa.framework */; };
@@ -79,6 +80,7 @@
 		A058D80A7EF44593B0F24EB7 /* DynamicIslandUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = DynamicIslandUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		DAA671E7B1B26733F02166C5 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		DFA269966BB987D4A1B411A2 /* SpotifyLibraryTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SpotifyLibraryTests.swift; sourceTree = "<group>"; };
+		A1B2C3D4E5F60718293A4B5D /* ExtensionRPCServerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ExtensionRPCServerTests.swift; sourceTree = "<group>"; };
 		E1F2A3B4C5D6E7F8A9B0C1D2 /* JSONLUsageParserTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = JSONLUsageParserTests.swift; sourceTree = "<group>"; };
 		F2E3D4C5B6A7E8F9A0B1C2D3 /* NowPlayingTestClient */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "compiled.mach-o.executable"; path = "Contents/Helpers/NowPlayingTestClient"; sourceTree = "<group>"; };
 		F4C1DD09EC134302938E84F6 /* MediaRemoteAdapter.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MediaRemoteAdapter.framework; path = Frameworks/MediaRemoteAdapter.framework; sourceTree = SOURCE_ROOT; };
@@ -174,6 +176,7 @@
 			isa = PBXGroup;
 			children = (
 				DFA269966BB987D4A1B411A2 /* SpotifyLibraryTests.swift */,
+				A1B2C3D4E5F60718293A4B5D /* ExtensionRPCServerTests.swift */,
 				E1F2A3B4C5D6E7F8A9B0C1D2 /* JSONLUsageParserTests.swift */,
 				957599910322B546D91E6F96 /* Info.plist */,
 			);
@@ -436,6 +439,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				B4777BB9FE29243B253B8306 /* SpotifyLibraryTests.swift in Sources */,
+				A1B2C3D4E5F60718293A4B5C /* ExtensionRPCServerTests.swift in Sources */,
 				F1E2D3C4B5A6E7F8A9B0C1D2 /* JSONLUsageParserTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/DynamicIsland/services/Extensions/ExtensionRPCServer.swift
+++ b/DynamicIsland/services/Extensions/ExtensionRPCServer.swift
@@ -41,9 +41,17 @@ final class ExtensionRPCServer {
     static let shared = ExtensionRPCServer()
 
     private var listeners: [NWListener] = []
+    /// Whether the server is *meant* to be running. A restart is scheduled three
+    /// seconds out, so without this a `stop()` inside that window is undone by the
+    /// pending closure — the port reopens after the user switched the feature off.
+    private var shouldRun = false
+    /// The single pending restart. Both listeners report failure separately, and
+    /// two restarts in flight means the second cancels the healthy listeners the
+    /// first just created.
+    private var restartWorkItem: DispatchWorkItem?
     private var connections: [UUID: RPCClientConnection] = [:]
     private var shelfSubscribers: Set<String> = [] // bundleIdentifiers subscribed to shelf events
-    private let port: UInt16 = 9020
+    private let port: UInt16 = ExtensionRPCServer.rpcPort
     private let queue = DispatchQueue(label: "com.ebullioscopic.Atoll.rpc.server", qos: .userInitiated)
     private let decoder = JSONDecoder()
     private let encoder = JSONEncoder()
@@ -53,6 +61,7 @@ final class ExtensionRPCServer {
     // MARK: - Lifecycle
 
     func start() {
+        shouldRun = true
         guard listeners.isEmpty else {
             logDiagnostics("RPC server already running")
             return
@@ -71,10 +80,22 @@ final class ExtensionRPCServer {
     }
 
     /// The loopback address of each family. Both are attempted; one is enough.
-    private static let loopbackHosts: [NWEndpoint.Host] = [
+    /// Binding only `::1` silently drops clients that resolve `localhost` to
+    /// `127.0.0.1`, so a test asserts both families are still listed.
+    static let loopbackHosts: [NWEndpoint.Host] = [
         .ipv4(.loopback),
         .ipv6(.loopback)
     ]
+
+    static let rpcPort: UInt16 = 9020
+
+    /// The endpoint a listener is pinned to. Split out from `makeListener` so a
+    /// test can assert the address *and* the port without opening a socket:
+    /// `isLoopback` ignores the port, so nothing else would catch this binding
+    /// drifting to the wrong one.
+    static func requiredLocalEndpoint(for host: NWEndpoint.Host) -> NWEndpoint {
+        .hostPort(host: host, port: NWEndpoint.Port(integerLiteral: rpcPort))
+    }
 
     private func makeListener(boundTo host: NWEndpoint.Host) -> NWListener? {
         let params = NWParameters(tls: nil)
@@ -83,10 +104,7 @@ final class ExtensionRPCServer {
         params.defaultProtocolStack.applicationProtocols.insert(wsOptions, at: 0)
         // Without this the listener takes the wildcard address and the port is
         // reachable from the local network.
-        params.requiredLocalEndpoint = NWEndpoint.hostPort(
-            host: host,
-            port: NWEndpoint.Port(integerLiteral: port)
-        )
+        params.requiredLocalEndpoint = Self.requiredLocalEndpoint(for: host)
         params.allowLocalEndpointReuse = true
 
         let listener: NWListener
@@ -128,7 +146,25 @@ final class ExtensionRPCServer {
         start()
     }
 
+    /// Coalesces the restarts the two listeners request independently, and lets
+    /// `stop()` call one off.
+    private func scheduleListenerRestart() {
+        guard shouldRun else { return }
+        restartWorkItem?.cancel()
+
+        let workItem = DispatchWorkItem { [weak self] in
+            guard let self, self.shouldRun else { return }
+            self.restartWorkItem = nil
+            self.restartListeners()
+        }
+        restartWorkItem = workItem
+        DispatchQueue.main.asyncAfter(deadline: .now() + 3, execute: workItem)
+    }
+
     func stop() {
+        shouldRun = false
+        restartWorkItem?.cancel()
+        restartWorkItem = nil
         for listener in listeners {
             listener.cancel()
         }
@@ -224,9 +260,7 @@ final class ExtensionRPCServer {
             // Restart both families rather than the failed one alone: the state
             // handler cannot say which listener it belongs to, and a half-open
             // server is harder to reason about than a restarted one.
-            DispatchQueue.main.asyncAfter(deadline: .now() + 3) { [weak self] in
-                self?.restartListeners()
-            }
+            scheduleListenerRestart()
         case .cancelled:
             logDiagnostics("RPC server listener on \(host) cancelled")
         default:

--- a/DynamicIsland/services/Extensions/ExtensionRPCServer.swift
+++ b/DynamicIsland/services/Extensions/ExtensionRPCServer.swift
@@ -23,11 +23,24 @@ import Defaults
 /// WebSocket server for Atoll RPC.
 /// Uses Apple's Network.framework (`NWListener`) — no external dependencies.
 /// Listens on localhost:9020 for JSON-RPC 2.0 requests over WebSocket.
+///
+/// ## Loopback only, and checked twice
+/// `NWListener(using:on:)` binds the **wildcard** address, so this port used to
+/// accept connections from anything on the same network — a client identifies
+/// itself by simply stating a `bundleIdentifier`, so a machine on the café Wi-Fi
+/// could drive the extension API. It is now bound to the loopback address of
+/// each family, and every accepted connection's peer is checked as well: a bind
+/// is one line away from being widened by accident, and the check costs nothing.
+///
+/// Two listeners rather than one because a socket bound to `127.0.0.1` does not
+/// accept `::1` and vice versa, and a client resolving "localhost" may arrive on
+/// either. Each is optional: on a Mac with one family disabled the other still
+/// serves.
 @MainActor
 final class ExtensionRPCServer {
     static let shared = ExtensionRPCServer()
 
-    private var listener: NWListener?
+    private var listeners: [NWListener] = []
     private var connections: [UUID: RPCClientConnection] = [:]
     private var shelfSubscribers: Set<String> = [] // bundleIdentifiers subscribed to shelf events
     private let port: UInt16 = 9020
@@ -40,41 +53,86 @@ final class ExtensionRPCServer {
     // MARK: - Lifecycle
 
     func start() {
-        guard listener == nil else {
+        guard listeners.isEmpty else {
             logDiagnostics("RPC server already running")
             return
         }
 
+        for host in Self.loopbackHosts {
+            if let listener = makeListener(boundTo: host) {
+                listeners.append(listener)
+                listener.start(queue: queue)
+            }
+        }
+
+        if listeners.isEmpty {
+            Logger.log("RPC server could not bind to loopback on port \(port)", category: .extensions)
+        }
+    }
+
+    /// The loopback address of each family. Both are attempted; one is enough.
+    private static let loopbackHosts: [NWEndpoint.Host] = [
+        .ipv4(.loopback),
+        .ipv6(.loopback)
+    ]
+
+    private func makeListener(boundTo host: NWEndpoint.Host) -> NWListener? {
         let params = NWParameters(tls: nil)
         let wsOptions = NWProtocolWebSocket.Options()
         wsOptions.autoReplyPing = true
         params.defaultProtocolStack.applicationProtocols.insert(wsOptions, at: 0)
+        // Without this the listener takes the wildcard address and the port is
+        // reachable from the local network.
+        params.requiredLocalEndpoint = NWEndpoint.hostPort(
+            host: host,
+            port: NWEndpoint.Port(integerLiteral: port)
+        )
+        params.allowLocalEndpointReuse = true
 
+        let listener: NWListener
         do {
-            listener = try NWListener(using: params, on: NWEndpoint.Port(integerLiteral: port))
+            // The port comes from `requiredLocalEndpoint`, and passing it again
+            // as `on:` is rejected outright: the two ways of saying where to
+            // bind may not be combined.
+            listener = try NWListener(using: params)
         } catch {
-            Logger.log("Failed to create RPC listener: \(error.localizedDescription)", category: .extensions)
-            return
+            Logger.log(
+                "Failed to create RPC listener on \(host): \(error.localizedDescription)",
+                category: .extensions
+            )
+            return nil
         }
 
-        listener?.stateUpdateHandler = { [weak self] state in
+        listener.stateUpdateHandler = { [weak self] state in
             Task { @MainActor in
-                self?.handleListenerState(state)
+                self?.handleListenerState(state, host: host)
             }
         }
 
-        listener?.newConnectionHandler = { [weak self] connection in
+        listener.newConnectionHandler = { [weak self] connection in
             Task { @MainActor in
                 self?.handleNewConnection(connection)
             }
         }
 
-        listener?.start(queue: queue)
+        return listener
+    }
+
+    /// Rebinds without disturbing clients that are still connected: a listener
+    /// failing says nothing about the connections it already handed over.
+    private func restartListeners() {
+        for listener in listeners {
+            listener.cancel()
+        }
+        listeners.removeAll()
+        start()
     }
 
     func stop() {
-        listener?.cancel()
-        listener = nil
+        for listener in listeners {
+            listener.cancel()
+        }
+        listeners.removeAll()
         for (_, conn) in connections {
             conn.connection.cancel()
         }
@@ -154,25 +212,40 @@ final class ExtensionRPCServer {
 
     // MARK: - Connection Handling
 
-    private func handleListenerState(_ state: NWListener.State) {
+    private func handleListenerState(_ state: NWListener.State, host: NWEndpoint.Host) {
         switch state {
         case .ready:
-            Logger.log("Started Atoll RPC WebSocket server on port \(port)", category: .extensions)
+            Logger.log("Started Atoll RPC WebSocket server on \(host):\(port)", category: .extensions)
         case .failed(let error):
-            Logger.log("RPC server failed: \(error.localizedDescription)", category: .extensions)
-            // Attempt restart after delay
+            Logger.log(
+                "RPC server on \(host) failed: \(error.localizedDescription)",
+                category: .extensions
+            )
+            // Restart both families rather than the failed one alone: the state
+            // handler cannot say which listener it belongs to, and a half-open
+            // server is harder to reason about than a restarted one.
             DispatchQueue.main.asyncAfter(deadline: .now() + 3) { [weak self] in
-                self?.listener = nil
-                self?.start()
+                self?.restartListeners()
             }
         case .cancelled:
-            logDiagnostics("RPC server listener cancelled")
+            logDiagnostics("RPC server listener on \(host) cancelled")
         default:
             break
         }
     }
 
     private func handleNewConnection(_ nwConnection: NWConnection) {
+        // Belt and braces: the listener is bound to loopback, and anything that
+        // still arrives from elsewhere is dropped before it can send a byte.
+        guard Self.isLoopback(nwConnection.endpoint) else {
+            Logger.log(
+                "Refused an RPC connection from \(nwConnection.endpoint) — this server is local-only",
+                category: .extensions
+            )
+            nwConnection.cancel()
+            return
+        }
+
         let connID = UUID()
         let clientConn = RPCClientConnection(
             id: connID,
@@ -190,6 +263,39 @@ final class ExtensionRPCServer {
         nwConnection.start(queue: queue)
         receiveMessage(connID: connID)
         logDiagnostics("RPC client connected (id: \(connID.uuidString.prefix(8)))")
+    }
+
+    /// Whether a peer is on this Mac.
+    ///
+    /// Pure and static so the interesting cases — an IPv4-mapped IPv6 peer that
+    /// *is* loopback, a LAN address that merely starts with 127 in text form —
+    /// can be decided by a test rather than by reading the code and hoping.
+    static func isLoopback(_ endpoint: NWEndpoint) -> Bool {
+        switch endpoint {
+        case .hostPort(let host, _):
+            return isLoopback(host)
+        case .unix:
+            // A filesystem socket is as local as it gets.
+            return true
+        default:
+            return false
+        }
+    }
+
+    static func isLoopback(_ host: NWEndpoint.Host) -> Bool {
+        switch host {
+        case .ipv4(let address):
+            return address.isLoopback
+        case .ipv6(let address):
+            // `::ffff:127.0.0.1` arrives on a dual-stack socket and is loopback,
+            // however little it looks like it.
+            if let mapped = address.asIPv4 { return mapped.isLoopback }
+            return address.isLoopback
+        case .name(let name, _):
+            return name == "localhost" || name == "localhost."
+        @unknown default:
+            return false
+        }
     }
 
     private func handleConnectionState(connID: UUID, state: NWConnection.State) {

--- a/DynamicIslandTests/ExtensionRPCServerTests.swift
+++ b/DynamicIslandTests/ExtensionRPCServerTests.swift
@@ -1,0 +1,82 @@
+/*
+ * Atoll (DynamicIsland)
+ * Copyright (C) 2024-2026 Atoll Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import Network
+import XCTest
+
+@testable import Atoll
+
+/// The peer check that keeps the extension RPC server local.
+///
+/// The listener is bound to loopback, so in practice nothing else should ever
+/// reach this code — which is exactly why it is worth testing: a bug here would
+/// only surface the day the bind changed.
+@MainActor
+final class ExtensionRPCServerTests: XCTestCase {
+    private func endpoint(_ host: NWEndpoint.Host) -> NWEndpoint {
+        .hostPort(host: host, port: 9_020)
+    }
+
+    func testLoopbackPeersAreAccepted() {
+        XCTAssertTrue(ExtensionRPCServer.isLoopback(endpoint(.ipv4(.loopback))))
+        XCTAssertTrue(ExtensionRPCServer.isLoopback(endpoint(.ipv6(.loopback))))
+        XCTAssertTrue(ExtensionRPCServer.isLoopback(endpoint(.name("localhost", nil))))
+    }
+
+    /// The whole point of the fix: before it, this connection was served.
+    func testALocalNetworkPeerIsRefused() {
+        let lan = IPv4Address("192.168.1.105")!
+        XCTAssertFalse(ExtensionRPCServer.isLoopback(endpoint(.ipv4(lan))))
+    }
+
+    func testAPublicAddressIsRefused() {
+        XCTAssertFalse(ExtensionRPCServer.isLoopback(endpoint(.ipv4(IPv4Address("93.184.216.34")!))))
+        XCTAssertFalse(ExtensionRPCServer.isLoopback(endpoint(.ipv6(IPv6Address("2606:2800:220:1::1")!))))
+    }
+
+    /// A dual-stack socket reports an IPv4 peer as `::ffff:127.0.0.1`, which is
+    /// loopback however little it looks like one. Rejecting it would break every
+    /// IPv4 client the day the listener accepted them on an IPv6 socket.
+    func testAnIPv4MappedLoopbackPeerIsAccepted() {
+        let mapped = IPv6Address("::ffff:127.0.0.1")!
+        XCTAssertTrue(ExtensionRPCServer.isLoopback(endpoint(.ipv6(mapped))))
+    }
+
+    /// The mirror image: a mapped *LAN* address must not sneak through on the
+    /// strength of being IPv6-shaped.
+    func testAnIPv4MappedLocalNetworkPeerIsRefused() {
+        let mapped = IPv6Address("::ffff:192.168.1.105")!
+        XCTAssertFalse(ExtensionRPCServer.isLoopback(endpoint(.ipv6(mapped))))
+    }
+
+    /// Anything not addressed by host and port — a Bonjour service, say — is not
+    /// something this server should be answering.
+    func testAServiceEndpointIsRefused() {
+        let service = NWEndpoint.service(
+            name: "Atoll", type: "_atoll._tcp", domain: "local", interface: nil
+        )
+        XCTAssertFalse(ExtensionRPCServer.isLoopback(service))
+    }
+
+    /// The naive version of this check was a string comparison, which would have
+    /// accepted a hostname merely *containing* "localhost".
+    func testALookalikeHostnameIsRefused() {
+        XCTAssertFalse(ExtensionRPCServer.isLoopback(endpoint(.name("localhost.evil.example", nil))))
+        XCTAssertFalse(ExtensionRPCServer.isLoopback(endpoint(.name("notlocalhost", nil))))
+    }
+}

--- a/DynamicIslandTests/ExtensionRPCServerTests.swift
+++ b/DynamicIslandTests/ExtensionRPCServerTests.swift
@@ -44,6 +44,31 @@ final class ExtensionRPCServerTests: XCTestCase {
         XCTAssertFalse(ExtensionRPCServer.isLoopback(endpoint(.ipv4(lan))))
     }
 
+    /// `isLoopback` ignores the port, so the peer-check tests above stay green
+    /// even if the listener binds the wrong one. This pins the binding itself.
+    func testTheListenerIsPinnedToLoopbackOnTheRPCPort() {
+        for host in ExtensionRPCServer.loopbackHosts {
+            let endpoint = ExtensionRPCServer.requiredLocalEndpoint(for: host)
+            guard case let .hostPort(boundHost, boundPort) = endpoint else {
+                return XCTFail("expected a hostPort endpoint, got \(endpoint)")
+            }
+            XCTAssertEqual(boundPort, 9_020)
+            XCTAssertTrue(
+                ExtensionRPCServer.isLoopback(endpoint),
+                "\(boundHost) is not a loopback address"
+            )
+        }
+    }
+
+    /// Binding one family only would silently drop clients that resolve
+    /// `localhost` to the other.
+    func testBothLoopbackFamiliesAreBound() {
+        let hosts = ExtensionRPCServer.loopbackHosts.map(String.init(describing:))
+        XCTAssertEqual(ExtensionRPCServer.loopbackHosts.count, 2, "both IPv4 and IPv6 must be bound")
+        XCTAssertTrue(hosts.contains { $0.contains("127.0.0.1") }, "IPv4 loopback missing: \(hosts)")
+        XCTAssertTrue(hosts.contains { $0.contains("::1") }, "IPv6 loopback missing: \(hosts)")
+    }
+
     func testAPublicAddressIsRefused() {
         XCTAssertFalse(ExtensionRPCServer.isLoopback(endpoint(.ipv4(IPv4Address("93.184.216.34")!))))
         XCTAssertFalse(ExtensionRPCServer.isLoopback(endpoint(.ipv6(IPv6Address("2606:2800:220:1::1")!))))


### PR DESCRIPTION
`ExtensionRPCServer` is documented as listening on localhost, but it created its `NWListener` with `using:on:` only — which binds the wildcard address. Anything on the same network could reach port 9020 and drive the extension API, and a client identifies itself simply by stating a bundle identifier, so reaching the port is the whole of the authentication.

## The fix

The listener now binds the loopback address explicitly, and any connection whose remote endpoint is not loopback is cancelled before it can send a byte.

Two details worth knowing for review:

- `NWListener.Parameters.requiredLocalEndpoint` and the `on: port` argument cannot both be set — the combination fails with `EINVAL` at listener start. The port is carried in the endpoint instead.
- IPv4 and IPv6 loopback need **two listeners**; a single `requiredLocalEndpoint` binds one family only, and binding just `::1` silently drops clients that resolve `localhost` to `127.0.0.1`.

## Verifying

Before: `lsof -nP -iTCP:9020 -sTCP:LISTEN` shows `*:9020`, and `nc <LAN-IP> 9020` from another machine connects.
After: it shows `127.0.0.1:9020` and `[::1]:9020`, and the same `nc` is refused.

`ExtensionRPCServerTests.swift` covers the endpoint construction and the remote-endpoint rejection (82 lines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Extension RPC connections are now restricted to the local device.
  * LAN and public network connections are rejected.
  * IPv4, IPv6, localhost, and Unix socket endpoints are validated consistently.
  * The service listens on both IPv4 and IPv6 loopback addresses.

* **Documentation**
  * Added a changelog entry describing strengthened local-only RPC access.

* **Tests**
  * Added coverage for accepted loopback and rejected non-local or lookalike endpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->