### PR TITLE
fix(bluetooth): stop the launch crash and the main-thread subprocesses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The separate-tab clipboard now uses the same card grid (two columns) with drag-out and per-item delete, replacing the single-column list (#698).
 
 ### Fixed
+- Fixed a launch crash (`BUG IN CLIENT OF LIBDISPATCH: trying to lock recursively`) that could trap while a Bluetooth audio device was connected. `BluetoothAudioManager`'s initialiser scanned connected devices synchronously, and that scan blocks on `Process.waitUntilExit()`, which spins the run loop — letting SwiftUI evaluate a view body that reads `BluetoothAudioManager.shared` and re-enter the initialiser that was still running. The scan now starts on the next main-queue turn instead.
 - Fixed excessive memory usage by streaming LLM usage JSONL files instead of loading them entirely into memory
 - Reduced idle CPU from always-on notch hover polling and OSDUIHelper process checks by backing off when the app is idle (#641).
 - Rich-text clipboard entries now keep their formatting when dragged out of the notch. Rich content is captured as RTF at copy time — including web/HTML copies (browsers, GitHub) that expose only `public.html`, which is now converted to RTF — and the drag offers that styled RTF with a plain-text fallback. Rich-text editors (TextEdit, Pages, Word) receive the formatting; plain-text targets still get plain text. The exact result depends on what the destination app accepts (#717, closes #712).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed Open, Open With, Show in Finder, Quick Look, Compress, Copy Path, and the image actions all missing from the Shelf file context menu, caused by `ShelfItem.fileURL` returning a hard-coded `nil` for files (#682).
 - Fixed the notch auto-closing in the middle of a drag and cancelling the session: dragging an item out necessarily takes the cursor off the panel, which tore down the view acting as the drag source (#682).
 - Fixed an issue where scrolling a long note inside the Dynamic Island returned the view to the home view instead of scrolling the note. (`#636`)
+- Stopped the Bluetooth battery refresh from stalling the interface. It ran `system_profiler` and `pmset` on the main thread — about 200 ms each time — at launch and again on every connect, disconnect and refresh, four times in the first twenty seconds of a session here. Those two now run in the background, and the `system_profiler` reading is shared for 30 seconds instead of being taken separately for battery levels and for each device's model lookup, so a connect no longer spawns it twice. Battery levels are unchanged; on a cold start the percentage can arrive a moment after the device does, which the existing brief wait before showing the connection already covers.
 
 ### Removed
 

--- a/DynamicIsland/managers/BluetoothAudioManager.swift
+++ b/DynamicIsland/managers/BluetoothAudioManager.swift
@@ -74,6 +74,31 @@ class BluetoothAudioManager: ObservableObject {
     private var isPmsetRefreshInFlight = false
     private var lastPmsetRefreshDate: Date?
     private let pmsetRefreshCooldown: TimeInterval = 5
+    /// The last `system_profiler` reading, shared by everything that needs one.
+    ///
+    /// Spawning that process costs ~200 ms, and it was being spawned once for
+    /// battery levels and again per device for the vendor/product lookup, on
+    /// every connect and every battery refresh. One reading serves them all.
+    private var profilerSnapshot: [String: Any]?
+    private var profilerSnapshotDate: Date?
+    /// Short enough that a stale reading never outlives the event that made it
+    /// interesting; connect and disconnect clear it outright.
+    private let profilerSnapshotTTL: TimeInterval = 30
+    /// Guards the snapshot, which is read from the main thread and written from
+    /// the battery queue.
+    private let profilerSnapshotLock = NSLock()
+
+    /// Where the subprocess half of a battery refresh runs.
+    private let batteryFetchQueue = DispatchQueue(
+        label: "com.dynamicisland.bluetooth.battery", qos: .utility
+    )
+    private var isSubprocessBatteryRefreshInFlight = false
+    private var lastSubprocessBatteryRefresh: Date?
+    /// Last values the subprocesses reported, so the cheap in-process pass can
+    /// keep publishing them instead of dropping a level it already knew.
+    private var subprocessAddressPercentages: [String: Int] = [:]
+    private var subprocessNamePercentages: [String: Int] = [:]
+
     private var hudBatteryWaitTasks: [UUID: Task<Void, Never>] = [:]
     private let hudBatteryWaitInterval: TimeInterval = 0.3
     private let hudBatteryWaitTimeout: TimeInterval = 1.8
@@ -314,7 +339,11 @@ class BluetoothAudioManager: ObservableObject {
     /// Handles Bluetooth device connection notification from DistributedNotificationCenter
     @objc private func handleDeviceConnectedNotification(_ notification: Notification) {
         print("🎧 [BluetoothAudioManager] 📡 Device connection notification received")
-        
+
+        // The cached `system_profiler` reading describes the world as it was
+        // before this device arrived, and the very next thing that happens is
+        // someone asking about that device.
+        invalidateProfilerSnapshot()
         // Re-check all devices since distributed notification doesn't contain device object
         checkForNewlyConnectedDevices()
     }
@@ -322,7 +351,8 @@ class BluetoothAudioManager: ObservableObject {
     /// Handles Bluetooth device disconnection notification from DistributedNotificationCenter
     @objc private func handleDeviceDisconnectedNotification(_ notification: Notification) {
         print("🎧 [BluetoothAudioManager] 📡 Device disconnection notification received")
-        
+
+        invalidateProfilerSnapshot()
         // Re-check all devices to update connection state
         updateConnectedDevices()
     }
@@ -1191,6 +1221,16 @@ class BluetoothAudioManager: ObservableObject {
         return nil
     }
 
+    /// Republishes battery levels from the sources that cost nothing, and asks
+    /// for the expensive ones in the background.
+    ///
+    /// The IORegistry and the preference files are read in-process in well under
+    /// a millisecond. `system_profiler` and `pmset` are subprocesses; running
+    /// them here meant roughly 200 ms on the main thread, at launch and again on
+    /// every connect, disconnect and refresh — measured at four runs in the
+    /// first twenty seconds of a session. They now run on ``batteryFetchQueue``
+    /// and their last answers are kept, so this pass still publishes everything
+    /// it knew a moment ago rather than briefly forgetting a level.
     private func updateBatteryStatuses(force: Bool = false) {
         let now = Date()
         if !force, let lastBatteryStatusUpdate,
@@ -1198,6 +1238,12 @@ class BluetoothAudioManager: ObservableObject {
             return
         }
 
+        publishBatteryStatuses(now: now)
+        requestSubprocessBatteryRefresh(force: force)
+    }
+
+    /// Merges the cheap sources with the last subprocess answers and publishes.
+    private func publishBatteryStatuses(now: Date = Date()) {
         var combinedAddressPercentages: [String: Int] = [:]
         var combinedNamePercentages: [String: Int] = [:]
 
@@ -1209,12 +1255,8 @@ class BluetoothAudioManager: ObservableObject {
         mergeBatteryLevels(into: &combinedAddressPercentages, from: defaults.addresses)
         mergeBatteryLevels(into: &combinedNamePercentages, from: defaults.names)
 
-        let profiler = collectSystemProfilerBatteryLevels()
-        mergeBatteryLevels(into: &combinedAddressPercentages, from: profiler.addresses)
-        mergeBatteryLevels(into: &combinedNamePercentages, from: profiler.names)
-
-        let pmsetEntries = collectPmsetAccessoryBatteryEntries()
-        mergePmsetEntries(pmsetEntries, into: &combinedNamePercentages, logNewEntries: true)
+        mergeBatteryLevels(into: &combinedAddressPercentages, from: subprocessAddressPercentages)
+        mergeBatteryLevels(into: &combinedNamePercentages, from: subprocessNamePercentages)
 
         var statuses: [String: String] = [:]
         for (key, value) in combinedAddressPercentages {
@@ -1232,6 +1274,38 @@ class BluetoothAudioManager: ObservableObject {
             applyUpdates()
         } else {
             DispatchQueue.main.sync(execute: applyUpdates)
+        }
+    }
+
+    /// Runs `system_profiler` and `pmset` off the main thread, then republishes.
+    private func requestSubprocessBatteryRefresh(force: Bool) {
+        guard !isSubprocessBatteryRefreshInFlight else { return }
+        if !force, let last = lastSubprocessBatteryRefresh,
+           Date().timeIntervalSince(last) < batteryStatusUpdateInterval {
+            return
+        }
+        isSubprocessBatteryRefreshInFlight = true
+
+        batteryFetchQueue.async { [weak self] in
+            guard let self else { return }
+            let profiler = self.collectSystemProfilerBatteryLevels()
+            let pmsetEntries = self.collectPmsetAccessoryBatteryEntries()
+
+            DispatchQueue.main.async {
+                self.isSubprocessBatteryRefreshInFlight = false
+                self.lastSubprocessBatteryRefresh = Date()
+
+                var addresses = self.subprocessAddressPercentages
+                var names = self.subprocessNamePercentages
+                self.mergeBatteryLevels(into: &addresses, from: profiler.addresses)
+                self.mergeBatteryLevels(into: &names, from: profiler.names)
+                self.mergePmsetEntries(pmsetEntries, into: &names, logNewEntries: true)
+
+                self.subprocessAddressPercentages = addresses
+                self.subprocessNamePercentages = names
+                self.publishBatteryStatuses()
+                self.applyConnectedDeviceBatteryLevels(triggerPmsetFallback: false)
+            }
         }
     }
 
@@ -1469,7 +1543,43 @@ class BluetoothAudioManager: ObservableObject {
         return Array(identifiers)
     }
 
+    /// A `system_profiler` reading, from cache when there is a fresh one.
+    ///
+    /// Callers used to each spawn their own; on a connect that meant the process
+    /// ran twice on the main thread before the HUD could appear.
     private func systemProfilerBluetoothDictionary() -> [String: Any]? {
+        profilerSnapshotLock.lock()
+        if let snapshot = profilerSnapshot,
+           let date = profilerSnapshotDate,
+           Date().timeIntervalSince(date) < profilerSnapshotTTL {
+            profilerSnapshotLock.unlock()
+            return snapshot
+        }
+        profilerSnapshotLock.unlock()
+
+        let fresh = runSystemProfilerBluetoothDictionary()
+
+        profilerSnapshotLock.lock()
+        profilerSnapshot = fresh
+        profilerSnapshotDate = fresh == nil ? nil : Date()
+        profilerSnapshotLock.unlock()
+
+        return fresh
+    }
+
+    /// Forgets the cached reading.
+    ///
+    /// Called when a device connects or disconnects: that is exactly the moment
+    /// the previous reading stopped describing reality, and also the moment
+    /// something is about to ask.
+    private func invalidateProfilerSnapshot() {
+        profilerSnapshotLock.lock()
+        profilerSnapshot = nil
+        profilerSnapshotDate = nil
+        profilerSnapshotLock.unlock()
+    }
+
+    private func runSystemProfilerBluetoothDictionary() -> [String: Any]? {
         let process = Process()
         process.launchPath = "/usr/sbin/system_profiler"
         process.arguments = ["SPBluetoothDataType", "-json"]

--- a/DynamicIsland/managers/BluetoothAudioManager.swift
+++ b/DynamicIsland/managers/BluetoothAudioManager.swift
@@ -106,8 +106,27 @@ class BluetoothAudioManager: ObservableObject {
         setupBluetoothObservers()
         setupAirPodsListeningModeObservers()
         setupAirPodsListeningModeLogObserver()
-        checkInitialDevices()
         startPollingForChanges()
+
+        // Deliberately deferred rather than called here.
+        //
+        // `checkInitialDevices()` reaches `systemProfilerBluetoothDictionary()`,
+        // which blocks on `Process.waitUntilExit()`. On the main thread that
+        // **spins the run loop**, so a SwiftUI run-loop observer gets to evaluate
+        // `ContentView.body` while this initialiser is still running. That body
+        // reads `BluetoothAudioManager.shared` — it is a default argument of
+        // `InlineHUD.init` — which re-enters the `swift_once` currently
+        // constructing this very instance, and libdispatch traps with
+        // "BUG IN CLIENT OF LIBDISPATCH: trying to lock recursively".
+        //
+        // It only reproduced with a Bluetooth audio device connected, because
+        // that is what makes the `system_profiler` call slow enough to matter.
+        //
+        // Hopping to the next main-queue turn lets `shared` finish publishing
+        // before any of that work runs, so the re-entry cannot happen.
+        DispatchQueue.main.async { [weak self] in
+            self?.checkInitialDevices()
+        }
     }
     
     deinit {


### PR DESCRIPTION
Two related problems in `BluetoothAudioManager`, both caused by shelling out synchronously.

## 1. Launch crash: `BUG IN CLIENT OF LIBDISPATCH: trying to lock recursively`

The initialiser scanned connected devices synchronously, and that scan blocks on `Process.waitUntilExit()`, which spins the run loop. That let SwiftUI evaluate a view body which reads `BluetoothAudioManager.shared` — re-entering the `static let` initialiser that had not finished running, which traps in `swift_once`.

It only triggers with a Bluetooth audio device connected at launch, which is why it is intermittent.

The scan now starts on the next main-queue turn, so the initialiser returns before anything can read `.shared`.

## 2. `system_profiler` and `pmset` ran on the main thread

The Bluetooth battery refresh ran both — about 200 ms each — on the main thread at launch and again on every connect, disconnect and refresh; four times in the first twenty seconds of a session here.

Both now run in the background, and the `system_profiler` reading is shared for 30 seconds instead of being taken separately for battery levels and for each device's model lookup, so a connect no longer spawns it twice.

Battery levels are unchanged. On a cold start the percentage can arrive a moment after the device does, which the existing brief wait before showing the connection already covers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
