### PR TITLE
fix(shortcuts): use the documented Cmd+Shift+V for clipboard history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed Notch expansion FPS stutter. Music and Timer managers now cache `NSHostingView` fitting sizes and reuse them for hover-only updates. When the panel size is unchanged, the window moves with `setFrameOrigin` instead of `setFrame`; `FlyoutFrameCalculator.swift` centralizes the flyout placement calculation (#741).
 - Fixed Canvas desync during Notch transitions. Static artwork is rendered by SwiftUI, while Spotify Canvas uses an `AVPlayerLayer` hosted in an `NSViewRepresentable`. During close, the video layer implicitly animated its own frame in a separate Core Animation transaction, creating a second, slower slide-out that conflicted with SwiftUI’s transition (#741).
 
-- Fixed the clipboard history shortcut being registered as Cmd+Shift+C while Settings documented Cmd+Shift+V ("similar to Windows+V on PC"). The default is now Cmd+Shift+V, and a one-time migration moves anyone still on the old default, since `KeyboardShortcuts` persists a default on first launch and would otherwise keep the old key forever. Custom shortcuts are left alone.
+- Fixed the clipboard history shortcut being registered as Cmd+Shift+C while Settings documented Cmd+Shift+V ("similar to Windows+V on PC"). The default is now Cmd+Shift+V, and a one-time migration moves persisted Cmd+Shift+C values, since `KeyboardShortcuts` persists a default on first launch and would otherwise keep the old key forever, and a stored value does not record whether it came from that default or from a deliberate Cmd+Shift+C choice. Every other custom shortcut is left alone.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed Notch expansion FPS stutter. Music and Timer managers now cache `NSHostingView` fitting sizes and reuse them for hover-only updates. When the panel size is unchanged, the window moves with `setFrameOrigin` instead of `setFrame`; `FlyoutFrameCalculator.swift` centralizes the flyout placement calculation (#741).
 - Fixed Canvas desync during Notch transitions. Static artwork is rendered by SwiftUI, while Spotify Canvas uses an `AVPlayerLayer` hosted in an `NSViewRepresentable`. During close, the video layer implicitly animated its own frame in a separate Core Animation transaction, creating a second, slower slide-out that conflicted with SwiftUI’s transition (#741).
 
+- Fixed the clipboard history shortcut being registered as Cmd+Shift+C while Settings documented Cmd+Shift+V ("similar to Windows+V on PC"). The default is now Cmd+Shift+V, and a one-time migration moves anyone still on the old default, since `KeyboardShortcuts` persists a default on first launch and would otherwise keep the old key forever. Custom shortcuts are left alone.
+
 ### Removed
 
 ## [2.3.2] - 2026-07-20

--- a/DynamicIsland/DynamicIslandApp.swift
+++ b/DynamicIsland/DynamicIslandApp.swift
@@ -644,6 +644,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         Defaults.Keys.migrateMusicControlSlots()
         Defaults.Keys.migrateCapsLockTintMode()
         Defaults.Keys.migrateThirdPartyDDCIntegration()
+        Defaults.Keys.migrateClipboardShortcutToV()
 
         Defaults.publisher(.enableThirdPartyDDCIntegration, options: [])
             .sink { _ in

--- a/DynamicIsland/Shortcuts/ShortcutConstants.swift
+++ b/DynamicIsland/Shortcuts/ShortcutConstants.swift
@@ -24,7 +24,7 @@ import KeyboardShortcuts
 import SwiftUI
 
 extension KeyboardShortcuts.Name {
-    static let clipboardHistoryPanel = Self("clipboardHistoryPanel", default: .init(.c, modifiers: [.shift, .command]))
+    static let clipboardHistoryPanel = Self("clipboardHistoryPanel", default: .init(.v, modifiers: [.shift, .command]))
     static let colorPickerPanel = Self("colorPickerPanel", default: .init(.p, modifiers: [.shift, .command]))
     static let screenAssistantPanel = Self("screenAssistantPanel", default: .init(.a, modifiers: [.shift, .command]))
     static let decreaseBacklight = Self("decreaseBacklight", default: .init(.f1, modifiers: [.command]))

--- a/DynamicIsland/models/Constants.swift
+++ b/DynamicIsland/models/Constants.swift
@@ -1393,14 +1393,20 @@ extension Defaults.Keys {
     ///
     /// Only a shortcut still sitting on the old default is moved. Anyone who picked their own
     /// keeps it — including, unavoidably, anyone who deliberately chose Cmd+Shift+C.
+    ///
+    /// The marker is written last: if this crashed between marking and moving, the migration
+    /// would be considered done while the shortcut still sat on the old key, with no second
+    /// chance to correct it. Running twice is harmless by comparison, since the second run
+    /// finds Cmd+Shift+V rather than the legacy default and changes nothing.
     static func migrateClipboardShortcutToV() {
         guard Defaults[.didMigrateClipboardShortcutToV] == false else { return }
-        Defaults[.didMigrateClipboardShortcutToV] = true
 
         let legacyDefault = KeyboardShortcuts.Shortcut(.c, modifiers: [.shift, .command])
-        guard KeyboardShortcuts.getShortcut(for: .clipboardHistoryPanel) == legacyDefault else { return }
+        if KeyboardShortcuts.getShortcut(for: .clipboardHistoryPanel) == legacyDefault {
+            KeyboardShortcuts.setShortcut(.init(.v, modifiers: [.shift, .command]), for: .clipboardHistoryPanel)
+        }
 
-        KeyboardShortcuts.setShortcut(.init(.v, modifiers: [.shift, .command]), for: .clipboardHistoryPanel)
+        Defaults[.didMigrateClipboardShortcutToV] = true
     }
 
     static func migrateCapsLockTintMode() {

--- a/DynamicIsland/models/Constants.swift
+++ b/DynamicIsland/models/Constants.swift
@@ -22,6 +22,7 @@
 
 import SwiftUI
 import Defaults
+import KeyboardShortcuts
 import Lottie
 import Foundation
 
@@ -1325,6 +1326,7 @@ extension Defaults.Keys {
     static let capsLockIndicatorUseGreenColor = Key<Bool>("capsLockIndicatorUseGreenColor", default: false) // Legacy toggle
     static let capsLockIndicatorTintMode = Key<CapsLockIndicatorTintMode>("capsLockIndicatorTintMode", default: .white)
     static let didMigrateCapsLockTintMode = Key<Bool>("didMigrateCapsLockTintMode", default: false)
+    static let didMigrateClipboardShortcutToV = Key<Bool>("didMigrateClipboardShortcutToV", default: false)
     static let showCapsLockLabel = Key<Bool>("showCapsLockLabel", default: false)
     
     // MARK: ImageService
@@ -1380,6 +1382,25 @@ extension Defaults.Keys {
         }
 
         normalizeMusicAuxControls()
+    }
+
+    /// Move the clipboard shortcut off the old Cmd+Shift+C default.
+    ///
+    /// Settings has always documented Cmd+Shift+V ("similar to Windows+V on PC") while the
+    /// shortcut was registered as Cmd+Shift+C. Changing the default alone fixes nothing for
+    /// anyone who has already launched Atoll: `KeyboardShortcuts.Name` writes its default into
+    /// UserDefaults on first run and never overwrites it, so the old value would win forever.
+    ///
+    /// Only a shortcut still sitting on the old default is moved. Anyone who picked their own
+    /// keeps it — including, unavoidably, anyone who deliberately chose Cmd+Shift+C.
+    static func migrateClipboardShortcutToV() {
+        guard Defaults[.didMigrateClipboardShortcutToV] == false else { return }
+        Defaults[.didMigrateClipboardShortcutToV] = true
+
+        let legacyDefault = KeyboardShortcuts.Shortcut(.c, modifiers: [.shift, .command])
+        guard KeyboardShortcuts.getShortcut(for: .clipboardHistoryPanel) == legacyDefault else { return }
+
+        KeyboardShortcuts.setShortcut(.init(.v, modifiers: [.shift, .command]), for: .clipboardHistoryPanel)
     }
 
     static func migrateCapsLockTintMode() {


### PR DESCRIPTION
Settings has always documented Cmd+Shift+V ("similar to Windows+V on PC"), but
the shortcut was registered as Cmd+Shift+C. It has been `.c` since the first
commit that touched `ShortcutConstants.swift`, so Cmd+Shift+V never worked.

Changing the default alone fixes nothing for existing users:
`KeyboardShortcuts.Name` writes its default into UserDefaults on first launch
and never overwrites it, so the stored Cmd+Shift+C would keep winning. A
one-time migration moves anyone still sitting on the old default.

Custom shortcuts are left alone. The one unavoidable cost is that someone who
deliberately picked Cmd+Shift+C is moved too, because a stored value doesn't
record whether it came from a choice or from the persisted default.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated the default clipboard history shortcut from **Cmd+Shift+C** to **Cmd+Shift+V**.
  * Existing custom shortcuts remain unchanged when they differ from the previous default.

* **Bug Fixes**
  * Added a one-time migration for saved **Cmd+Shift+C** values to **Cmd+Shift+V**.
  * Customizations using the previous default cannot be distinguished from the old default and may also be migrated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->