### PR TITLE
feat(clipboard): add Maccy as a clipboard source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,13 +19,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Lyrics on the side**: Added ability to show lyrics of the current song when calendar is disabled (#741)
 
+- **Maccy as clipboard source**: A new "Clipboard Source" setting hands the clipboard over to [Maccy](https://maccy.app) instead of Atoll's own history. The notch clipboard icon then opens Maccy, Atoll stops polling the pasteboard, and its own clipboard panel and tabs are hidden. Atoll also releases its clipboard shortcut while an external app is selected: Atoll's default Cmd+Shift+C is Maccy's default popup hotkey too, so both apps answered one key press and the popup only flashed open and shut. Atoll's built-in manager stays the default, and is used automatically when the selected app isn't installed.
+
 ### Changed
 - Improved the Dutch localization by adding missing translations, corrected terminology, and wording aligned with Apple's Dutch macOS conventions.
 - Refreshing the LLM Usage card now skips session logs whose last write predates the seven-day window instead of re-reading the whole log history, and counts a repeated record when the copy inside the window would previously have been suppressed by a copy outside it (#691).
 - The separate-tab clipboard now uses the same card grid (two columns) with drag-out and per-item delete, replacing the single-column list (#698).
 
 ### Fixed
-- Fixed provider icons stretching into a flat smear inside menu-style pickers (most visibly the AirDrop icon in the Shelf's Quick Share popover). Rendering a picker's selected row into the `NSPopUpButton` title drops SwiftUI's frame but keeps `.resizable()`, so the icon expanded to the button's full width; icons now carry their own point size instead. Also affects the Quick Share picker in Settings and the third-party display app picker.
+- Fixed provider icons stretching into a flat smear inside menu-style pickers (most visibly the AirDrop icon in the Shelf's Quick Share popover). Rendering a picker's selected row into the `NSPopUpButton` title drops SwiftUI's frame but keeps `.resizable()`, so the icon expanded to the button's full width; icons now carry their own point size instead. Also affects the Quick Share picker in Settings and the third-party display/clipboard app pickers.
 - Fixed the LLM Usage card prompting for the login keychain password on every refresh when the Gemini language server is down. The app now tries the language server first (no keychain needed), and otherwise reads the Gemini CLI's token through the `security` CLI, which is covered by the item's `apple-tool:` partition grant and never triggers a password prompt.
 - Fixed the timer being clipped behind the notch after the layout changes, and made the boxes in StatsView uniformly sized.
 - Removed the separate floating timer control window; Pause/Stop buttons now render inline inside the notch, vertically centered with the timer countdown (#711).

--- a/DynamicIsland/DynamicIslandApp.swift
+++ b/DynamicIsland/DynamicIslandApp.swift
@@ -677,6 +677,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
         // Setup Lunar integration
         LunarManager.shared.configure(coordinator: coordinator)
+
+        // Bring up the clipboard provider router so it can detect an external clipboard
+        // app (Maccy) and keep Atoll's own polling in step with the user's choice.
+        ClipboardProviderManager.shared.refreshDetectionStatus()
         
         // Setup ScreenRecording Manager
         if Defaults[.enableScreenRecordingDetection] && !AppRuntimeEnvironment.isUITesting {
@@ -957,6 +961,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
         KeyboardShortcuts.isEnabled = Defaults[.enableShortcuts]
         registerOptionalShortcutHandlers()
+
+        // Must follow the registration above: an external clipboard app owns the clipboard
+        // hotkey, so Atoll releases its own to avoid two apps answering one key press.
+        ClipboardProviderManager.shared.syncShortcutRegistration()
         updateFeatureShortcutAvailability()
 
         if !Defaults[.showOnAllDisplays] {
@@ -1281,6 +1289,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         KeyboardShortcuts.onKeyDown(for: .clipboardHistoryPanel) { [weak self] in
             guard let self else { return }
             guard Defaults[.enableShortcuts], Defaults[.enableClipboardManager] else { return }
+
+            // An external clipboard app owns the feature: hand the shortcut to it and
+            // skip Atoll's own history entirely.
+            if ClipboardProviderManager.handleClipboardTrigger() { return }
 
             if !ClipboardManager.shared.isMonitoring {
                 ClipboardManager.shared.startMonitoring()

--- a/DynamicIsland/DynamicIslandViewCoordinator.swift
+++ b/DynamicIsland/DynamicIslandViewCoordinator.swift
@@ -235,6 +235,7 @@ class DynamicIslandViewCoordinator: ObservableObject {
             Defaults.publisher(.enableNotes).map { _ in () }.eraseToAnyPublisher(),
             Defaults.publisher(.enableClipboardManager).map { _ in () }.eraseToAnyPublisher(),
             Defaults.publisher(.clipboardDisplayMode).map { _ in () }.eraseToAnyPublisher(),
+            Defaults.publisher(.clipboardProvider).map { _ in () }.eraseToAnyPublisher(),
             Defaults.publisher(.enableTerminalFeature).map { _ in () }.eraseToAnyPublisher(),
             Defaults.publisher(.enableMinimalisticUI).map { _ in () }.eraseToAnyPublisher()
         )

--- a/DynamicIsland/components/Notch/DynamicIslandHeader.swift
+++ b/DynamicIsland/components/Notch/DynamicIslandHeader.swift
@@ -36,6 +36,7 @@ struct DynamicIslandHeader: View {
     @Default(.showClipboardIcon) var showClipboardIcon
     @Default(.showColorPickerIcon) var showColorPickerIcon
     @Default(.clipboardDisplayMode) var clipboardDisplayMode
+    @Default(.clipboardProvider) var clipboardProvider
     @Default(.showBatteryIndicator) var showBatteryIndicator
     @Default(.showBatteryPercentInside) var showBatteryPercentInside
     @Default(.showMinimalisticBatteryIndicator) var showMinimalisticBatteryIndicator
@@ -90,8 +91,15 @@ struct DynamicIslandHeader: View {
                     
                     if Defaults[.enableClipboardManager]
                         && showClipboardIcon
-                        && clipboardDisplayMode != .separateTab {
+                        // With an external provider the icon is the way into that app,
+                        // so it stays put no matter which built-in display mode is set.
+                        // (`clipboardProvider` is observed so this re-evaluates on change.)
+                        && (ClipboardProviderManager.resolvedProvider.isExternal
+                            || clipboardDisplayMode != .separateTab) {
                         Button(action: {
+                            // An external clipboard app takes the tap instead of Atoll's own UI.
+                            if ClipboardProviderManager.handleClipboardTrigger() { return }
+
                             // Switch behavior based on display mode
                             switch clipboardDisplayMode {
                             case .panel:
@@ -133,7 +141,8 @@ struct DynamicIslandHeader: View {
                             }
                         }
                         .onAppear {
-                            if Defaults[.enableClipboardManager] && !clipboardManager.isMonitoring {
+                            // Skip polling while another app owns the clipboard history.
+                            if ClipboardProviderManager.usesBuiltInClipboard && !clipboardManager.isMonitoring {
                                 clipboardManager.startMonitoring()
                             }
                         }
@@ -282,6 +291,7 @@ struct DynamicIslandHeader: View {
         .onChange(of: coordinator.shouldToggleClipboardPopover) { _ in
             // Only toggle if clipboard is enabled
             if Defaults[.enableClipboardManager] {
+                if ClipboardProviderManager.handleClipboardTrigger() { return }
                 switch clipboardDisplayMode {
                 case .panel:
                     ClipboardPanelManager.shared.toggleClipboardPanel()

--- a/DynamicIsland/components/Notch/NotchClipboardView.swift
+++ b/DynamicIsland/components/Notch/NotchClipboardView.swift
@@ -104,7 +104,8 @@ struct NotchClipboardView: View {
             vm.setAutoCloseSuppression(isShowing, token: autoCloseToken)
         }
         .onAppear {
-            if Defaults[.enableClipboardManager], !clipboardManager.isMonitoring {
+            // Skip polling while another app owns the clipboard history.
+            if ClipboardProviderManager.usesBuiltInClipboard, !clipboardManager.isMonitoring {
                 clipboardManager.startMonitoring()
             }
         }

--- a/DynamicIsland/components/Notch/NotchNotesView.swift
+++ b/DynamicIsland/components/Notch/NotchNotesView.swift
@@ -27,6 +27,7 @@ struct NotchNotesView: View {
     @Default(.savedNotes) var savedNotes
     @Default(.clipboardDisplayMode) var clipboardDisplayMode
     @Default(.enableClipboardManager) var enableClipboardManager
+    @Default(.clipboardProvider) var clipboardProvider
     @Default(.enableAppleNotesSync) var enableAppleNotesSync
     
     @State private var selectedNoteId: UUID?
@@ -43,7 +44,7 @@ struct NotchNotesView: View {
     @Default(.enableNotes) var enableNotes
     
     var showSplitView: Bool {
-        return enableClipboardManager && clipboardDisplayMode == .separateTab
+        return ClipboardProviderManager.usesBuiltInClipboard && clipboardDisplayMode == .separateTab
     }
 
     var body: some View {
@@ -127,6 +128,9 @@ struct NotchNotesView: View {
             updateLayoutState()
         }
         .onChange(of: clipboardDisplayMode) { _, _ in
+            updateLayoutState()
+        }
+        .onChange(of: clipboardProvider) { _, _ in
             updateLayoutState()
         }
         .onChange(of: enableNotes) { _, _ in

--- a/DynamicIsland/components/Settings/SettingsView.swift
+++ b/DynamicIsland/components/Settings/SettingsView.swift
@@ -904,6 +904,7 @@ struct SettingsView: View {
 
             // Clipboard
             SettingsSearchEntry(tab: .clipboard, title: "Enable Clipboard Manager", keywords: ["clipboard", "manager"], highlightID: SettingsTab.clipboard.highlightID(for: "Enable Clipboard Manager")),
+            SettingsSearchEntry(tab: .clipboard, title: "Clipboard Source", keywords: ["maccy", "provider", "third-party", "clipboard"], highlightID: SettingsTab.clipboard.highlightID(for: "Clipboard Source")),
             SettingsSearchEntry(tab: .clipboard, title: "Show Clipboard Icon", keywords: ["icon", "clipboard"], highlightID: SettingsTab.clipboard.highlightID(for: "Show Clipboard Icon")),
             SettingsSearchEntry(tab: .clipboard, title: "Display Mode", keywords: ["list", "grid", "clipboard"], highlightID: SettingsTab.clipboard.highlightID(for: "Display Mode")),
             SettingsSearchEntry(tab: .clipboard, title: "History Size", keywords: ["history", "clipboard"], highlightID: SettingsTab.clipboard.highlightID(for: "History Size")),
@@ -7575,13 +7576,42 @@ struct StatsSettings: View {
 
 struct ClipboardSettings: View {
     @ObservedObject var clipboardManager = ClipboardManager.shared
+    @ObservedObject private var providerManager = ClipboardProviderManager.shared
     @Default(.enableClipboardManager) var enableClipboardManager
     @Default(.clipboardHistorySize) var clipboardHistorySize
     @Default(.showClipboardIcon) var showClipboardIcon
     @Default(.clipboardDisplayMode) var clipboardDisplayMode
+    @Default(.clipboardProvider) var clipboardProvider
 
     private func highlightID(_ title: String) -> String {
         SettingsTab.clipboard.highlightID(for: title)
+    }
+
+    /// Mirrors `ClipboardProviderManager.resolvedProvider`, but reads the observed manager
+    /// so the form re-renders as soon as the external app is installed or removed.
+    private var usesBuiltInClipboard: Bool {
+        !(clipboardProvider.isExternal && providerManager.isDetected)
+    }
+
+    private var providerStatusText: String {
+        if !providerManager.isDetected { return String(localized: "Not installed") }
+        return providerManager.isRunning ? String(localized: "Running") : String(localized: "Installed")
+    }
+
+    private var providerStatusColor: Color {
+        if !providerManager.isDetected { return .secondary }
+        return providerManager.isRunning ? .green : .orange
+    }
+
+    private var providerStatusDescription: String {
+        let name = clipboardProvider.displayName
+        if !providerManager.isDetected {
+            return "\(name) isn't installed. Atoll uses its own history for now."
+        }
+        if !providerManager.isRunning {
+            return "\(name) isn't running yet. Atoll opens it the first time you use the clipboard."
+        }
+        return "The notch clipboard icon opens \(name). From the keyboard, use \(name)'s own hotkey."
     }
 
     var body: some View {
@@ -7592,7 +7622,7 @@ struct ClipboardSettings: View {
                 }
                 .settingsHighlight(id: highlightID("Enable Clipboard Manager"))
                 .onChange(of: enableClipboardManager) { _, enabled in
-                    if enabled {
+                    if enabled && usesBuiltInClipboard {
                         clipboardManager.startMonitoring()
                     } else {
                         clipboardManager.stopMonitoring()
@@ -7611,111 +7641,177 @@ struct ClipboardSettings: View {
                     }
                     .settingsHighlight(id: highlightID("Show Clipboard Icon"))
 
-                    HStack {
-                        Text("Display Mode")
-                        Spacer()
-                        Picker("", selection: $clipboardDisplayMode) {
-                            ForEach(ClipboardDisplayMode.allCases, id: \.self) { mode in
-                                Text(mode.displayName).tag(mode)
-                            }
-                        }
-                        .pickerStyle(.menu)
-                        .frame(minWidth: 100)
-                    }
-                    .settingsHighlight(id: highlightID("Display Mode"))
-
-                    HStack {
-                        Text("History Size")
-                        Spacer()
-                        Picker("", selection: $clipboardHistorySize) {
-                            Text("3 items").tag(3)
-                            Text("5 items").tag(5)
-                            Text("7 items").tag(7)
-                            Text("10 items").tag(10)
-                        }
-                        .pickerStyle(.menu)
-                        .frame(minWidth: 100)
-                    }
-                    .settingsHighlight(id: highlightID("History Size"))
-
-                    HStack {
-                        Text("Current Items")
-                        Spacer()
-                        Text("\(clipboardManager.clipboardHistory.count)")
-                            .foregroundColor(.secondary)
-                    }
-
-                    HStack {
-                        Text("Pinned Items")
-                        Spacer()
-                        Text("\(clipboardManager.pinnedItems.count)")
-                            .foregroundColor(.secondary)
-                    }
-
-                    HStack {
-                        Text("Monitoring Status")
-                        Spacer()
-                        Text(clipboardManager.isMonitoring ? "Active" : "Stopped")
-                            .foregroundColor(clipboardManager.isMonitoring ? .green : .secondary)
-                    }
-                } header: {
-                    Text("Settings")
-                } footer: {
-                    switch clipboardDisplayMode {
-                    case .popover:
-                        Text("Popover mode shows clipboard as a dropdown attached to the clipboard button.")
-                    case .panel:
-                        Text("Panel mode shows clipboard in a floating window near the notch.")
-                    case .separateTab:
-                        Text("Separate Tab mode integrates Copied Items and Notes into a single view. If both are enabled, Notes appear on the right and Clipboard on the left.")
-                    case .notchTab:
-                        Text("Notch Tab mode shows clipboard in its own tab inside the notch. Drag text, image, or single-file items straight out to Finder or another app.")
-                    }
-                }
-
-                Section {
-                    Button("Clear Clipboard History") {
-                        clipboardManager.clearHistory()
-                    }
-                    .foregroundColor(.red)
-                    .disabled(clipboardManager.clipboardHistory.isEmpty)
-
-                    Button("Clear Pinned Items") {
-                        clipboardManager.pinnedItems.removeAll()
-                        clipboardManager.savePinnedItemsToDefaults()
-                    }
-                    .foregroundColor(.red)
-                    .disabled(clipboardManager.pinnedItems.isEmpty)
-                } header: {
-                    Text("Actions")
-                } footer: {
-                    Text("Clear clipboard history removes recent copies. Clear pinned items removes your favorites. Both actions are permanent.")
-                }
-
-                if !clipboardManager.clipboardHistory.isEmpty {
-                    Section {
-                        ForEach(clipboardManager.clipboardHistory) { item in
-                            VStack(alignment: .leading, spacing: 4) {
-                                HStack {
-                                    Image(systemName: item.type.icon)
-                                        .foregroundColor(.blue)
-                                        .frame(width: 16)
-                                    Text(item.type.displayName)
-                                        .font(.caption)
-                                        .foregroundColor(.secondary)
-                                    Spacer()
-                                    Text(timeAgoString(from: item.timestamp))
-                                        .font(.caption2)
-                                        .foregroundColor(.secondary)
+                    Picker(selection: $clipboardProvider) {
+                        ForEach(ClipboardProvider.allCases) { provider in
+                            HStack {
+                                if provider.isExternal {
+                                    AppIconImage(
+                                        bundleIdentifiers: provider.bundleIdentifiers,
+                                        symbolFallback: "doc.on.clipboard",
+                                        symbolColor: .secondary
+                                    )
                                 }
-                                Text(item.preview)
-                                    .font(.system(.body, design: .monospaced))
-                                    .lineLimit(2)
+                                Text(provider.displayName)
                             }
-                            .padding(.vertical, 2)
+                            .tag(provider)
+                        }
+                    } label: {
+                        Text("Clipboard Source")
+                    }
+                    .settingsHighlight(id: highlightID("Clipboard Source"))
+
+                    if clipboardProvider.isExternal {
+                        HStack {
+                            Text("Status")
+                            Spacer()
+                            Text(providerStatusText)
+                                .font(.caption)
+                                .foregroundStyle(providerStatusColor)
+                        }
+
+                        Text(providerStatusDescription)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+
+                        HStack(spacing: 16) {
+                            Button {
+                                providerManager.refreshDetectionStatus()
+                            } label: {
+                                Label("Refresh detection", systemImage: "arrow.clockwise")
+                                    .font(.caption)
+                            }
+                            .buttonStyle(.link)
+
+                            if providerManager.isDetected {
+                                Button {
+                                    ClipboardProviderManager.openProviderPopup(clipboardProvider)
+                                } label: {
+                                    Label("Open \(clipboardProvider.displayName)", systemImage: "arrow.up.forward.app")
+                                        .font(.caption)
+                                }
+                                .buttonStyle(.link)
+                            } else if let downloadURL = clipboardProvider.downloadURL {
+                                Link(destination: downloadURL) {
+                                    Label("Get \(clipboardProvider.displayName)", systemImage: "arrow.down.circle")
+                                        .font(.caption)
+                                }
+                            }
+                        }
+                    }
+                } header: {
+                    Text("Clipboard Source")
+                } footer: {
+                    Text(clipboardProvider.description)
+                }
+
+                if usesBuiltInClipboard {
+                    Section {
+                        HStack {
+                            Text("Display Mode")
+                            Spacer()
+                            Picker("", selection: $clipboardDisplayMode) {
+                                ForEach(ClipboardDisplayMode.allCases, id: \.self) { mode in
+                                    Text(mode.displayName).tag(mode)
+                                }
+                            }
+                            .pickerStyle(.menu)
+                            .frame(minWidth: 100)
+                        }
+                        .settingsHighlight(id: highlightID("Display Mode"))
+
+                        HStack {
+                            Text("History Size")
+                            Spacer()
+                            Picker("", selection: $clipboardHistorySize) {
+                                Text("3 items").tag(3)
+                                Text("5 items").tag(5)
+                                Text("7 items").tag(7)
+                                Text("10 items").tag(10)
+                            }
+                            .pickerStyle(.menu)
+                            .frame(minWidth: 100)
+                        }
+                        .settingsHighlight(id: highlightID("History Size"))
+
+                        HStack {
+                            Text("Current Items")
+                            Spacer()
+                            Text("\(clipboardManager.clipboardHistory.count)")
+                                .foregroundColor(.secondary)
+                        }
+
+                        HStack {
+                            Text("Pinned Items")
+                            Spacer()
+                            Text("\(clipboardManager.pinnedItems.count)")
+                                .foregroundColor(.secondary)
+                        }
+
+                        HStack {
+                            Text("Monitoring Status")
+                            Spacer()
+                            Text(clipboardManager.isMonitoring ? "Active" : "Stopped")
+                                .foregroundColor(clipboardManager.isMonitoring ? .green : .secondary)
                         }
                     } header: {
-                        Text("Current History")
+                        Text("Settings")
+                    } footer: {
+                        switch clipboardDisplayMode {
+                        case .popover:
+                            Text("Popover mode shows clipboard as a dropdown attached to the clipboard button.")
+                        case .panel:
+                            Text("Panel mode shows clipboard in a floating window near the notch.")
+                        case .separateTab:
+                            Text("Separate Tab mode integrates Copied Items and Notes into a single view. If both are enabled, Notes appear on the right and Clipboard on the left.")
+                        case .notchTab:
+                            Text("Notch Tab mode shows clipboard in its own tab inside the notch. Drag text, image, or single-file items straight out to Finder or another app.")
+                        }
+                    }
+
+                    Section {
+                        Button("Clear Clipboard History") {
+                            clipboardManager.clearHistory()
+                        }
+                        .foregroundColor(.red)
+                        .disabled(clipboardManager.clipboardHistory.isEmpty)
+
+                        Button("Clear Pinned Items") {
+                            clipboardManager.pinnedItems.removeAll()
+                            clipboardManager.savePinnedItemsToDefaults()
+                        }
+                        .foregroundColor(.red)
+                        .disabled(clipboardManager.pinnedItems.isEmpty)
+                    } header: {
+                        Text("Actions")
+                    } footer: {
+                        Text("Clear clipboard history removes recent copies. Clear pinned items removes your favorites. Both actions are permanent.")
+                    }
+
+                    if !clipboardManager.clipboardHistory.isEmpty {
+                        Section {
+                            ForEach(clipboardManager.clipboardHistory) { item in
+                                VStack(alignment: .leading, spacing: 4) {
+                                    HStack {
+                                        Image(systemName: item.type.icon)
+                                            .foregroundColor(.blue)
+                                            .frame(width: 16)
+                                        Text(item.type.displayName)
+                                            .font(.caption)
+                                            .foregroundColor(.secondary)
+                                        Spacer()
+                                        Text(timeAgoString(from: item.timestamp))
+                                            .font(.caption2)
+                                            .foregroundColor(.secondary)
+                                    }
+                                    Text(item.preview)
+                                        .font(.system(.body, design: .monospaced))
+                                        .lineLimit(2)
+                                }
+                                .padding(.vertical, 2)
+                            }
+                        } header: {
+                            Text("Current History")
+                        }
                     }
                 }
             }
@@ -7723,7 +7819,8 @@ struct ClipboardSettings: View {
         .formStyle(.grouped)
         .navigationTitle("Clipboard")
         .onAppear {
-            if enableClipboardManager && !clipboardManager.isMonitoring {
+            providerManager.refreshDetectionStatus()
+            if usesBuiltInClipboard && enableClipboardManager && !clipboardManager.isMonitoring {
                 clipboardManager.startMonitoring()
             }
         }

--- a/DynamicIsland/components/Tabs/TabSelectionView.swift
+++ b/DynamicIsland/components/Tabs/TabSelectionView.swift
@@ -87,7 +87,7 @@ struct TabSelectionView: View {
             tabsArray.append(TabModel(label: "Usage", icon: "chart.bar.doc.horizontal", view: .llmUsage))
         }
 
-        if Defaults[.enableNotes] || (Defaults[.enableClipboardManager] && Defaults[.clipboardDisplayMode] == .separateTab) {
+        if Defaults[.enableNotes] || (ClipboardProviderManager.usesBuiltInClipboard && Defaults[.clipboardDisplayMode] == .separateTab) {
             let label = Defaults[.enableNotes] ? "Notes" : "Clipboard"
             let icon = Defaults[.enableNotes] ? "note.text" : "doc.on.clipboard"
             tabsArray.append(TabModel(label: label, icon: icon, view: .notes))

--- a/DynamicIsland/managers/ClipboardProviderManager.swift
+++ b/DynamicIsland/managers/ClipboardProviderManager.swift
@@ -1,0 +1,253 @@
+/*
+ * Atoll (DynamicIsland)
+ * Copyright (C) 2024-2026 Atoll Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import AppKit
+import Combine
+import Defaults
+import Foundation
+import KeyboardShortcuts
+
+/// Routes Atoll's clipboard triggers to whichever app the user picked as their clipboard
+/// manager (see `ClipboardProvider`).
+///
+/// Atoll's own manager stays the default. When an external provider is selected, Atoll
+/// stops collecting its own history and every clipboard entry point — the notch button,
+/// the keyboard shortcut, the coordinator toggle — opens that app instead of Atoll's
+/// panel/popover/tab.
+///
+/// External apps are opened by *reopening* them (`NSWorkspace.openApplication`), which is
+/// the same event their own Dock/status-item click sends: Maccy answers
+/// `applicationShouldHandleReopen` by toggling its popup, so no Accessibility permission
+/// or synthesized hotkey is involved, and a second trigger closes the popup again —
+/// matching the toggle semantics of Atoll's own clipboard UI.
+@MainActor
+final class ClipboardProviderManager: ObservableObject {
+    static let shared = ClipboardProviderManager()
+
+    /// Whether the selected external app is installed on this machine.
+    @Published private(set) var isDetected: Bool = false
+
+    /// Whether the selected external app is currently running.
+    @Published private(set) var isRunning: Bool = false
+
+    private var workspaceObservers: [NSObjectProtocol] = []
+    private var cancellables = Set<AnyCancellable>()
+
+    private init() {
+        refreshDetectionStatus()
+        setupWorkspaceObservers()
+        setupSettingsObserver()
+    }
+
+    // MARK: - Resolution (pure, Defaults-only)
+    //
+    // These are `nonisolated` so sizing helpers and view bodies can ask "is the built-in
+    // clipboard UI in play?" without hopping actors or touching published state.
+
+    /// The provider actually in effect. Falls back to the built-in manager when the chosen
+    /// app isn't installed, so an uninstalled app never leaves the clipboard feature dead.
+    nonisolated static var resolvedProvider: ClipboardProvider {
+        let provider = Defaults[.clipboardProvider]
+        return isInstalled(provider) ? provider : .builtIn
+    }
+
+    /// Atoll collects its own history and shows its own clipboard UI.
+    /// Display mode, history size, and the clipboard tabs only apply while this is true.
+    nonisolated static var usesBuiltInClipboard: Bool {
+        Defaults[.enableClipboardManager] && resolvedProvider == .builtIn
+    }
+
+    // MARK: - Trigger routing
+
+    /// Hand a clipboard trigger to the external provider.
+    ///
+    /// `nonisolated` so the keyboard-shortcut handler and SwiftUI button actions can ask
+    /// this without hopping actors; only the published state update goes back to the main
+    /// actor.
+    ///
+    /// - Returns: `true` when an external app took over the trigger; `false` when the
+    ///   caller should fall through to Atoll's own clipboard UI.
+    @discardableResult
+    nonisolated static func handleClipboardTrigger() -> Bool {
+        openProviderPopup(resolvedProvider)
+    }
+
+    /// Reopen the provider app, which toggles its clipboard popup.
+    @discardableResult
+    nonisolated static func openProviderPopup(_ provider: ClipboardProvider) -> Bool {
+        guard provider.isExternal, let appURL = applicationURL(for: provider) else { return false }
+
+        let configuration = NSWorkspace.OpenConfiguration()
+        configuration.activates = true
+        // Reuse the running instance — a second instance would not toggle the popup.
+        configuration.createsNewApplicationInstance = false
+
+        NSWorkspace.shared.openApplication(at: appURL, configuration: configuration) { app, error in
+            Task { @MainActor in
+                if let error {
+                    NSLog("%@", "📋 Failed to open \(provider.displayName): \(error.localizedDescription)")
+                }
+                shared.isRunning = app != nil
+            }
+        }
+        return true
+    }
+
+    // MARK: - Detection
+
+    // `nonisolated(unsafe)` because the cache is read from nonisolated resolution helpers on
+    // whichever thread asks; every access below is serialized by `installationCacheLock`.
+    nonisolated(unsafe) private static var installationCache: [String: Bool] = [:]
+    private static let installationCacheLock = NSLock()
+
+    /// Cached because view bodies and notch sizing ask this on every layout pass;
+    /// the cache is dropped whenever an app is installed, launched, or removed.
+    nonisolated static func isInstalled(_ provider: ClipboardProvider) -> Bool {
+        guard provider.isExternal else { return true }
+
+        installationCacheLock.lock()
+        if let cached = installationCache[provider.rawValue] {
+            installationCacheLock.unlock()
+            return cached
+        }
+        installationCacheLock.unlock()
+
+        let installed = applicationURL(for: provider) != nil
+
+        installationCacheLock.lock()
+        installationCache[provider.rawValue] = installed
+        installationCacheLock.unlock()
+
+        return installed
+    }
+
+    nonisolated static func invalidateInstallationCache() {
+        installationCacheLock.lock()
+        installationCache.removeAll()
+        installationCacheLock.unlock()
+    }
+
+    nonisolated static func applicationURL(for provider: ClipboardProvider) -> URL? {
+        for bundleID in provider.bundleIdentifiers {
+            if let url = NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleID),
+               FileManager.default.fileExists(atPath: url.path) {
+                return url
+            }
+        }
+        return nil
+    }
+
+    nonisolated static func isRunning(_ provider: ClipboardProvider) -> Bool {
+        guard provider.isExternal else { return false }
+        let identifiers = Set(provider.bundleIdentifiers)
+        return NSWorkspace.shared.runningApplications.contains {
+            guard let bundleID = $0.bundleIdentifier else { return false }
+            return identifiers.contains(bundleID)
+        }
+    }
+
+    /// Re-check install/run state of the selected provider (e.g. after an install).
+    func refreshDetectionStatus() {
+        Self.invalidateInstallationCache()
+        let provider = Defaults[.clipboardProvider]
+        isDetected = Self.isInstalled(provider) && provider.isExternal
+        isRunning = Self.isRunning(provider)
+    }
+
+    // MARK: - Built-in monitoring
+
+    /// Keep Atoll's own pasteboard polling in step with the selected provider: there is no
+    /// point paying for a timer and a second copy of the history while another app owns it.
+    ///
+    /// Driven by the settings observer, so switching provider takes effect immediately
+    /// rather than waiting for the next notch render.
+    func syncBuiltInMonitoring() {
+        if Self.usesBuiltInClipboard {
+            if !ClipboardManager.shared.isMonitoring {
+                ClipboardManager.shared.startMonitoring()
+            }
+        } else if ClipboardManager.shared.isMonitoring {
+            ClipboardManager.shared.stopMonitoring()
+        }
+    }
+
+    // MARK: - Keyboard shortcut
+
+    /// Release Atoll's clipboard shortcut while another app owns the clipboard.
+    ///
+    /// Atoll's shortcut defaults to Cmd+Shift+C, which is also Maccy's default popup hotkey.
+    /// With both registered, one key press reaches both apps: Maccy opens its popup and
+    /// Atoll's reopen toggles it straight back shut, so the popup only flashes. The app that
+    /// owns the clipboard owns the hotkey too; the notch icon stays as Atoll's way in.
+    ///
+    /// Must run after `registerOptionalShortcutHandlers()` — `KeyboardShortcuts.disable`
+    /// unregisters the hotkey rather than remembering a disabled state, so a later
+    /// registration would silently bring the collision back.
+    func syncShortcutRegistration() {
+        if Self.usesBuiltInClipboard {
+            KeyboardShortcuts.enable(.clipboardHistoryPanel)
+        } else {
+            KeyboardShortcuts.disable(.clipboardHistoryPanel)
+        }
+    }
+
+    /// Leave Atoll's own clipboard tab when the feature is handed to another app, so the
+    /// notch isn't left sitting on a view that no longer receives anything.
+    private func dismissBuiltInClipboardViewIfNeeded() {
+        guard !Self.usesBuiltInClipboard else { return }
+        let coordinator = DynamicIslandViewCoordinator.shared
+        if coordinator.currentView == .clipboard {
+            coordinator.currentView = .home
+        }
+    }
+
+    // MARK: - Observers
+
+    private func setupWorkspaceObservers() {
+        let center = NSWorkspace.shared.notificationCenter
+
+        for name in [NSWorkspace.didLaunchApplicationNotification,
+                     NSWorkspace.didTerminateApplicationNotification] {
+            let observer = center.addObserver(forName: name, object: nil, queue: .main) { [weak self] notification in
+                guard let app = notification.userInfo?[NSWorkspace.applicationUserInfoKey] as? NSRunningApplication,
+                      let bundleID = app.bundleIdentifier,
+                      ClipboardProvider.allCases.contains(where: { $0.bundleIdentifiers.contains(bundleID) })
+                else { return }
+                Task { @MainActor in
+                    self?.refreshDetectionStatus()
+                }
+            }
+            workspaceObservers.append(observer)
+        }
+    }
+
+    private func setupSettingsObserver() {
+        Publishers.Merge(
+            Defaults.publisher(.clipboardProvider).map { _ in () }.eraseToAnyPublisher(),
+            Defaults.publisher(.enableClipboardManager).map { _ in () }.eraseToAnyPublisher()
+        )
+        .receive(on: DispatchQueue.main)
+        .sink { [weak self] _ in
+            self?.refreshDetectionStatus()
+            self?.syncBuiltInMonitoring()
+            self?.syncShortcutRegistration()
+            self?.dismissBuiltInClipboardViewIfNeeded()
+        }
+        .store(in: &cancellables)
+    }
+}

--- a/DynamicIsland/models/Constants.swift
+++ b/DynamicIsland/models/Constants.swift
@@ -329,6 +329,53 @@ enum ClipboardDisplayMode: String, CaseIterable, Codable, Defaults.Serializable 
     }
 }
 
+/// Which app backs Atoll's clipboard history.
+///
+/// Atoll ships its own manager and stays the default, but people who already live in a
+/// dedicated clipboard app can hand the feature over to it: every clipboard trigger
+/// (notch button, keyboard shortcut) then opens that app instead of Atoll's own UI.
+enum ClipboardProvider: String, CaseIterable, Codable, Defaults.Serializable, Identifiable {
+    case builtIn = "builtIn"
+    case maccy = "maccy"
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .builtIn: return String(localized: "Atoll (built-in)")
+        case .maccy: return "Maccy"
+        }
+    }
+
+    /// True for anything that isn't Atoll's own clipboard manager.
+    var isExternal: Bool { self != .builtIn }
+
+    /// Bundle identifiers to try when detecting the app and looking up its icon.
+    var bundleIdentifiers: [String] {
+        switch self {
+        case .builtIn: return []
+        case .maccy: return ["org.p0deje.Maccy"]
+        }
+    }
+
+    /// Where to send the user when the app isn't installed yet.
+    var downloadURL: URL? {
+        switch self {
+        case .builtIn: return nil
+        case .maccy: return URL(string: "https://maccy.app")
+        }
+    }
+
+    var description: String {
+        switch self {
+        case .builtIn:
+            return "Atoll keeps its own clipboard history and shows it in the notch."
+        case .maccy:
+            return "Maccy handles the clipboard. Atoll's own history and clipboard shortcut are turned off."
+        }
+    }
+}
+
 enum ScreenAssistantDisplayMode: String, CaseIterable, Codable, Defaults.Serializable {
     case popover = "popover"     // Traditional popover attached to button
     case panel = "panel"         // Floating panel near notch
@@ -1199,6 +1246,7 @@ extension Defaults.Keys {
     static let clipboardHistorySize = Key<Int>("clipboardHistorySize", default: 3)
     static let showClipboardIcon = Key<Bool>("showClipboardIcon", default: true)
     static let clipboardDisplayMode = Key<ClipboardDisplayMode>("clipboardDisplayMode", default: .panel)
+    static let clipboardProvider = Key<ClipboardProvider>("clipboardProvider", default: .builtIn)
     
     // MARK: Screen Assistant Feature
     static let enableScreenAssistant = Key<Bool>("enableScreenAssistant", default: true)

--- a/DynamicIsland/models/DynamicIslandViewModel.swift
+++ b/DynamicIsland/models/DynamicIslandViewModel.swift
@@ -94,7 +94,7 @@ class DynamicIslandViewModel: NSObject, ObservableObject {
 
     private func focusClipboardTabIfNeeded() {
         guard !Defaults[.enableMinimalisticUI] else { return }
-        guard Defaults[.enableClipboardManager] else { return }
+        guard ClipboardProviderManager.usesBuiltInClipboard else { return }
         guard Defaults[.clipboardDisplayMode] == .separateTab else { return }
         guard let lastCopyDate = ClipboardManager.shared.lastCopiedItemDate else { return }
         guard Date().timeIntervalSince(lastCopyDate) <= clipboardFocusWindow else { return }

--- a/DynamicIsland/sizing/matters.swift
+++ b/DynamicIsland/sizing/matters.swift
@@ -122,7 +122,7 @@ func enabledStandardTabCount() -> Int {
     }
 
     // Notes / Clipboard tab
-    if Defaults[.enableNotes] || (Defaults[.enableClipboardManager] && Defaults[.clipboardDisplayMode] == .separateTab) {
+    if Defaults[.enableNotes] || (ClipboardProviderManager.usesBuiltInClipboard && Defaults[.clipboardDisplayMode] == .separateTab) {
         count += 1
     }
 


### PR DESCRIPTION
Adds a "Clipboard Source" setting under Settings › Clipboard, so people who
already use a dedicated clipboard app can hand the feature over to it instead
of running two clipboard histories side by side.

Atoll's own manager stays the default. Picking Maccy:

- sends the notch clipboard icon to Maccy instead of Atoll's panel/popover/tab
- stops Atoll polling the pasteboard
- hides Atoll's own clipboard panel and tabs
- falls back to Atoll's own manager if Maccy isn't installed, so the feature is
  never left dead

Maccy is opened by reopening the app: it answers `applicationShouldHandleReopen`
by toggling its popup, the same thing its status item click does. No
Accessibility permission and no synthetic hotkey.

Atoll also releases its clipboard shortcut while an external app is selected.
When both apps are bound to the same key, one press reaches both: Maccy opened
its popup and Atoll's reopen toggled it straight back shut. That is what the
two defaults did here, and #747 moves Atoll's off Maccy's.

Adding another app is one enum case plus its bundle id, as long as that app also
shows its popup when reopened.

Built on #746: the new picker uses `AppIconImage`, so without that fix the
Maccy icon stretches the same way.

<img width="485" height="281" alt="Clipboard Source setting with Maccy selected and detected as running" src="https://github.com/user-attachments/assets/008b6f6e-021b-489b-8b71-f7e26c45ed5b" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for selecting Maccy as an external clipboard source.
  * Added settings to detect, open, refresh, or download supported clipboard providers.
  * Clipboard shortcuts and controls now route to the selected provider automatically.
  * Atoll falls back to its built-in clipboard manager when an external provider is unavailable.

* **Bug Fixes**
  * Fixed picker icons appearing stretched by fitting images to their intended sizes.
  * Improved synchronization when clipboard providers are installed, closed, or changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->