### PR TITLE
Add configurable horizontal offset for the main notch

### DIFF
--- a/DynamicIsland/DynamicIslandApp.swift
+++ b/DynamicIsland/DynamicIslandApp.swift
@@ -447,7 +447,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         let centerX = screenFrame.origin.x + (screenFrame.width / 2)
         let roundedWidth = window.frame.width.rounded()
         let roundedHeight = window.frame.height.rounded()
-        let newX = (centerX - (roundedWidth / 2)).rounded()
+        let newX = (centerX - (roundedWidth / 2) + Defaults[.notchHorizontalOffset]).rounded()
         let newY = (screenFrame.maxY + topBleed - roundedHeight).rounded()
 
         window.setFrame(NSRect(
@@ -658,7 +658,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         let maxHeight = screenFrame.height + topBleed
         let clampedHeight = min(size.height, maxHeight).rounded()
         let centerX = screenFrame.midX
-        let newX = (centerX - (clampedWidth / 2)).rounded()
+        let newX = (centerX - (clampedWidth / 2) + Defaults[.notchHorizontalOffset]).rounded()
         let newY = (screenFrame.maxY + topBleed - clampedHeight).rounded()
         let targetFrame = NSRect(x: newX, y: newY, width: clampedWidth, height: clampedHeight)
 
@@ -814,6 +814,12 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
         Defaults.publisher(.openNotchWidth, options: []).sink { [weak self] _ in
             self?.debouncedUpdateWindowSize()
+        }.store(in: &cancellables)
+
+        Defaults.publisher(.notchHorizontalOffset, options: []).sink { [weak self] _ in
+            DispatchQueue.main.async {
+                self?.adjustWindowPosition()
+            }
         }.store(in: &cancellables)
 
         // Observe terminal settings changes

--- a/DynamicIsland/components/Settings/SettingsView.swift
+++ b/DynamicIsland/components/Settings/SettingsView.swift
@@ -4665,6 +4665,7 @@ struct Appearance: View {
     @Default(.selectedAppIconID) private var selectedAppIconID
     @Default(.openNotchWidth) var openNotchWidth
     @Default(.closedNotchWidth) var closedNotchWidth
+    @Default(.notchHorizontalOffset) var notchHorizontalOffset
     @Default(.customizePhysicalNotchWidth) var customizePhysicalNotchWidth
     @Default(.enableMinimalisticUI) var enableMinimalisticUI
     @Default(.lockScreenGlassCustomizationMode) private var lockScreenGlassCustomizationMode
@@ -4784,6 +4785,7 @@ struct Appearance: View {
             }
 
             notchWidthControls()
+            notchPositionControls()
 
             Section {
                 if #available(macOS 26.0, *) {
@@ -5401,6 +5403,46 @@ struct Appearance: View {
         } header: {
             HStack {
                 Text("Notch Width")
+                customBadge(text: "Beta")
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func notchPositionControls() -> some View {
+        Section {
+            let offsetRange = -500.0...500.0
+            let offsetBinding = Binding<Double>(
+                get: { Double(notchHorizontalOffset) },
+                set: { newValue in
+                    notchHorizontalOffset = CGFloat(min(max(newValue, offsetRange.lowerBound), offsetRange.upperBound))
+                }
+            )
+
+            Slider(value: offsetBinding, in: offsetRange, step: 1) {
+                HStack {
+                    Text("Horizontal offset")
+                    Spacer()
+                    Text("\(Int(notchHorizontalOffset)) px")
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .settingsHighlight(id: highlightID("Horizontal offset"))
+
+            HStack {
+                Text("Negative moves left; positive moves right")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                Spacer()
+                Button("Reset Position") {
+                    notchHorizontalOffset = 0
+                }
+                .disabled(notchHorizontalOffset == 0)
+                .buttonStyle(.bordered)
+            }
+        } header: {
+            HStack {
+                Text("Notch Position")
                 customBadge(text: "Beta")
             }
         }

--- a/DynamicIsland/menu/StatusBarMenu.swift
+++ b/DynamicIsland/menu/StatusBarMenu.swift
@@ -50,8 +50,20 @@ class StatusBarMenu: NSMenu {
         }
         
         // Set up the menu
+        let settingsItem = NSMenuItem(
+            title: "Settings…",
+            action: #selector(openSettings),
+            keyEquivalent: ","
+        )
+        settingsItem.target = self
+        self.addItem(settingsItem)
+        self.addItem(.separator())
         self.addItem(NSMenuItem(title: "Quit", action: #selector(NSApp.terminate(_:)), keyEquivalent: "q"))
         statusItem.menu = self
+    }
+
+    @objc private func openSettings() {
+        SettingsWindowController.shared.showWindow()
     }
 
 }

--- a/DynamicIsland/models/Constants.swift
+++ b/DynamicIsland/models/Constants.swift
@@ -964,6 +964,7 @@ extension Defaults.Keys {
     static let notchHeight = Key<CGFloat>("notchHeight", default: 32)
     static let openNotchWidth = Key<CGFloat>("openNotchWidth", default: 640)
     static let closedNotchWidth = Key<CGFloat>("closedNotchWidth", default: 150)
+    static let notchHorizontalOffset = Key<CGFloat>("notchHorizontalOffset", default: 0)
     static let customizePhysicalNotchWidth = Key<Bool>("customizePhysicalNotchWidth", default: false)
         //static let openLastTabByDefault = Key<Bool>("openLastTabByDefault", default: false)
     

--- a/UPSTREAM.md
+++ b/UPSTREAM.md
@@ -1,0 +1,21 @@
+# Atoll 二开跟随上游
+
+本仓库使用 `upstream` 指向官方 Atoll 仓库，`yiduo/notch-offset` 保存意朵的二开改动。
+
+## 同步作者最新功能
+
+先确认当前没有未提交改动，然后执行：
+
+```bash
+git fetch upstream dev
+git rebase upstream/dev
+```
+
+如果出现冲突，优先保留上游同一功能的最新实现，再重新应用水平偏移相关改动。完成后检查：
+
+```bash
+git diff upstream/dev...HEAD --stat
+git diff --check
+```
+
+水平偏移设置保存在 `notchHorizontalOffset`，默认值为 `0`。它只改变主刘海相对于屏幕中心的水平位置，不改变官方扩展接口。


### PR DESCRIPTION
## Summary

- add a persistent horizontal offset setting for the main notch window
- apply the offset during initial positioning and resize/reposition cycles
- add live-updating Appearance controls with reset
- expose a Settings item in the status bar menu

## Details

The offset defaults to 0 and is constrained to -500...500 px. It works with display switching and the show-on-all-displays mode. The setting is intentionally separate from AtollExtensionKit widget positioning.

## Validation

Built successfully with Xcode 26.6 and the macOS 26.5 SDK on arm64.

This change was developed on top of the `dev` branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Notch Position setting with a horizontal offset slider and reset option.
  * The notch now repositions immediately when its horizontal offset changes.
  * Added a Settings menu item with a Command-comma keyboard shortcut.

* **Documentation**
  * Documented the new notch positioning setting and synchronization workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->