### PR TITLE
feat: add host-managed static web plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Static web plugins**: Install local `.atollplugin` packages, enable or disable them as isolated notch tabs, and replace an installed plugin with the same identifier after confirmation. (#781)
+
 - **Fingerprint lock screen activity**: choose the lock, an animated fingerprint scan, or both from Lock Screen settings. The fingerprint uses an attributed Lottie animation and completes its green scan while the Mac unlocks. (#774)
 
 - TIDAL can now be selected as the music source. Atoll follows the TIDAL desktop app's macOS Now Playing session, so unrelated videos no longer replace its metadata or controls, and the real-time waveform captures TIDAL's separate player process. (#764)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- **Static web plugins**: Install local `.atollplugin` packages, enable or disable them as isolated notch tabs, and replace an installed plugin with the same identifier after confirmation. (#781)
+- **Static web plugins**: Install local `.atollplugin` packages, enable or disable them as isolated notch tabs, open explicitly allowed external links with fixed or locally generated query parameters, and replace an installed plugin with the same identifier after confirmation. (#781)
 
 - **Fingerprint lock screen activity**: choose the lock, an animated fingerprint scan, or both from Lock Screen settings. The fingerprint uses an attributed Lottie animation and completes its green scan while the Mac unlocks. (#774)
 

--- a/DynamicIsland.xcodeproj/project.pbxproj
+++ b/DynamicIsland.xcodeproj/project.pbxproj
@@ -32,6 +32,9 @@
 		7EF19C172F577040005B9929 /* SwiftTerm in Frameworks */ = {isa = PBXBuildFile; productRef = 7EF19C162F577040005B9929 /* SwiftTerm */; };
 		8C9E422544384A70B829EDE7 /* NowPlayingPayloadTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2137D0F9431A495AA62ACE96 /* NowPlayingPayloadTests.swift */; };
 		9A7D1A012F90000200A71001 /* AudioTapTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A7D1A022F90000200A71002 /* AudioTapTests.swift */; };
+		A70000000000000000000002 /* StaticPluginPackageValidatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A70000000000000000000001 /* StaticPluginPackageValidatorTests.swift */; };
+		A70000000000000000000004 /* StaticPluginManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A70000000000000000000003 /* StaticPluginManagerTests.swift */; };
+		A70000000000000000000006 /* StaticPluginNavigationPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A70000000000000000000005 /* StaticPluginNavigationPolicyTests.swift */; };
 		A1B2C3D40000000000000001 /* LyricsMetadataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D40000000000000002 /* LyricsMetadataTests.swift */; };
 		A1B2C3D4E5F60718293A4B5C /* ExtensionRPCServerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60718293A4B5D /* ExtensionRPCServerTests.swift */; };
 		A3C83CAF84544DCE386C3BB8 /* DynamicIslandUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54078F29304A9DBBEFBDF932 /* DynamicIslandUITests.swift */; };
@@ -90,6 +93,9 @@
 		8DC2ACF06B40405DB1A8F99E /* MarqueeTextMeasurementTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarqueeTextMeasurementTests.swift; sourceTree = "<group>"; };
 		957599910322B546D91E6F96 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		9A7D1A022F90000200A71002 /* AudioTapTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AudioTapTests.swift; sourceTree = "<group>"; };
+		A70000000000000000000001 /* StaticPluginPackageValidatorTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StaticPluginPackageValidatorTests.swift; sourceTree = "<group>"; };
+		A70000000000000000000003 /* StaticPluginManagerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StaticPluginManagerTests.swift; sourceTree = "<group>"; };
+		A70000000000000000000005 /* StaticPluginNavigationPolicyTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StaticPluginNavigationPolicyTests.swift; sourceTree = "<group>"; };
 		A058D80A7EF44593B0F24EB7 /* DynamicIslandUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = DynamicIslandUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		A1B2C3D40000000000000002 /* LyricsMetadataTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LyricsMetadataTests.swift; sourceTree = "<group>"; };
 		A1B2C3D4E5F60718293A4B5D /* ExtensionRPCServerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ExtensionRPCServerTests.swift; sourceTree = "<group>"; };
@@ -195,6 +201,9 @@
 		50983E4A1FCC1F5E2220FF8A /* DynamicIslandTests */ = {
 			isa = PBXGroup;
 			children = (
+				A70000000000000000000001 /* StaticPluginPackageValidatorTests.swift */,
+				A70000000000000000000003 /* StaticPluginManagerTests.swift */,
+				A70000000000000000000005 /* StaticPluginNavigationPolicyTests.swift */,
 				9A7D1A022F90000200A71002 /* AudioTapTests.swift */,
 				A4B5C6D7E8F90123456789AC /* AppleMusicControllerTests.swift */,
 				C0DEFACE1234567890ABCDEF /* FlyoutFrameCalculatorTests.swift */,
@@ -478,6 +487,9 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A70000000000000000000002 /* StaticPluginPackageValidatorTests.swift in Sources */,
+				A70000000000000000000004 /* StaticPluginManagerTests.swift in Sources */,
+				A70000000000000000000006 /* StaticPluginNavigationPolicyTests.swift in Sources */,
 				9A7D1A012F90000200A71001 /* AudioTapTests.swift in Sources */,
 				A4B5C6D7E8F90123456789AB /* AppleMusicControllerTests.swift in Sources */,
 				B4777BB9FE29243B253B8306 /* SpotifyLibraryTests.swift in Sources */,

--- a/DynamicIsland/ContentView.swift
+++ b/DynamicIsland/ContentView.swift
@@ -198,7 +198,7 @@ struct ContentView: View {
             isStaticPluginView: coordinator.currentView == .staticPlugin,
             selectedPluginID: coordinator.selectedStaticPluginID,
             enabledPlugins: staticPluginManager.enabledPlugins,
-            visibleScreenHeight: NSScreen.main?.visibleFrame.height,
+            visibleScreenHeight: currentScreenVisibleHeight,
             fallbackMaximumHeight: baseSize.height + statsAdditionalRowHeight
         ) {
             return pluginSize
@@ -2385,6 +2385,17 @@ struct ContentView: View {
         let count = enabledStatsGraphCount()
         if count == 0 { return 0 }
         return count <= 3 ? 1 : 2
+    }
+
+    private var currentScreenVisibleHeight: CGFloat? {
+        NSScreen.screens.first { $0.localizedName == vm.screen }?.visibleFrame.height
+            ?? NSScreen.main?.visibleFrame.height
+    }
+
+    /// 返回当前选中且仍启用的静态插件。
+    private func currentStaticPlugin() -> InstalledStaticPlugin? {
+        guard let selectedID = coordinator.selectedStaticPluginID else { return nil }
+        return staticPluginManager.enabledPlugins.first { $0.id == selectedID }
     }
 
     private func currentExtensionTabPayload() -> ExtensionNotchExperiencePayload? {

--- a/DynamicIsland/ContentView.swift
+++ b/DynamicIsland/ContentView.swift
@@ -2385,14 +2385,17 @@ struct ContentView: View {
         return staticPluginManager.enabledPlugins.first { $0.id == selectedID }
     }
 
-    /// 将插件期望高度限制在 Atoll 现有刘海展开范围内。
+    /// 尊重插件请求高度，同时避免刘海内容超出当前屏幕可用范围。
     private func staticPluginPreferredHeight(baseSize: CGSize) -> CGFloat? {
         guard let preferredHeight = currentStaticPlugin()?.manifest.tab.preferredHeight else {
             return nil
         }
-        let minHeight = baseSize.height
-        let maxHeight = baseSize.height + statsAdditionalRowHeight
-        return min(max(CGFloat(preferredHeight), minHeight), maxHeight)
+        return StaticPluginLayout.resolvedHeight(
+            preferredHeight: CGFloat(preferredHeight),
+            baseHeight: baseSize.height,
+            visibleScreenHeight: NSScreen.main?.visibleFrame.height,
+            fallbackMaximumHeight: baseSize.height + statsAdditionalRowHeight
+        )
     }
 
     private func currentExtensionTabPayload() -> ExtensionNotchExperiencePayload? {

--- a/DynamicIsland/ContentView.swift
+++ b/DynamicIsland/ContentView.swift
@@ -193,10 +193,18 @@ struct ContentView: View {
             return CGSize(width: baseSize.width, height: terminalHeight)
         }
 
+        if let pluginSize = StaticPluginLayout.resolvedSize(
+            baseSize: baseSize,
+            isStaticPluginView: coordinator.currentView == .staticPlugin,
+            selectedPluginID: coordinator.selectedStaticPluginID,
+            enabledPlugins: staticPluginManager.enabledPlugins,
+            visibleScreenHeight: NSScreen.main?.visibleFrame.height,
+            fallbackMaximumHeight: baseSize.height + statsAdditionalRowHeight
+        ) {
+            return pluginSize
+        }
+
         if coordinator.currentView == .staticPlugin {
-            if let preferredHeight = staticPluginPreferredHeight(baseSize: baseSize) {
-                return CGSize(width: baseSize.width, height: preferredHeight)
-            }
             return baseSize
         }
 
@@ -2377,25 +2385,6 @@ struct ContentView: View {
         let count = enabledStatsGraphCount()
         if count == 0 { return 0 }
         return count <= 3 ? 1 : 2
-    }
-
-    /// 返回当前选中且仍启用的静态插件。
-    private func currentStaticPlugin() -> InstalledStaticPlugin? {
-        guard let selectedID = coordinator.selectedStaticPluginID else { return nil }
-        return staticPluginManager.enabledPlugins.first { $0.id == selectedID }
-    }
-
-    /// 尊重插件请求高度，同时避免刘海内容超出当前屏幕可用范围。
-    private func staticPluginPreferredHeight(baseSize: CGSize) -> CGFloat? {
-        guard let preferredHeight = currentStaticPlugin()?.manifest.tab.preferredHeight else {
-            return nil
-        }
-        return StaticPluginLayout.resolvedHeight(
-            preferredHeight: CGFloat(preferredHeight),
-            baseHeight: baseSize.height,
-            visibleScreenHeight: NSScreen.main?.visibleFrame.height,
-            fallbackMaximumHeight: baseSize.height + statsAdditionalRowHeight
-        )
     }
 
     private func currentExtensionTabPayload() -> ExtensionNotchExperiencePayload? {

--- a/DynamicIsland/ContentView.swift
+++ b/DynamicIsland/ContentView.swift
@@ -50,6 +50,7 @@ struct ContentView: View {
     @ObservedObject var doNotDisturbManager = DoNotDisturbManager.shared
     @ObservedObject var lockScreenManager = LockScreenManager.shared
     @ObservedObject var capsLockManager = CapsLockManager.shared
+    @ObservedObject var staticPluginManager = StaticPluginManager.shared
     @ObservedObject var extensionLiveActivityManager = ExtensionLiveActivityManager.shared
     @ObservedObject var extensionNotchExperienceManager = ExtensionNotchExperienceManager.shared
     @ObservedObject var localSendService = LocalSendService.shared
@@ -190,6 +191,13 @@ struct ContentView: View {
             let maxFraction = Defaults[.terminalMaxHeightFraction]
             let terminalHeight = min(screenHeight * maxFraction, max(300, screenHeight * maxFraction))
             return CGSize(width: baseSize.width, height: terminalHeight)
+        }
+
+        if coordinator.currentView == .staticPlugin {
+            if let preferredHeight = staticPluginPreferredHeight(baseSize: baseSize) {
+                return CGSize(width: baseSize.width, height: preferredHeight)
+            }
+            return baseSize
         }
 
         if coordinator.currentView == .extensionExperience {
@@ -1189,6 +1197,12 @@ struct ContentView: View {
                                 NotchClipboardView()
                             case .terminal:
                                 NotchTerminalView()
+                            case .staticPlugin:
+                                if let plugin = currentStaticPlugin() {
+                                    StaticPluginWebView(plugin: plugin)
+                                } else {
+                                    NotchHomeView(albumArtNamespace: albumArtNamespace)
+                                }
                             case .extensionExperience:
                                 if let payload = currentExtensionTabPayload() {
                                     ExtensionNotchExperienceTabView(payload: payload)
@@ -2363,6 +2377,22 @@ struct ContentView: View {
         let count = enabledStatsGraphCount()
         if count == 0 { return 0 }
         return count <= 3 ? 1 : 2
+    }
+
+    /// 返回当前选中且仍启用的静态插件。
+    private func currentStaticPlugin() -> InstalledStaticPlugin? {
+        guard let selectedID = coordinator.selectedStaticPluginID else { return nil }
+        return staticPluginManager.enabledPlugins.first { $0.id == selectedID }
+    }
+
+    /// 将插件期望高度限制在 Atoll 现有刘海展开范围内。
+    private func staticPluginPreferredHeight(baseSize: CGSize) -> CGFloat? {
+        guard let preferredHeight = currentStaticPlugin()?.manifest.tab.preferredHeight else {
+            return nil
+        }
+        let minHeight = baseSize.height
+        let maxHeight = baseSize.height + statsAdditionalRowHeight
+        return min(max(CGFloat(preferredHeight), minHeight), maxHeight)
     }
 
     private func currentExtensionTabPayload() -> ExtensionNotchExperiencePayload? {

--- a/DynamicIsland/ContentView.swift
+++ b/DynamicIsland/ContentView.swift
@@ -1208,6 +1208,7 @@ struct ContentView: View {
                             case .staticPlugin:
                                 if let plugin = currentStaticPlugin() {
                                     StaticPluginWebView(plugin: plugin)
+                                        .id("\(plugin.id):\(staticPluginManager.reloadRevision)")
                                 } else {
                                     NotchHomeView(albumArtNamespace: albumArtNamespace)
                                 }

--- a/DynamicIsland/DynamicIslandApp.swift
+++ b/DynamicIsland/DynamicIslandApp.swift
@@ -546,7 +546,16 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         var baseSize = Defaults[.enableMinimalisticUI] ? minimalisticOpenNotchSize(isDynamicIslandMode: shouldUseDynamicIslandMode(for: vm.screen)) : openNotchSize
         
         // Use a consistent height for different view types
-        if coordinator.currentView == .timer {
+        if let pluginSize = StaticPluginLayout.resolvedSize(
+            baseSize: baseSize,
+            isStaticPluginView: coordinator.currentView == .staticPlugin,
+            selectedPluginID: coordinator.selectedStaticPluginID,
+            enabledPlugins: StaticPluginManager.shared.enabledPlugins,
+            visibleScreenHeight: NSScreen.main?.visibleFrame.height,
+            fallbackMaximumHeight: baseSize.height + statsSecondRowContentHeight + statsGridSpacingHeight
+        ) {
+            baseSize = pluginSize
+        } else if coordinator.currentView == .timer {
             baseSize.height = 250 // Extra space for timer presets
         } else if coordinator.currentView == .notes {
             let preferredHeight = coordinator.notesLayoutState.preferredHeight

--- a/DynamicIsland/DynamicIslandApp.swift
+++ b/DynamicIsland/DynamicIslandApp.swift
@@ -809,6 +809,16 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             }
         }.store(in: &cancellables)
 
+        // Replace 可保持插件 ID 不变；扫描修订号保证已打开窗口仍会刷新内容和高度。
+        StaticPluginManager.shared.$reloadRevision
+            .dropFirst()
+            .sink { [weak self] _ in
+                DispatchQueue.main.async {
+                    self?.updateWindowSizeIfNeeded()
+                }
+            }
+            .store(in: &cancellables)
+
         coordinator.$notesLayoutState
             .removeDuplicates()
             .sink { [weak self] _ in

--- a/DynamicIsland/DynamicIslandApp.swift
+++ b/DynamicIsland/DynamicIslandApp.swift
@@ -408,7 +408,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     {
         // Use the current required size instead of always using openNotchSize
         let baseSize = calculateRequiredNotchSize()
-        let requiredSize = adjustedSizeForScreen(baseSize, screen: screen)
+        let pluginAdjustedSize = staticPluginAdjustedSize(baseSize, for: screen)
+        let requiredSize = adjustedSizeForScreen(pluginAdjustedSize, screen: screen)
         let roundedWidth = requiredSize.width.rounded()
         let roundedHeight = requiredSize.height.rounded()
         
@@ -546,16 +547,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         var baseSize = Defaults[.enableMinimalisticUI] ? minimalisticOpenNotchSize(isDynamicIslandMode: shouldUseDynamicIslandMode(for: vm.screen)) : openNotchSize
         
         // Use a consistent height for different view types
-        if let pluginSize = StaticPluginLayout.resolvedSize(
-            baseSize: baseSize,
-            isStaticPluginView: coordinator.currentView == .staticPlugin,
-            selectedPluginID: coordinator.selectedStaticPluginID,
-            enabledPlugins: StaticPluginManager.shared.enabledPlugins,
-            visibleScreenHeight: NSScreen.main?.visibleFrame.height,
-            fallbackMaximumHeight: baseSize.height + statsSecondRowContentHeight + statsGridSpacingHeight
-        ) {
-            baseSize = pluginSize
-        } else if coordinator.currentView == .timer {
+        if coordinator.currentView == .timer {
             baseSize.height = 250 // Extra space for timer presets
         } else if coordinator.currentView == .notes {
             let preferredHeight = coordinator.notesLayoutState.preferredHeight
@@ -635,6 +627,28 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         return adjusted
     }
 
+    /// 按每个窗口所在屏幕重新限制静态插件高度，避免副屏超出可用范围。
+    private func staticPluginAdjustedSize(_ size: CGSize, for screen: NSScreen) -> CGSize {
+        let baseContentSize = Defaults[.enableMinimalisticUI]
+            ? minimalisticOpenNotchSize(isDynamicIslandMode: shouldUseDynamicIslandMode(for: screen.localizedName))
+            : openNotchSize
+        guard let pluginContentSize = StaticPluginLayout.resolvedSize(
+            baseSize: baseContentSize,
+            isStaticPluginView: coordinator.currentView == .staticPlugin,
+            selectedPluginID: coordinator.selectedStaticPluginID,
+            enabledPlugins: StaticPluginManager.shared.enabledPlugins,
+            visibleScreenHeight: screen.visibleFrame.height,
+            fallbackMaximumHeight: baseContentSize.height + statsSecondRowContentHeight + statsGridSpacingHeight
+        ) else {
+            return size
+        }
+        var adjusted = size
+        adjusted.height = pluginContentSize.height + notchShadowPaddingValue(
+            isMinimalistic: Defaults[.enableMinimalisticUI]
+        )
+        return adjusted
+    }
+
     func ensureWindowSize(_ size: CGSize, animated: Bool, force: Bool = false) {
         resizeWindows(to: size, animated: animated, force: force)
     }
@@ -644,7 +658,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
         if Defaults[.showOnAllDisplays] {
             for (screen, window) in windows {
-                let screenSize = adjustedSizeForScreen(size, screen: screen)
+                let screenSize = adjustedSizeForScreen(
+                    staticPluginAdjustedSize(size, for: screen),
+                    screen: screen
+                )
                 if force || window.frame.size != screenSize {
                     resizeWindow(window, on: screen, to: screenSize, animated: animated)
                 }
@@ -652,7 +669,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         } else if let window {
             let screen = window.screen ?? NSScreen.screens.first { $0.frame.intersects(window.frame) } ?? NSScreen.main ?? NSScreen.screens.first
             guard let screen else { return }
-            let screenSize = adjustedSizeForScreen(size, screen: screen)
+            let screenSize = adjustedSizeForScreen(
+                staticPluginAdjustedSize(size, for: screen),
+                screen: screen
+            )
             if force || window.frame.size != screenSize {
                 resizeWindow(window, on: screen, to: screenSize, animated: animated)
             }

--- a/DynamicIsland/DynamicIslandViewCoordinator.swift
+++ b/DynamicIsland/DynamicIslandViewCoordinator.swift
@@ -105,7 +105,7 @@ class DynamicIslandViewCoordinator: ObservableObject {
     private var cancellables = Set<AnyCancellable>()
     private var hoverOpenSuppressedUntil: Date = .distantPast
     
-    private static let tabOrder: [NotchViews] = [.home, .shelf, .timer, .stats, .llmUsage, .colorPicker, .notes, .clipboard, .terminal, .extensionExperience]
+    private static let tabOrder: [NotchViews] = [.home, .shelf, .timer, .stats, .llmUsage, .colorPicker, .notes, .clipboard, .terminal, .staticPlugin, .extensionExperience]
     
     /// Direction of the most recent tab switch (true = forward/right, false = backward/left)
     @Published var tabSwitchForward: Bool = true
@@ -126,6 +126,8 @@ class DynamicIslandViewCoordinator: ObservableObject {
     
     @Published var statsSecondRowExpansion: CGFloat = 1
     @Published var notesLayoutState: NotesLayoutState = .list
+    /// 当前刘海标签选中的静态插件 ID。
+    @Published var selectedStaticPluginID: String?
     @Published var selectedExtensionExperienceID: String?
     
     
@@ -168,6 +170,7 @@ class DynamicIslandViewCoordinator: ObservableObject {
     @Published var selectedScreen: String = NSScreen.main?.localizedName ?? "Unknown"
 
     @Published var optionKeyPressed: Bool = true
+    private let staticPluginManager = StaticPluginManager.shared
     private let extensionNotchExperienceManager = ExtensionNotchExperienceManager.shared
     
     private init() {
@@ -200,6 +203,16 @@ class DynamicIslandViewCoordinator: ObservableObject {
             }
             .store(in: &cancellables)
 
+        Publishers.CombineLatest(
+            staticPluginManager.$plugins,
+            staticPluginManager.$disabledPluginIDs
+        )
+        .receive(on: DispatchQueue.main)
+        .sink { [weak self] _, _ in
+            self?.handleStaticPluginSnapshot()
+        }
+        .store(in: &cancellables)
+
         Defaults.publisher(.enableThirdPartyExtensions)
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in
@@ -222,6 +235,7 @@ class DynamicIslandViewCoordinator: ObservableObject {
             .store(in: &cancellables)
 
         handleExtensionExperienceSnapshot(extensionNotchExperienceManager.activeExperiences)
+        handleStaticPluginSnapshot()
 
         // Observe all tab-affecting settings to enforce minimum notch width
         Publishers.MergeMany(
@@ -310,6 +324,19 @@ class DynamicIslandViewCoordinator: ObservableObject {
 
     private func handleExtensionFeatureToggle() {
         handleExtensionExperienceSnapshot(extensionNotchExperienceManager.activeExperiences)
+    }
+
+    /// 插件被禁用、删除或校验失效时退出已经不存在的标签页。
+    private func handleStaticPluginSnapshot() {
+        guard let selectedStaticPluginID,
+              staticPluginManager.enabledPlugins.contains(where: { $0.id == selectedStaticPluginID }) else {
+            self.selectedStaticPluginID = nil
+            guard currentView == .staticPlugin else { return }
+            withAnimation(.smooth) {
+                currentView = .home
+            }
+            return
+        }
     }
 
     private func resetExtensionViewIfNeeded() {

--- a/DynamicIsland/components/Settings/ExtensionsSettings.swift
+++ b/DynamicIsland/components/Settings/ExtensionsSettings.swift
@@ -16,15 +16,19 @@
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
+import AppKit
 import SwiftUI
 import Defaults
 import AtollExtensionKit
+import UniformTypeIdentifiers
 
 struct ExtensionsSettingsView: View {
     @ObservedObject private var authManager = ExtensionAuthorizationManager.shared
+    @ObservedObject private var staticPluginManager = StaticPluginManager.shared
     @State private var searchText = ""
     @State private var selectedEntry: ExtensionAuthorizationEntry?
     @State private var showingRemoveConfirmation = false
+    @State private var staticPluginAlert: StaticPluginAlert?
     
     private func highlightID(_ title: String) -> String {
         "extensions-\(title)"
@@ -42,6 +46,7 @@ struct ExtensionsSettingsView: View {
     var body: some View {
         Form {
             globalTogglesSection
+            staticPluginsSection
             
             if authManager.isExtensionsFeatureEnabled {
                 authorizedAppsSection
@@ -56,6 +61,130 @@ struct ExtensionsSettingsView: View {
             }
         } message: { entry in
             Text("Remove \(entry.appName) from the authorized extensions list? This will dismiss all active live activities, lock screen widgets, and notch experiences from this app.")
+        }
+    }
+
+    private var staticPluginsSection: some View {
+        Section {
+            Button("Import Plugin", systemImage: "plus") {
+                chooseStaticPlugin()
+            }
+
+            if staticPluginManager.plugins.isEmpty {
+                Text("No static plugins installed")
+                    .foregroundStyle(.secondary)
+            } else {
+                ForEach(staticPluginManager.plugins) { plugin in
+                    StaticPluginSettingsRow(
+                        plugin: plugin,
+                        isEnabled: !staticPluginManager.isDisabled(pluginID: plugin.id),
+                        onEnabledChange: {
+                            staticPluginManager.setEnabled($0, pluginID: plugin.id)
+                        },
+                        onRemove: {
+                            staticPluginAlert = .remove(plugin)
+                        }
+                    )
+                }
+            }
+
+            ForEach(staticPluginManager.discoveryErrors, id: \.self) { error in
+                Label(error, systemImage: "exclamationmark.triangle")
+                    .font(.caption)
+                    .foregroundStyle(.orange)
+            }
+        } header: {
+            HStack {
+                Text("Static Plugins")
+                Spacer()
+                if !staticPluginManager.plugins.isEmpty {
+                    Text("\(staticPluginManager.plugins.count) installed")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        } footer: {
+            Text("Static plugins run local HTML, CSS, and JavaScript inside Atoll. Declared links open in your default browser.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+        .alert(item: $staticPluginAlert) { alert in
+            switch alert {
+            case .replace(let sourceURL, let incoming, let installed):
+                return Alert(
+                    title: Text("Replace Static Plugin?"),
+                    message: Text("Replace \(installed.manifest.name) \(installed.manifest.version) with version \(incoming.manifest.version)?"),
+                    primaryButton: .cancel(),
+                    secondaryButton: .destructive(Text("Replace")) {
+                        performStaticPluginOperation {
+                            try staticPluginManager.install(from: sourceURL, replacingExisting: true)
+                        }
+                    }
+                )
+            case .remove(let plugin):
+                return Alert(
+                    title: Text("Remove Static Plugin?"),
+                    message: Text("Remove \(plugin.manifest.name) from Atoll?"),
+                    primaryButton: .cancel(),
+                    secondaryButton: .destructive(Text("Remove")) {
+                        performStaticPluginOperation {
+                            try staticPluginManager.remove(pluginID: plugin.id)
+                        }
+                    }
+                )
+            case .error(let message):
+                return Alert(
+                    title: Text("Static Plugin Error"),
+                    message: Text(message),
+                    dismissButton: .default(Text("OK"))
+                )
+            }
+        }
+    }
+
+    /// 让用户选择一个本地目录包，所有格式和安全检查仍由校验器完成。
+    private func chooseStaticPlugin() {
+        let panel = NSOpenPanel()
+        panel.title = "Import Static Plugin"
+        panel.message = "Choose a directory ending in .atollplugin."
+        panel.prompt = "Import"
+        panel.allowsMultipleSelection = false
+        panel.canChooseDirectories = true
+        panel.canChooseFiles = true
+        panel.treatsFilePackagesAsDirectories = false
+        if let pluginType = UTType(filenameExtension: "atollplugin", conformingTo: .package) {
+            panel.allowedContentTypes = [pluginType]
+        }
+        guard panel.runModal() == .OK, let sourceURL = panel.url else { return }
+        prepareStaticPluginImport(from: sourceURL)
+    }
+
+    /// 校验导入内容，并在相同 ID 时要求用户明确确认 Replace。
+    private func prepareStaticPluginImport(from sourceURL: URL) {
+        do {
+            let incoming = try StaticPluginPackageValidator().validate(packageURL: sourceURL)
+            if let installed = staticPluginManager.plugins.first(where: { $0.id == incoming.id }) {
+                staticPluginAlert = .replace(
+                    sourceURL: sourceURL,
+                    incoming: incoming,
+                    installed: installed
+                )
+            } else {
+                try staticPluginManager.install(from: sourceURL, replacingExisting: false)
+            }
+        } catch {
+            staticPluginAlert = .error(error.localizedDescription)
+        }
+    }
+
+    private func performStaticPluginOperation(_ operation: () throws -> Void) {
+        do {
+            try operation()
+        } catch {
+            let message = error.localizedDescription
+            DispatchQueue.main.async {
+                staticPluginAlert = .error(message)
+            }
         }
     }
     
@@ -166,6 +295,73 @@ struct ExtensionsSettingsView: View {
                 .foregroundStyle(.secondary)
             }
         }
+    }
+}
+
+private enum StaticPluginAlert: Identifiable {
+    case replace(
+        sourceURL: URL,
+        incoming: InstalledStaticPlugin,
+        installed: InstalledStaticPlugin
+    )
+    case remove(InstalledStaticPlugin)
+    case error(String)
+
+    var id: String {
+        switch self {
+        case .replace(_, let incoming, _):
+            return "replace-\(incoming.id)"
+        case .remove(let plugin):
+            return "remove-\(plugin.id)"
+        case .error(let message):
+            return "error-\(message)"
+        }
+    }
+}
+
+@MainActor
+private struct StaticPluginSettingsRow: View {
+    /// 当前展示的已安装插件。
+    let plugin: InstalledStaticPlugin
+    /// 插件当前是否启用。
+    let isEnabled: Bool
+    let onEnabledChange: (Bool) -> Void
+    let onRemove: () -> Void
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Image(systemName: plugin.manifest.tab.icon)
+                .frame(width: 24)
+                .foregroundStyle(.secondary)
+
+            VStack(alignment: .leading, spacing: 3) {
+                HStack(spacing: 6) {
+                    Text(plugin.manifest.name)
+                        .font(.system(size: 13, weight: .medium))
+                    Text(plugin.manifest.version)
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                }
+                Text(plugin.id)
+                    .font(.system(size: 11))
+                    .foregroundStyle(.secondary)
+            }
+
+            Spacer()
+
+            Toggle(
+                "Enabled",
+                isOn: Binding(get: { isEnabled }, set: onEnabledChange)
+            )
+            .labelsHidden()
+
+            Button(role: .destructive, action: onRemove) {
+                Image(systemName: "trash")
+            }
+            .buttonStyle(.borderless)
+            .help("Remove Plugin")
+        }
+        .padding(.vertical, 6)
     }
 }
 

--- a/DynamicIsland/components/StaticPlugins/StaticPluginNavigationPolicy.swift
+++ b/DynamicIsland/components/StaticPlugins/StaticPluginNavigationPolicy.swift
@@ -23,11 +23,11 @@ struct StaticPluginNavigationPolicy {
     /// 用户点击后可交给系统浏览器打开的精确 URL。
     let allowedExternalURLs: Set<URL>
 
-    /// 只根据已验证的插件边界决定导航去向，不在这里产生系统副作用。
+    /// 只根据已验证的插件边界决定导航去向；`mainFrame == nil` 表示新窗口目标，仍需用户点击才允许外部打开。
     func decision(
         for url: URL,
         userActivated: Bool,
-        mainFrame: Bool
+        mainFrame: Bool?
     ) -> StaticPluginNavigationDecision {
         if url.isFileURL {
             let rootPath = pluginRoot.standardizedFileURL.resolvingSymlinksInPath().path
@@ -38,7 +38,7 @@ struct StaticPluginNavigationPolicy {
         }
 
         guard userActivated,
-              mainFrame,
+              mainFrame != false,
               let scheme = url.scheme?.lowercased(),
               ["http", "https"].contains(scheme),
               allowedExternalURLs.contains(url) else {

--- a/DynamicIsland/components/StaticPlugins/StaticPluginNavigationPolicy.swift
+++ b/DynamicIsland/components/StaticPlugins/StaticPluginNavigationPolicy.swift
@@ -22,6 +22,8 @@ struct StaticPluginNavigationPolicy {
     let pluginRoot: URL
     /// 用户点击后可交给系统浏览器打开的精确 URL。
     let allowedExternalURLs: Set<URL>
+    /// 用户点击后可交给系统浏览器打开的动态查询 URL 前缀。
+    let allowedExternalURLPrefixes: Set<String>
 
     /// 只根据已验证的插件边界决定导航去向；`mainFrame == nil` 表示新窗口目标，仍需用户点击才允许外部打开。
     func decision(
@@ -37,11 +39,13 @@ struct StaticPluginNavigationPolicy {
                 : .cancel
         }
 
+        let allowedExternalURL = allowedExternalURLs.contains(url)
+            || allowedExternalURLPrefixes.contains { url.absoluteString.hasPrefix($0) }
         guard userActivated,
               mainFrame != false,
               let scheme = url.scheme?.lowercased(),
               ["http", "https"].contains(scheme),
-              allowedExternalURLs.contains(url) else {
+              allowedExternalURL else {
             return .cancel
         }
         return .openExternally(url)

--- a/DynamicIsland/components/StaticPlugins/StaticPluginNavigationPolicy.swift
+++ b/DynamicIsland/components/StaticPlugins/StaticPluginNavigationPolicy.swift
@@ -1,0 +1,60 @@
+/*
+ * Atoll (DynamicIsland)
+ * Copyright (C) 2024-2026 Atoll Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+import AppKit
+import Foundation
+
+enum StaticPluginNavigationDecision: Equatable {
+    case allow
+    case cancel
+    case openExternally(URL)
+}
+
+struct StaticPluginNavigationPolicy {
+    /// 插件唯一允许读取的目录。
+    let pluginRoot: URL
+    /// 用户点击后可交给系统浏览器打开的精确 URL。
+    let allowedExternalURLs: Set<URL>
+
+    /// 只根据已验证的插件边界决定导航去向，不在这里产生系统副作用。
+    func decision(
+        for url: URL,
+        userActivated: Bool,
+        mainFrame: Bool
+    ) -> StaticPluginNavigationDecision {
+        if url.isFileURL {
+            let rootPath = pluginRoot.standardizedFileURL.resolvingSymlinksInPath().path
+            let candidatePath = url.standardizedFileURL.resolvingSymlinksInPath().path
+            return candidatePath == rootPath || candidatePath.hasPrefix(rootPath + "/")
+                ? .allow
+                : .cancel
+        }
+
+        guard userActivated,
+              mainFrame,
+              let scheme = url.scheme?.lowercased(),
+              ["http", "https"].contains(scheme),
+              allowedExternalURLs.contains(url) else {
+            return .cancel
+        }
+        return .openExternally(url)
+    }
+}
+
+protocol StaticPluginExternalOpening {
+    /// 使用宿主认可的系统机制打开外部 URL。
+    func open(_ url: URL)
+}
+
+struct WorkspaceStaticPluginExternalOpener: StaticPluginExternalOpening {
+    func open(_ url: URL) {
+        _ = NSWorkspace.shared.open(url)
+    }
+}

--- a/DynamicIsland/components/StaticPlugins/StaticPluginWebView.swift
+++ b/DynamicIsland/components/StaticPlugins/StaticPluginWebView.swift
@@ -140,7 +140,8 @@ struct StaticPluginWebRepresentable: NSViewRepresentable {
             }
             let policy = StaticPluginNavigationPolicy(
                 pluginRoot: plugin.rootURL,
-                allowedExternalURLs: plugin.allowedExternalURLs
+                allowedExternalURLs: plugin.allowedExternalURLs,
+                allowedExternalURLPrefixes: plugin.allowedExternalURLPrefixes
             )
             switch policy.decision(
                 for: url,

--- a/DynamicIsland/components/StaticPlugins/StaticPluginWebView.swift
+++ b/DynamicIsland/components/StaticPlugins/StaticPluginWebView.swift
@@ -37,7 +37,7 @@ struct StaticPluginWebView: View {
     }
 }
 
-private struct StaticPluginWebRepresentable: NSViewRepresentable {
+struct StaticPluginWebRepresentable: NSViewRepresentable {
     /// 当前需要展示的已校验插件。
     let plugin: InstalledStaticPlugin
     /// WebKit 配置或加载失败时显示的错误。
@@ -180,6 +180,11 @@ private struct StaticPluginWebRepresentable: NSViewRepresentable {
             withError error: Error
         ) {
             loadingError.wrappedValue = error.localizedDescription
+        }
+
+        /// 后续导航成功时移除先前失败留下的错误遮罩。
+        func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+            loadingError.wrappedValue = nil
         }
     }
 }

--- a/DynamicIsland/components/StaticPlugins/StaticPluginWebView.swift
+++ b/DynamicIsland/components/StaticPlugins/StaticPluginWebView.swift
@@ -145,7 +145,7 @@ private struct StaticPluginWebRepresentable: NSViewRepresentable {
             switch policy.decision(
                 for: url,
                 userActivated: navigationAction.navigationType == .linkActivated,
-                mainFrame: navigationAction.targetFrame?.isMainFrame == true
+                mainFrame: navigationAction.targetFrame?.isMainFrame
             ) {
             case .allow:
                 decisionHandler(.allow)

--- a/DynamicIsland/components/StaticPlugins/StaticPluginWebView.swift
+++ b/DynamicIsland/components/StaticPlugins/StaticPluginWebView.swift
@@ -1,0 +1,185 @@
+/*
+ * Atoll (DynamicIsland)
+ * Copyright (C) 2024-2026 Atoll Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+import SwiftUI
+import WebKit
+
+struct StaticPluginWebView: View {
+    static let networkBlockingRules = """
+    [
+      {"trigger":{"url-filter":"^https?://.*"},"action":{"type":"block"}},
+      {"trigger":{"url-filter":"^wss?://.*"},"action":{"type":"block"}}
+    ]
+    """
+
+    /// 当前需要展示的已校验插件。
+    let plugin: InstalledStaticPlugin
+    @State private var loadingError: String?
+
+    var body: some View {
+        ZStack {
+            StaticPluginWebRepresentable(plugin: plugin, loadingError: $loadingError)
+            if let loadingError {
+                ContentUnavailableView(
+                    "Plugin Could Not Load",
+                    systemImage: "exclamationmark.triangle",
+                    description: Text(loadingError)
+                )
+            }
+        }
+    }
+}
+
+private struct StaticPluginWebRepresentable: NSViewRepresentable {
+    /// 当前需要展示的已校验插件。
+    let plugin: InstalledStaticPlugin
+    /// WebKit 配置或加载失败时显示的错误。
+    @Binding var loadingError: String?
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(
+            plugin: plugin,
+            loadingError: $loadingError,
+            externalOpener: WorkspaceStaticPluginExternalOpener()
+        )
+    }
+
+    func makeNSView(context: Context) -> WKWebView {
+        let configuration = WKWebViewConfiguration()
+        configuration.websiteDataStore = .nonPersistent()
+        configuration.preferences.javaScriptCanOpenWindowsAutomatically = false
+        let webView = WKWebView(frame: .zero, configuration: configuration)
+        webView.navigationDelegate = context.coordinator
+        webView.uiDelegate = context.coordinator
+        webView.allowsBackForwardNavigationGestures = false
+        webView.allowsLinkPreview = false
+        webView.setValue(false, forKey: "drawsBackground")
+        context.coordinator.loadPlugin(in: webView)
+        return webView
+    }
+
+    func updateNSView(_ webView: WKWebView, context: Context) {
+        context.coordinator.update(plugin: plugin, loadingError: $loadingError)
+        context.coordinator.loadPluginIfNeeded(in: webView)
+    }
+
+    final class Coordinator: NSObject, WKNavigationDelegate, WKUIDelegate {
+        private var plugin: InstalledStaticPlugin
+        private var loadingError: Binding<String?>
+        private let externalOpener: StaticPluginExternalOpening
+        private var configuredPlugin: InstalledStaticPlugin?
+        private var configurationInProgress = false
+
+        init(
+            plugin: InstalledStaticPlugin,
+            loadingError: Binding<String?>,
+            externalOpener: StaticPluginExternalOpening
+        ) {
+            self.plugin = plugin
+            self.loadingError = loadingError
+            self.externalOpener = externalOpener
+        }
+
+        /// 同步 SwiftUI 传入的新插件和错误绑定。
+        func update(plugin: InstalledStaticPlugin, loadingError: Binding<String?>) {
+            if self.plugin != plugin {
+                configuredPlugin = nil
+            }
+            self.plugin = plugin
+            self.loadingError = loadingError
+        }
+
+        /// 首次展示时先安装网络拦截规则，再读取本地入口。
+        func loadPlugin(in webView: WKWebView) {
+            guard !configurationInProgress else { return }
+            configurationInProgress = true
+            loadingError.wrappedValue = nil
+            WKContentRuleListStore.default().compileContentRuleList(
+                forIdentifier: "AtollStaticPluginNetworkBlocker",
+                encodedContentRuleList: StaticPluginWebView.networkBlockingRules
+            ) { [weak self, weak webView] ruleList, error in
+                Task { @MainActor in
+                    guard let self, let webView else { return }
+                    self.configurationInProgress = false
+                    guard let ruleList else {
+                        self.loadingError.wrappedValue = error?.localizedDescription
+                            ?? "Atoll could not install the offline-content rules."
+                        return
+                    }
+                    webView.configuration.userContentController.add(ruleList)
+                    self.configuredPlugin = self.plugin
+                    webView.loadFileURL(
+                        self.plugin.entrypointURL,
+                        allowingReadAccessTo: self.plugin.rootURL
+                    )
+                }
+            }
+        }
+
+        /// 插件被 Replace 后在清单或入口变化时重新配置加载。
+        func loadPluginIfNeeded(in webView: WKWebView) {
+            guard configuredPlugin != plugin else { return }
+            loadPlugin(in: webView)
+        }
+
+        func webView(
+            _ webView: WKWebView,
+            decidePolicyFor navigationAction: WKNavigationAction,
+            decisionHandler: @escaping (WKNavigationActionPolicy) -> Void
+        ) {
+            guard let url = navigationAction.request.url else {
+                decisionHandler(.cancel)
+                return
+            }
+            let policy = StaticPluginNavigationPolicy(
+                pluginRoot: plugin.rootURL,
+                allowedExternalURLs: plugin.allowedExternalURLs
+            )
+            switch policy.decision(
+                for: url,
+                userActivated: navigationAction.navigationType == .linkActivated,
+                mainFrame: navigationAction.targetFrame?.isMainFrame == true
+            ) {
+            case .allow:
+                decisionHandler(.allow)
+            case .cancel:
+                decisionHandler(.cancel)
+            case .openExternally(let url):
+                externalOpener.open(url)
+                decisionHandler(.cancel)
+            }
+        }
+
+        func webView(
+            _ webView: WKWebView,
+            createWebViewWith configuration: WKWebViewConfiguration,
+            for navigationAction: WKNavigationAction,
+            windowFeatures: WKWindowFeatures
+        ) -> WKWebView? {
+            nil
+        }
+
+        func webView(
+            _ webView: WKWebView,
+            didFail navigation: WKNavigation!,
+            withError error: Error
+        ) {
+            loadingError.wrappedValue = error.localizedDescription
+        }
+
+        func webView(
+            _ webView: WKWebView,
+            didFailProvisionalNavigation navigation: WKNavigation!,
+            withError error: Error
+        ) {
+            loadingError.wrappedValue = error.localizedDescription
+        }
+    }
+}

--- a/DynamicIsland/components/Tabs/TabSelectionView.swift
+++ b/DynamicIsland/components/Tabs/TabSelectionView.swift
@@ -30,14 +30,30 @@ struct TabModel: Identifiable {
     let label: String
     let icon: String
     let view: NotchViews
+    /// 静态插件标签对应的插件 ID。
+    let staticPluginID: String?
     let experienceID: String?
     let accentColor: Color?
 
-    init(label: String, icon: String, view: NotchViews, experienceID: String? = nil, accentColor: Color? = nil) {
-        self.id = experienceID.map { "extension-\($0)" } ?? "system-\(view)-\(label)"
+    init(
+        label: String,
+        icon: String,
+        view: NotchViews,
+        staticPluginID: String? = nil,
+        experienceID: String? = nil,
+        accentColor: Color? = nil
+    ) {
+        if let staticPluginID {
+            self.id = "static-\(staticPluginID)"
+        } else if let experienceID {
+            self.id = "extension-\(experienceID)"
+        } else {
+            self.id = "system-\(view)-\(label)"
+        }
         self.label = label
         self.icon = icon
         self.view = view
+        self.staticPluginID = staticPluginID
         self.experienceID = experienceID
         self.accentColor = accentColor
     }
@@ -45,6 +61,7 @@ struct TabModel: Identifiable {
 
 struct TabSelectionView: View {
     @ObservedObject var coordinator = DynamicIslandViewCoordinator.shared
+    @ObservedObject private var staticPluginManager = StaticPluginManager.shared
     @ObservedObject private var extensionNotchExperienceManager = ExtensionNotchExperienceManager.shared
     @StateObject private var quickShareService = QuickShareService.shared
     @Default(.quickShareProvider) private var quickShareProvider
@@ -95,6 +112,20 @@ struct TabSelectionView: View {
         if Defaults[.enableTerminalFeature] {
             tabsArray.append(TabModel(label: "Terminal", icon: "apple.terminal", view: .terminal))
         }
+        for plugin in staticPluginManager.enabledPlugins {
+            let requestedIcon = plugin.manifest.tab.icon
+            let icon = NSImage(systemSymbolName: requestedIcon, accessibilityDescription: nil) == nil
+                ? "puzzlepiece.extension"
+                : requestedIcon
+            tabsArray.append(
+                TabModel(
+                    label: plugin.manifest.tab.title,
+                    icon: icon,
+                    view: .staticPlugin,
+                    staticPluginID: plugin.id
+                )
+            )
+        }
         if extensionTabsEnabled {
             for payload in extensionTabPayloads {
                 guard let tab = payload.descriptor.tab else { continue }
@@ -121,7 +152,9 @@ struct TabSelectionView: View {
 
                 // Render the tab button
                 TabButton(label: tab.label, icon: tab.icon, selected: isSelected) {
-                    if tab.view == .extensionExperience {
+                    if tab.view == .staticPlugin {
+                        coordinator.selectedStaticPluginID = tab.staticPluginID
+                    } else if tab.view == .extensionExperience {
                         coordinator.selectedExtensionExperienceID = tab.experienceID
                     }
                     coordinator.currentView = tab.view
@@ -149,6 +182,9 @@ struct TabSelectionView: View {
         .onAppear {
             ensureValidSelection(with: tabs)
         }
+        .onChange(of: tabs.map(\.id)) { _, _ in
+            ensureValidSelection(with: tabs)
+        }
     }
 
     private var extensionTabsEnabled: Bool {
@@ -167,6 +203,10 @@ struct TabSelectionView: View {
     }
 
     private func isSelected(_ tab: TabModel) -> Bool {
+        if tab.view == .staticPlugin {
+            return coordinator.currentView == .staticPlugin
+                && coordinator.selectedStaticPluginID == tab.staticPluginID
+        }
         if tab.view == .extensionExperience {
             return coordinator.currentView == .extensionExperience
                 && coordinator.selectedExtensionExperienceID == tab.experienceID
@@ -180,9 +220,14 @@ struct TabSelectionView: View {
             return
         }
         guard let first = tabs.first else { return }
-        if first.view == .extensionExperience {
+        if first.view == .staticPlugin {
+            coordinator.selectedStaticPluginID = first.staticPluginID
+            coordinator.selectedExtensionExperienceID = nil
+        } else if first.view == .extensionExperience {
+            coordinator.selectedStaticPluginID = nil
             coordinator.selectedExtensionExperienceID = first.experienceID
         } else {
+            coordinator.selectedStaticPluginID = nil
             coordinator.selectedExtensionExperienceID = nil
         }
         coordinator.currentView = first.view

--- a/DynamicIsland/enums/generic.swift
+++ b/DynamicIsland/enums/generic.swift
@@ -80,6 +80,7 @@ public enum NotchViews {
     case notes
     case clipboard
     case terminal
+    case staticPlugin
     case extensionExperience
 }
 

--- a/DynamicIsland/managers/StaticPlugins/StaticPluginManager.swift
+++ b/DynamicIsland/managers/StaticPlugins/StaticPluginManager.swift
@@ -1,0 +1,175 @@
+/*
+ * Atoll (DynamicIsland)
+ * Copyright (C) 2024-2026 Atoll Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+import Combine
+import Foundation
+
+enum StaticPluginManagerError: LocalizedError, Equatable {
+    case replacementConfirmationRequired(String)
+    case pluginNotFound(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .replacementConfirmationRequired(let pluginID):
+            return "A plugin with ID \(pluginID) is already installed. Confirm Replace to continue."
+        case .pluginNotFound(let pluginID):
+            return "The static plugin \(pluginID) is not installed."
+        }
+    }
+}
+
+@MainActor
+final class StaticPluginManager: ObservableObject {
+    typealias ReplaceItem = (_ originalURL: URL, _ newURL: URL) throws -> Void
+
+    static let shared = StaticPluginManager()
+
+    /// 所有通过校验的已安装插件。
+    @Published private(set) var plugins: [InstalledStaticPlugin] = []
+    /// 当前被用户禁用的插件 ID；独立存储以避免修改插件包。
+    @Published private(set) var disabledPluginIDs: Set<String>
+    /// 扫描时发现但无法加载的插件错误。
+    @Published private(set) var discoveryErrors: [String] = []
+
+    private let installationRoot: URL
+    private let userDefaults: UserDefaults
+    private let fileManager: FileManager
+    private let validator: StaticPluginPackageValidator
+    private let replaceItem: ReplaceItem
+    private static let disabledPluginIDsKey = "disabledStaticPluginIDs"
+
+    var enabledPlugins: [InstalledStaticPlugin] {
+        plugins.filter { !disabledPluginIDs.contains($0.id) }
+    }
+
+    init(
+        installationRoot: URL? = nil,
+        userDefaults: UserDefaults = .standard,
+        fileManager: FileManager = .default,
+        replaceItem: ReplaceItem? = nil
+    ) {
+        let resolvedRoot = installationRoot ?? fileManager
+            .urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
+            .appendingPathComponent("DynamicIsland", isDirectory: true)
+            .appendingPathComponent("StaticPlugins", isDirectory: true)
+        self.installationRoot = resolvedRoot
+        self.userDefaults = userDefaults
+        self.fileManager = fileManager
+        self.validator = StaticPluginPackageValidator(fileManager: fileManager)
+        self.disabledPluginIDs = Set(userDefaults.stringArray(forKey: Self.disabledPluginIDsKey) ?? [])
+        self.replaceItem = replaceItem ?? { originalURL, newURL in
+            _ = try fileManager.replaceItemAt(
+                originalURL,
+                withItemAt: newURL,
+                backupItemName: nil,
+                options: []
+            )
+        }
+        reload()
+    }
+
+    /// 重新扫描安装目录；单个坏包不会阻止其他插件加载。
+    func reload() {
+        do {
+            try fileManager.createDirectory(at: installationRoot, withIntermediateDirectories: true)
+            let packageURLs = try fileManager.contentsOfDirectory(
+                at: installationRoot,
+                includingPropertiesForKeys: [.isDirectoryKey],
+                options: [.skipsHiddenFiles]
+            )
+            var loadedPlugins: [InstalledStaticPlugin] = []
+            var errors: [String] = []
+            for packageURL in packageURLs
+                .filter({ $0.pathExtension.lowercased() == "atollplugin" })
+                .sorted(by: { $0.lastPathComponent.localizedStandardCompare($1.lastPathComponent) == .orderedAscending }) {
+                do {
+                    loadedPlugins.append(try validator.validate(packageURL: packageURL))
+                } catch {
+                    errors.append("\(packageURL.lastPathComponent): \(error.localizedDescription)")
+                }
+            }
+            plugins = loadedPlugins.sorted {
+                $0.manifest.name.localizedStandardCompare($1.manifest.name) == .orderedAscending
+            }
+            discoveryErrors = errors
+        } catch {
+            plugins = []
+            discoveryErrors = [error.localizedDescription]
+        }
+    }
+
+    /// 安装新插件；相同 ID 只有在明确确认后才替换。
+    func install(from sourceURL: URL, replacingExisting: Bool) throws {
+        let sourcePlugin = try validator.validate(packageURL: sourceURL)
+        try fileManager.createDirectory(at: installationRoot, withIntermediateDirectories: true)
+        let destinationURL = installedURL(for: sourcePlugin.id)
+        let destinationExists = fileManager.fileExists(atPath: destinationURL.path)
+        if destinationExists && !replacingExisting {
+            throw StaticPluginManagerError.replacementConfirmationRequired(sourcePlugin.id)
+        }
+
+        let stagingParentURL = installationRoot
+            .appendingPathComponent(".staging", isDirectory: true)
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let stagedPackageURL = stagingParentURL
+            .appendingPathComponent("\(sourcePlugin.id).atollplugin", isDirectory: true)
+        try fileManager.createDirectory(at: stagingParentURL, withIntermediateDirectories: true)
+        defer { try? fileManager.removeItem(at: stagingParentURL) }
+
+        try fileManager.copyItem(at: sourceURL, to: stagedPackageURL)
+        _ = try validator.validate(packageURL: stagedPackageURL)
+
+        if destinationExists {
+            try replaceItem(destinationURL, stagedPackageURL)
+        } else {
+            try fileManager.moveItem(at: stagedPackageURL, to: destinationURL)
+        }
+        reload()
+    }
+
+    /// 更新启用状态并立即发布标签页变化。
+    func setEnabled(_ enabled: Bool, pluginID: String) {
+        guard plugins.contains(where: { $0.id == pluginID }) else { return }
+        var updatedIDs = disabledPluginIDs
+        if enabled {
+            updatedIDs.remove(pluginID)
+        } else {
+            updatedIDs.insert(pluginID)
+        }
+        disabledPluginIDs = updatedIDs
+        persistDisabledPluginIDs()
+    }
+
+    /// 返回插件当前是否被用户禁用。
+    func isDisabled(pluginID: String) -> Bool {
+        disabledPluginIDs.contains(pluginID)
+    }
+
+    /// 删除指定插件及其禁用状态。
+    func remove(pluginID: String) throws {
+        guard plugins.contains(where: { $0.id == pluginID }) else {
+            throw StaticPluginManagerError.pluginNotFound(pluginID)
+        }
+        try fileManager.removeItem(at: installedURL(for: pluginID))
+        var updatedIDs = disabledPluginIDs
+        updatedIDs.remove(pluginID)
+        disabledPluginIDs = updatedIDs
+        persistDisabledPluginIDs()
+        reload()
+    }
+
+    private func installedURL(for pluginID: String) -> URL {
+        installationRoot.appendingPathComponent("\(pluginID).atollplugin", isDirectory: true)
+    }
+
+    private func persistDisabledPluginIDs() {
+        userDefaults.set(disabledPluginIDs.sorted(), forKey: Self.disabledPluginIDsKey)
+    }
+}

--- a/DynamicIsland/managers/StaticPlugins/StaticPluginManager.swift
+++ b/DynamicIsland/managers/StaticPlugins/StaticPluginManager.swift
@@ -14,6 +14,8 @@ import Foundation
 enum StaticPluginManagerError: LocalizedError, Equatable {
     case replacementConfirmationRequired(String)
     case pluginNotFound(String)
+    case installedPackageNameMismatch(expected: String, actual: String)
+    case pluginChangedDuringInstall(expectedID: String, actualID: String)
 
     var errorDescription: String? {
         switch self {
@@ -21,6 +23,10 @@ enum StaticPluginManagerError: LocalizedError, Equatable {
             return "A plugin with ID \(pluginID) is already installed. Confirm Replace to continue."
         case .pluginNotFound(let pluginID):
             return "The static plugin \(pluginID) is not installed."
+        case .installedPackageNameMismatch(let expected, let actual):
+            return "Installed plugin package \(actual) must be named \(expected)."
+        case .pluginChangedDuringInstall(let expectedID, let actualID):
+            return "Plugin ID changed from \(expectedID) to \(actualID) while it was being installed."
         }
     }
 }
@@ -37,6 +43,8 @@ final class StaticPluginManager: ObservableObject {
     @Published private(set) var disabledPluginIDs: Set<String>
     /// 扫描时发现但无法加载的插件错误。
     @Published private(set) var discoveryErrors: [String] = []
+    /// 每次重新扫描后递增，使同 ID Replace 也能触发界面和窗口刷新。
+    @Published private(set) var reloadRevision: UInt = 0
 
     private let installationRoot: URL
     private let userDefaults: UserDefaults
@@ -77,6 +85,7 @@ final class StaticPluginManager: ObservableObject {
 
     /// 重新扫描安装目录；单个坏包不会阻止其他插件加载。
     func reload() {
+        defer { reloadRevision &+= 1 }
         do {
             try fileManager.createDirectory(at: installationRoot, withIntermediateDirectories: true)
             let packageURLs = try fileManager.contentsOfDirectory(
@@ -90,7 +99,15 @@ final class StaticPluginManager: ObservableObject {
                 .filter({ $0.pathExtension.lowercased() == "atollplugin" })
                 .sorted(by: { $0.lastPathComponent.localizedStandardCompare($1.lastPathComponent) == .orderedAscending }) {
                 do {
-                    loadedPlugins.append(try validator.validate(packageURL: packageURL))
+                    let plugin = try validator.validate(packageURL: packageURL)
+                    let expectedName = installedPackageName(for: plugin.id)
+                    guard packageURL.lastPathComponent == expectedName else {
+                        throw StaticPluginManagerError.installedPackageNameMismatch(
+                            expected: expectedName,
+                            actual: packageURL.lastPathComponent
+                        )
+                    }
+                    loadedPlugins.append(plugin)
                 } catch {
                     errors.append("\(packageURL.lastPathComponent): \(error.localizedDescription)")
                 }
@@ -124,7 +141,13 @@ final class StaticPluginManager: ObservableObject {
         defer { try? fileManager.removeItem(at: stagingParentURL) }
 
         try fileManager.copyItem(at: sourceURL, to: stagedPackageURL)
-        _ = try validator.validate(packageURL: stagedPackageURL)
+        let stagedPlugin = try validator.validate(packageURL: stagedPackageURL)
+        guard stagedPlugin.id == sourcePlugin.id else {
+            throw StaticPluginManagerError.pluginChangedDuringInstall(
+                expectedID: sourcePlugin.id,
+                actualID: stagedPlugin.id
+            )
+        }
 
         if destinationExists {
             try replaceItem(destinationURL, stagedPackageURL)
@@ -166,7 +189,11 @@ final class StaticPluginManager: ObservableObject {
     }
 
     private func installedURL(for pluginID: String) -> URL {
-        installationRoot.appendingPathComponent("\(pluginID).atollplugin", isDirectory: true)
+        installationRoot.appendingPathComponent(installedPackageName(for: pluginID), isDirectory: true)
+    }
+
+    private func installedPackageName(for pluginID: String) -> String {
+        "\(pluginID).atollplugin"
     }
 
     private func persistDisabledPluginIDs() {

--- a/DynamicIsland/models/DynamicIslandViewModel.swift
+++ b/DynamicIsland/models/DynamicIslandViewModel.swift
@@ -425,7 +425,7 @@ class DynamicIslandViewModel: NSObject, ObservableObject {
             isStaticPluginView: coordinator.currentView == .staticPlugin,
             selectedPluginID: coordinator.selectedStaticPluginID,
             enabledPlugins: StaticPluginManager.shared.enabledPlugins,
-            visibleScreenHeight: NSScreen.main?.visibleFrame.height,
+            visibleScreenHeight: currentScreenVisibleHeight,
             fallbackMaximumHeight: baseSize.height + statsSecondRowContentHeight + statsGridSpacingHeight
         ) {
             return pluginSize
@@ -452,6 +452,11 @@ class DynamicIslandViewModel: NSObject, ObservableObject {
             isStatsTabActive: coordinator.currentView == .stats,
             secondRowProgress: coordinator.statsSecondRowExpansion
         )
+    }
+
+    private var currentScreenVisibleHeight: CGFloat? {
+        NSScreen.screens.first { $0.localizedName == screen }?.visibleFrame.height
+            ?? NSScreen.main?.visibleFrame.height
     }
 
     func close() {

--- a/DynamicIsland/models/DynamicIslandViewModel.swift
+++ b/DynamicIsland/models/DynamicIslandViewModel.swift
@@ -420,6 +420,17 @@ class DynamicIslandViewModel: NSObject, ObservableObject {
         let baseSize = Defaults[.enableMinimalisticUI] ? minimalisticOpenNotchSize(isDynamicIslandMode: shouldUseDynamicIslandMode(for: screen)) : openNotchSize
         var adjustedSize = baseSize
 
+        if let pluginSize = StaticPluginLayout.resolvedSize(
+            baseSize: baseSize,
+            isStaticPluginView: coordinator.currentView == .staticPlugin,
+            selectedPluginID: coordinator.selectedStaticPluginID,
+            enabledPlugins: StaticPluginManager.shared.enabledPlugins,
+            visibleScreenHeight: NSScreen.main?.visibleFrame.height,
+            fallbackMaximumHeight: baseSize.height + statsSecondRowContentHeight + statsGridSpacingHeight
+        ) {
+            return pluginSize
+        }
+
         if coordinator.currentView == .notes || coordinator.currentView == .clipboard {
             let preferred = coordinator.notesLayoutState.preferredHeight
             adjustedSize.height = max(adjustedSize.height, preferred)

--- a/DynamicIsland/models/StaticPlugins/StaticPluginManifest.swift
+++ b/DynamicIsland/models/StaticPlugins/StaticPluginManifest.swift
@@ -25,6 +25,8 @@ struct StaticPluginManifest: Codable, Equatable {
     let tab: StaticPluginTabManifest
     /// 允许用户点击后交给系统浏览器打开的精确 URL。
     let allowedExternalURLs: [String]
+    /// 允许携带动态查询参数的外部 URL 前缀；校验器要求以 `?` 结尾。
+    let allowedExternalURLPrefixes: [String]
 
     init(from decoder: Decoder) throws {
         let values = try decoder.container(keyedBy: CodingKeys.self)
@@ -35,6 +37,10 @@ struct StaticPluginManifest: Codable, Equatable {
         entrypoint = try values.decode(String.self, forKey: .entrypoint)
         tab = try values.decode(StaticPluginTabManifest.self, forKey: .tab)
         allowedExternalURLs = try values.decodeIfPresent([String].self, forKey: .allowedExternalURLs) ?? []
+        allowedExternalURLPrefixes = try values.decodeIfPresent(
+            [String].self,
+            forKey: .allowedExternalURLPrefixes
+        ) ?? []
     }
 }
 
@@ -56,6 +62,8 @@ struct InstalledStaticPlugin: Identifiable, Equatable {
     let entrypointURL: URL
     /// 允许交给系统浏览器处理的精确 URL 集合。
     let allowedExternalURLs: Set<URL>
+    /// 允许交给系统浏览器处理并携带动态查询参数的已校验前缀。
+    let allowedExternalURLPrefixes: Set<String>
 
     var id: String { manifest.id }
 }

--- a/DynamicIsland/models/StaticPlugins/StaticPluginManifest.swift
+++ b/DynamicIsland/models/StaticPlugins/StaticPluginManifest.swift
@@ -59,3 +59,20 @@ struct InstalledStaticPlugin: Identifiable, Equatable {
 
     var id: String { manifest.id }
 }
+
+enum StaticPluginLayout {
+    static let maximumVisibleScreenFraction: CGFloat = 0.7
+
+    /// 将插件请求高度限制在默认刘海高度和当前屏幕安全高度之间。
+    static func resolvedHeight(
+        preferredHeight: CGFloat,
+        baseHeight: CGFloat,
+        visibleScreenHeight: CGFloat?,
+        fallbackMaximumHeight: CGFloat
+    ) -> CGFloat {
+        let maximumHeight = visibleScreenHeight.map {
+            max(baseHeight, $0 * maximumVisibleScreenFraction)
+        } ?? max(baseHeight, fallbackMaximumHeight)
+        return min(max(preferredHeight, baseHeight), maximumHeight)
+    }
+}

--- a/DynamicIsland/models/StaticPlugins/StaticPluginManifest.swift
+++ b/DynamicIsland/models/StaticPlugins/StaticPluginManifest.swift
@@ -63,6 +63,32 @@ struct InstalledStaticPlugin: Identifiable, Equatable {
 enum StaticPluginLayout {
     static let maximumVisibleScreenFraction: CGFloat = 0.7
 
+    /// 仅在静态插件标签选中时返回对应插件的窗口内容尺寸。
+    static func resolvedSize(
+        baseSize: CGSize,
+        isStaticPluginView: Bool,
+        selectedPluginID: String?,
+        enabledPlugins: [InstalledStaticPlugin],
+        visibleScreenHeight: CGFloat?,
+        fallbackMaximumHeight: CGFloat
+    ) -> CGSize? {
+        guard isStaticPluginView,
+              let selectedPluginID,
+              let preferredHeight = enabledPlugins.first(where: { $0.id == selectedPluginID })?
+                .manifest.tab.preferredHeight else {
+            return nil
+        }
+        return CGSize(
+            width: baseSize.width,
+            height: resolvedHeight(
+                preferredHeight: CGFloat(preferredHeight),
+                baseHeight: baseSize.height,
+                visibleScreenHeight: visibleScreenHeight,
+                fallbackMaximumHeight: fallbackMaximumHeight
+            )
+        )
+    }
+
     /// 将插件请求高度限制在默认刘海高度和当前屏幕安全高度之间。
     static func resolvedHeight(
         preferredHeight: CGFloat,

--- a/DynamicIsland/models/StaticPlugins/StaticPluginManifest.swift
+++ b/DynamicIsland/models/StaticPlugins/StaticPluginManifest.swift
@@ -1,0 +1,61 @@
+/*
+ * Atoll (DynamicIsland)
+ * Copyright (C) 2024-2026 Atoll Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+import Foundation
+
+struct StaticPluginManifest: Codable, Equatable {
+    /// 插件格式版本，宿主只加载明确支持的版本。
+    let schemaVersion: Int
+    /// 插件稳定标识，也是安装目录名的来源。
+    let id: String
+    /// 设置页展示名称。
+    let name: String
+    /// 设置页展示版本；v1 不比较版本大小。
+    let version: String
+    /// 包内 HTML 入口的相对路径。
+    let entrypoint: String
+    /// 刘海标签页展示配置。
+    let tab: StaticPluginTabManifest
+    /// 允许用户点击后交给系统浏览器打开的精确 URL。
+    let allowedExternalURLs: [String]
+
+    init(from decoder: Decoder) throws {
+        let values = try decoder.container(keyedBy: CodingKeys.self)
+        schemaVersion = try values.decode(Int.self, forKey: .schemaVersion)
+        id = try values.decode(String.self, forKey: .id)
+        name = try values.decode(String.self, forKey: .name)
+        version = try values.decode(String.self, forKey: .version)
+        entrypoint = try values.decode(String.self, forKey: .entrypoint)
+        tab = try values.decode(StaticPluginTabManifest.self, forKey: .tab)
+        allowedExternalURLs = try values.decodeIfPresent([String].self, forKey: .allowedExternalURLs) ?? []
+    }
+}
+
+struct StaticPluginTabManifest: Codable, Equatable {
+    /// 刘海标签文字。
+    let title: String
+    /// SF Symbols 名称；无效名称由界面回退为默认图标。
+    let icon: String
+    /// 展开内容期望高度，最终由刘海可用范围限制。
+    let preferredHeight: Double?
+}
+
+struct InstalledStaticPlugin: Identifiable, Equatable {
+    /// 已完成校验的插件清单。
+    let manifest: StaticPluginManifest
+    /// 插件可读取的唯一根目录。
+    let rootURL: URL
+    /// 已确认位于根目录内的 HTML 入口。
+    let entrypointURL: URL
+    /// 允许交给系统浏览器处理的精确 URL 集合。
+    let allowedExternalURLs: Set<URL>
+
+    var id: String { manifest.id }
+}

--- a/DynamicIsland/services/StaticPlugins/StaticPluginPackageValidator.swift
+++ b/DynamicIsland/services/StaticPlugins/StaticPluginPackageValidator.swift
@@ -1,0 +1,161 @@
+/*
+ * Atoll (DynamicIsland)
+ * Copyright (C) 2024-2026 Atoll Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+import Foundation
+
+enum StaticPluginValidationError: LocalizedError, Equatable {
+    case notPluginDirectory
+    case symbolicLink(String)
+    case missingManifest
+    case unreadableManifest
+    case unsupportedSchema(Int)
+    case invalidIdentifier
+    case emptyDisplayValue(String)
+    case unsafeEntrypoint
+    case invalidExternalURL(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .notPluginDirectory:
+            return "Select a directory ending in .atollplugin."
+        case .symbolicLink(let path):
+            return "Plugin packages cannot contain symbolic links: \(path)"
+        case .missingManifest:
+            return "The plugin does not contain a regular manifest.json file."
+        case .unreadableManifest:
+            return "The plugin manifest is not valid JSON."
+        case .unsupportedSchema(let version):
+            return "Plugin schema version \(version) is not supported."
+        case .invalidIdentifier:
+            return "The plugin ID must use a reverse-DNS-style value."
+        case .emptyDisplayValue(let field):
+            return "The plugin manifest field \(field) cannot be empty."
+        case .unsafeEntrypoint:
+            return "The plugin entry point must be a regular HTML file inside the package."
+        case .invalidExternalURL(let value):
+            return "External URL is not an absolute HTTP or HTTPS URL: \(value)"
+        }
+    }
+}
+
+struct StaticPluginPackageValidator {
+    private let fileManager: FileManager
+
+    init(fileManager: FileManager = .default) {
+        self.fileManager = fileManager
+    }
+
+    /// 校验未受信任的插件目录，并只返回已完成路径约束检查的数据。
+    func validate(packageURL: URL) throws -> InstalledStaticPlugin {
+        let sourceValues = try? packageURL.resourceValues(forKeys: [.isDirectoryKey, .isSymbolicLinkKey])
+        guard packageURL.pathExtension.lowercased() == "atollplugin",
+              sourceValues?.isDirectory == true else {
+            throw StaticPluginValidationError.notPluginDirectory
+        }
+        if sourceValues?.isSymbolicLink == true {
+            throw StaticPluginValidationError.symbolicLink(packageURL.lastPathComponent)
+        }
+
+        try rejectSymbolicLinks(in: packageURL)
+        let rootURL = packageURL.standardizedFileURL.resolvingSymlinksInPath()
+        let manifestURL = rootURL.appendingPathComponent("manifest.json")
+        guard isRegularFile(manifestURL) else {
+            throw StaticPluginValidationError.missingManifest
+        }
+
+        let manifest: StaticPluginManifest
+        do {
+            manifest = try JSONDecoder().decode(
+                StaticPluginManifest.self,
+                from: Data(contentsOf: manifestURL)
+            )
+        } catch {
+            throw StaticPluginValidationError.unreadableManifest
+        }
+
+        guard manifest.schemaVersion == 1 else {
+            throw StaticPluginValidationError.unsupportedSchema(manifest.schemaVersion)
+        }
+        guard isValidIdentifier(manifest.id) else {
+            throw StaticPluginValidationError.invalidIdentifier
+        }
+        try requireDisplayValue(manifest.name, field: "name")
+        try requireDisplayValue(manifest.version, field: "version")
+        try requireDisplayValue(manifest.tab.title, field: "tab.title")
+
+        let entrypointURL = rootURL
+            .appendingPathComponent(manifest.entrypoint)
+            .standardizedFileURL
+              .resolvingSymlinksInPath()
+        guard entrypointURL.pathExtension.lowercased() == "html",
+              isContained(entrypointURL, by: rootURL),
+              isRegularFile(entrypointURL) else {
+            throw StaticPluginValidationError.unsafeEntrypoint
+        }
+
+        let externalURLs = try Set(manifest.allowedExternalURLs.map(validateExternalURL))
+        return InstalledStaticPlugin(
+            manifest: manifest,
+            rootURL: rootURL,
+            entrypointURL: entrypointURL,
+            allowedExternalURLs: externalURLs
+        )
+    }
+
+    private func rejectSymbolicLinks(in rootURL: URL) throws {
+        guard let enumerator = fileManager.enumerator(
+            at: rootURL,
+            includingPropertiesForKeys: [.isSymbolicLinkKey],
+            options: []
+        ) else {
+            throw StaticPluginValidationError.notPluginDirectory
+        }
+        for case let itemURL as URL in enumerator {
+            if try itemURL.resourceValues(forKeys: [.isSymbolicLinkKey]).isSymbolicLink == true {
+                throw StaticPluginValidationError.symbolicLink(itemURL.lastPathComponent)
+            }
+        }
+    }
+
+    private func isRegularFile(_ url: URL) -> Bool {
+        (try? url.resourceValues(forKeys: [.isRegularFileKey]).isRegularFile) == true
+    }
+
+    private func isValidIdentifier(_ identifier: String) -> Bool {
+        let segments = identifier.split(separator: ".", omittingEmptySubsequences: false)
+        guard segments.count >= 2 else { return false }
+        return segments.allSatisfy { segment in
+            segment.range(
+                of: #"^[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?$"#,
+                options: .regularExpression
+            ) != nil
+        }
+    }
+
+    private func requireDisplayValue(_ value: String, field: String) throws {
+        guard !value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw StaticPluginValidationError.emptyDisplayValue(field)
+        }
+    }
+
+    private func validateExternalURL(_ value: String) throws -> URL {
+        guard let url = URL(string: value),
+              let scheme = url.scheme?.lowercased(),
+              ["http", "https"].contains(scheme),
+              url.host != nil else {
+            throw StaticPluginValidationError.invalidExternalURL(value)
+        }
+        return url
+    }
+
+    private func isContained(_ candidateURL: URL, by rootURL: URL) -> Bool {
+        candidateURL.path == rootURL.path || candidateURL.path.hasPrefix(rootURL.path + "/")
+    }
+}

--- a/DynamicIsland/services/StaticPlugins/StaticPluginPackageValidator.swift
+++ b/DynamicIsland/services/StaticPlugins/StaticPluginPackageValidator.swift
@@ -20,6 +20,7 @@ enum StaticPluginValidationError: LocalizedError, Equatable {
     case emptyDisplayValue(String)
     case unsafeEntrypoint
     case invalidExternalURL(String)
+    case invalidExternalURLPrefix(String)
 
     var errorDescription: String? {
         switch self {
@@ -41,6 +42,8 @@ enum StaticPluginValidationError: LocalizedError, Equatable {
             return "The plugin entry point must be a regular HTML file inside the package."
         case .invalidExternalURL(let value):
             return "External URL is not an absolute HTTP or HTTPS URL: \(value)"
+        case .invalidExternalURLPrefix(let value):
+            return "External URL prefix must be an absolute HTTP or HTTPS URL ending in ?: \(value)"
         }
     }
 }
@@ -101,11 +104,15 @@ struct StaticPluginPackageValidator {
         }
 
         let externalURLs = try Set(manifest.allowedExternalURLs.map(validateExternalURL))
+        let externalURLPrefixes = try Set(
+            manifest.allowedExternalURLPrefixes.map(validateExternalURLPrefix)
+        )
         return InstalledStaticPlugin(
             manifest: manifest,
             rootURL: rootURL,
             entrypointURL: entrypointURL,
-            allowedExternalURLs: externalURLs
+            allowedExternalURLs: externalURLs,
+            allowedExternalURLPrefixes: externalURLPrefixes
         )
     }
 
@@ -153,6 +160,22 @@ struct StaticPluginPackageValidator {
             throw StaticPluginValidationError.invalidExternalURL(value)
         }
         return url
+    }
+
+    /// 动态 URL 前缀必须在查询分隔符处结束，避免主机名或路径的文本前缀误匹配。
+    private func validateExternalURLPrefix(_ value: String) throws -> String {
+        guard value.hasSuffix("?"),
+              value == value.trimmingCharacters(in: .whitespacesAndNewlines),
+              let url = URL(string: value),
+              let scheme = url.scheme?.lowercased(),
+              ["http", "https"].contains(scheme),
+              url.host != nil,
+              url.user == nil,
+              url.password == nil,
+              url.fragment == nil else {
+            throw StaticPluginValidationError.invalidExternalURLPrefix(value)
+        }
+        return value
     }
 
     private func isContained(_ candidateURL: URL, by rootURL: URL) -> Bool {

--- a/DynamicIslandTests/StaticPluginManagerTests.swift
+++ b/DynamicIslandTests/StaticPluginManagerTests.swift
@@ -18,6 +18,15 @@ final class StaticPluginManagerTests: XCTestCase {
         case failed
     }
 
+    private final class MutatingCopyFileManager: FileManager {
+        var mutateCopiedPackage: ((URL) throws -> Void)?
+
+        override func copyItem(at srcURL: URL, to dstURL: URL) throws {
+            try super.copyItem(at: srcURL, to: dstURL)
+            try mutateCopiedPackage?(dstURL)
+        }
+    }
+
     private var rootURL: URL!
     private var installationRootURL: URL!
     private var defaults: UserDefaults!
@@ -78,17 +87,55 @@ final class StaticPluginManagerTests: XCTestCase {
         XCTAssertTrue(reloadedManager.enabledPlugins.isEmpty)
     }
 
-    func testInvalidReplacementKeepsOldVersion() throws {
-        let manager = makeManager()
+    func testInvalidStagedReplacementKeepsOldVersion() throws {
+        let fileManager = MutatingCopyFileManager()
+        let manager = makeManager(fileManager: fileManager)
         try manager.install(from: makePackage(version: "1.0.0"), replacingExisting: false)
 
-        XCTAssertThrowsError(
-            try manager.install(
-                from: makePackage(version: "2.0.0", entrypoint: "missing.html", writesEntrypoint: false),
-                replacingExisting: true
+        fileManager.mutateCopiedPackage = { stagedPackageURL in
+            try FileManager.default.removeItem(
+                at: stagedPackageURL.appendingPathComponent("index.html")
             )
-        )
+        }
 
+        XCTAssertThrowsError(
+            try manager.install(from: makePackage(version: "2.0.0"), replacingExisting: true)
+        ) { error in
+            XCTAssertEqual(error as? StaticPluginValidationError, .unsafeEntrypoint)
+        }
+
+        fileManager.mutateCopiedPackage = nil
+        manager.reload()
+        XCTAssertEqual(manager.plugins.first?.manifest.version, "1.0.0")
+    }
+
+    func testStagedPluginIDChangeKeepsOldVersion() throws {
+        let fileManager = MutatingCopyFileManager()
+        let manager = makeManager(fileManager: fileManager)
+        try manager.install(from: makePackage(version: "1.0.0"), replacingExisting: false)
+
+        fileManager.mutateCopiedPackage = { stagedPackageURL in
+            let manifestURL = stagedPackageURL.appendingPathComponent("manifest.json")
+            var manifest = try XCTUnwrap(
+                JSONSerialization.jsonObject(with: Data(contentsOf: manifestURL)) as? [String: Any]
+            )
+            manifest["id"] = "com.example.changed"
+            try JSONSerialization.data(withJSONObject: manifest).write(to: manifestURL)
+        }
+
+        XCTAssertThrowsError(
+            try manager.install(from: makePackage(version: "2.0.0"), replacingExisting: true)
+        ) { error in
+            XCTAssertEqual(
+                error as? StaticPluginManagerError,
+                .pluginChangedDuringInstall(
+                    expectedID: "com.example.tools",
+                    actualID: "com.example.changed"
+                )
+            )
+        }
+
+        fileManager.mutateCopiedPackage = nil
         manager.reload()
         XCTAssertEqual(manager.plugins.first?.manifest.version, "1.0.0")
     }
@@ -130,12 +177,36 @@ final class StaticPluginManagerTests: XCTestCase {
         XCTAssertEqual(manager.discoveryErrors.count, 1)
     }
 
+    func testReloadRejectsPackageWhoseDirectoryDoesNotMatchPluginID() throws {
+        let manager = makeManager()
+        let mismatchedURL = installationRootURL
+            .appendingPathComponent("wrong-name.atollplugin", isDirectory: true)
+        try FileManager.default.copyItem(at: makePackage(), to: mismatchedURL)
+
+        manager.reload()
+
+        XCTAssertTrue(manager.plugins.isEmpty)
+        XCTAssertEqual(manager.discoveryErrors.count, 1)
+    }
+
+    func testReloadRevisionChangesForSameIDReplacement() throws {
+        let manager = makeManager()
+        try manager.install(from: makePackage(), replacingExisting: false)
+        let installedRevision = manager.reloadRevision
+
+        try manager.install(from: makePackage(), replacingExisting: true)
+
+        XCTAssertGreaterThan(manager.reloadRevision, installedRevision)
+    }
+
     private func makeManager(
+        fileManager: FileManager = .default,
         replaceItem: StaticPluginManager.ReplaceItem? = nil
     ) -> StaticPluginManager {
         StaticPluginManager(
             installationRoot: installationRootURL,
             userDefaults: defaults,
+            fileManager: fileManager,
             replaceItem: replaceItem
         )
     }

--- a/DynamicIslandTests/StaticPluginManagerTests.swift
+++ b/DynamicIslandTests/StaticPluginManagerTests.swift
@@ -1,0 +1,169 @@
+/*
+ * Atoll (DynamicIsland)
+ * Copyright (C) 2024-2026 Atoll Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+import XCTest
+
+@testable import Atoll
+
+@MainActor
+final class StaticPluginManagerTests: XCTestCase {
+    private enum TestReplacementError: Error {
+        case failed
+    }
+
+    private var rootURL: URL!
+    private var installationRootURL: URL!
+    private var defaults: UserDefaults!
+    private var defaultsSuiteName: String!
+
+    override func setUpWithError() throws {
+        rootURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        installationRootURL = rootURL.appendingPathComponent("Installed", isDirectory: true)
+        try FileManager.default.createDirectory(at: rootURL, withIntermediateDirectories: true)
+        defaultsSuiteName = "StaticPluginManagerTests.\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: defaultsSuiteName)
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(at: rootURL)
+        defaults.removePersistentDomain(forName: defaultsSuiteName)
+        defaults = nil
+        defaultsSuiteName = nil
+        installationRootURL = nil
+        rootURL = nil
+    }
+
+    func testNewPluginIsInstalledAndDiscovered() throws {
+        let manager = makeManager()
+
+        try manager.install(from: makePackage(version: "1.0.0"), replacingExisting: false)
+
+        XCTAssertEqual(manager.plugins.map(\.id), ["com.example.tools"])
+        XCTAssertEqual(manager.enabledPlugins.map(\.id), ["com.example.tools"])
+        XCTAssertEqual(manager.plugins.first?.manifest.version, "1.0.0")
+    }
+
+    func testSameIDRequiresReplaceAndPreservesDisabledState() throws {
+        let manager = makeManager()
+        try manager.install(from: makePackage(version: "1.0.0"), replacingExisting: false)
+        manager.setEnabled(false, pluginID: "com.example.tools")
+
+        XCTAssertThrowsError(
+            try manager.install(from: makePackage(version: "2.0.0"), replacingExisting: false)
+        )
+
+        try manager.install(from: makePackage(version: "2.0.0"), replacingExisting: true)
+
+        XCTAssertEqual(manager.plugins.first?.manifest.version, "2.0.0")
+        XCTAssertTrue(manager.enabledPlugins.isEmpty)
+        XCTAssertTrue(manager.isDisabled(pluginID: "com.example.tools"))
+    }
+
+    func testDisabledStatePersistsAcrossManagerInstances() throws {
+        let manager = makeManager()
+        try manager.install(from: makePackage(), replacingExisting: false)
+        manager.setEnabled(false, pluginID: "com.example.tools")
+
+        let reloadedManager = makeManager()
+
+        XCTAssertTrue(reloadedManager.isDisabled(pluginID: "com.example.tools"))
+        XCTAssertTrue(reloadedManager.enabledPlugins.isEmpty)
+    }
+
+    func testInvalidReplacementKeepsOldVersion() throws {
+        let manager = makeManager()
+        try manager.install(from: makePackage(version: "1.0.0"), replacingExisting: false)
+
+        XCTAssertThrowsError(
+            try manager.install(
+                from: makePackage(version: "2.0.0", entrypoint: "missing.html", writesEntrypoint: false),
+                replacingExisting: true
+            )
+        )
+
+        manager.reload()
+        XCTAssertEqual(manager.plugins.first?.manifest.version, "1.0.0")
+    }
+
+    func testFileReplacementFailureKeepsOldVersion() throws {
+        let manager = makeManager { _, _ in
+            throw TestReplacementError.failed
+        }
+        try manager.install(from: makePackage(version: "1.0.0"), replacingExisting: false)
+
+        XCTAssertThrowsError(
+            try manager.install(from: makePackage(version: "2.0.0"), replacingExisting: true)
+        )
+
+        manager.reload()
+        XCTAssertEqual(manager.plugins.first?.manifest.version, "1.0.0")
+    }
+
+    func testRemoveClearsPackageAndDisabledState() throws {
+        let manager = makeManager()
+        try manager.install(from: makePackage(), replacingExisting: false)
+        manager.setEnabled(false, pluginID: "com.example.tools")
+
+        try manager.remove(pluginID: "com.example.tools")
+
+        XCTAssertTrue(manager.plugins.isEmpty)
+        XCTAssertFalse(manager.isDisabled(pluginID: "com.example.tools"))
+    }
+
+    func testReloadKeepsValidPluginsWhenAnotherPackageIsInvalid() throws {
+        let manager = makeManager()
+        try manager.install(from: makePackage(), replacingExisting: false)
+        let invalidURL = installationRootURL.appendingPathComponent("broken.atollplugin", isDirectory: true)
+        try FileManager.default.createDirectory(at: invalidURL, withIntermediateDirectories: true)
+
+        manager.reload()
+
+        XCTAssertEqual(manager.plugins.map(\.id), ["com.example.tools"])
+        XCTAssertEqual(manager.discoveryErrors.count, 1)
+    }
+
+    private func makeManager(
+        replaceItem: StaticPluginManager.ReplaceItem? = nil
+    ) -> StaticPluginManager {
+        StaticPluginManager(
+            installationRoot: installationRootURL,
+            userDefaults: defaults,
+            replaceItem: replaceItem
+        )
+    }
+
+    private func makePackage(
+        version: String = "1.0.0",
+        entrypoint: String = "index.html",
+        writesEntrypoint: Bool = true
+    ) throws -> URL {
+        let packageURL = rootURL
+            .appendingPathComponent("Sources", isDirectory: true)
+            .appendingPathComponent("\(UUID().uuidString).atollplugin", isDirectory: true)
+        try FileManager.default.createDirectory(at: packageURL, withIntermediateDirectories: true)
+        let manifest: [String: Any] = [
+            "schemaVersion": 1,
+            "id": "com.example.tools",
+            "name": "Tools",
+            "version": version,
+            "entrypoint": entrypoint,
+            "tab": ["title": "Tools", "icon": "wrench.and.screwdriver"],
+            "allowedExternalURLs": []
+        ]
+        try JSONSerialization.data(withJSONObject: manifest)
+            .write(to: packageURL.appendingPathComponent("manifest.json"))
+        if writesEntrypoint {
+            try Data("<html></html>".utf8)
+                .write(to: packageURL.appendingPathComponent("index.html"))
+        }
+        return packageURL
+    }
+}

--- a/DynamicIslandTests/StaticPluginNavigationPolicyTests.swift
+++ b/DynamicIslandTests/StaticPluginNavigationPolicyTests.swift
@@ -21,6 +21,7 @@ final class StaticPluginNavigationPolicyTests: XCTestCase {
 
     private let rootURL = URL(fileURLWithPath: "/tmp/Tools.atollplugin", isDirectory: true)
     private let allowedURL = URL(string: "https://geojson.io/")!
+    private let allowedPrefix = "https://uri.amap.com/marker?"
 
     func testLocalFileInsidePluginRootIsAllowed() {
         let policy = makePolicy()
@@ -60,11 +61,56 @@ final class StaticPluginNavigationPolicyTests: XCTestCase {
         )
     }
 
+    func testAllowlistedQueryPrefixUserClickOpensExternally() {
+        let target = URL(
+            string: "https://uri.amap.com/marker?position=116.403372,39.924912&coordinate=gaode"
+        )!
+
+        XCTAssertEqual(
+            makePolicy(allowedExternalURLPrefixes: [allowedPrefix]).decision(
+                for: target,
+                userActivated: true,
+                mainFrame: true
+            ),
+            .openExternally(target)
+        )
+    }
+
+    func testQueryPrefixDoesNotPermitAnotherHostOrPath() {
+        let policy = makePolicy(allowedExternalURLPrefixes: [allowedPrefix])
+
+        for value in [
+            "https://uri.amap.com.evil/marker?position=116,39",
+            "https://uri.amap.com/marker-extra?position=116,39",
+            "https://uri.amap.com/other?position=116,39"
+        ] {
+            XCTAssertEqual(
+                policy.decision(
+                    for: URL(string: value)!,
+                    userActivated: true,
+                    mainFrame: true
+                ),
+                .cancel
+            )
+        }
+    }
+
     func testScriptedAndPopupNavigationAreCancelled() {
         let policy = makePolicy()
 
         XCTAssertEqual(policy.decision(for: allowedURL, userActivated: false, mainFrame: true), .cancel)
         XCTAssertEqual(policy.decision(for: allowedURL, userActivated: true, mainFrame: false), .cancel)
+
+        let prefixedURL = URL(string: "https://uri.amap.com/marker?position=116,39")!
+        let prefixPolicy = makePolicy(allowedExternalURLPrefixes: [allowedPrefix])
+        XCTAssertEqual(
+            prefixPolicy.decision(for: prefixedURL, userActivated: false, mainFrame: true),
+            .cancel
+        )
+        XCTAssertEqual(
+            prefixPolicy.decision(for: prefixedURL, userActivated: true, mainFrame: false),
+            .cancel
+        )
     }
 
     func testUndeclaredAndNonHTTPURLsAreCancelled() {
@@ -115,10 +161,13 @@ final class StaticPluginNavigationPolicyTests: XCTestCase {
         XCTAssertNil(loadingError)
     }
 
-    private func makePolicy() -> StaticPluginNavigationPolicy {
+    private func makePolicy(
+        allowedExternalURLPrefixes: Set<String> = []
+    ) -> StaticPluginNavigationPolicy {
         StaticPluginNavigationPolicy(
             pluginRoot: rootURL,
-            allowedExternalURLs: [allowedURL]
+            allowedExternalURLs: [allowedURL],
+            allowedExternalURLPrefixes: allowedExternalURLPrefixes
         )
     }
 
@@ -137,7 +186,8 @@ final class StaticPluginNavigationPolicyTests: XCTestCase {
                     "title": "Tools",
                     "icon": "wrench.and.screwdriver"
                   },
-                  "allowedExternalURLs": []
+                  "allowedExternalURLs": [],
+                  "allowedExternalURLPrefixes": []
                 }
                 """.utf8
             )
@@ -146,7 +196,8 @@ final class StaticPluginNavigationPolicyTests: XCTestCase {
             manifest: manifest,
             rootURL: rootURL,
             entrypointURL: rootURL.appendingPathComponent("index.html"),
-            allowedExternalURLs: []
+            allowedExternalURLs: [],
+            allowedExternalURLPrefixes: []
         )
     }
 }

--- a/DynamicIslandTests/StaticPluginNavigationPolicyTests.swift
+++ b/DynamicIslandTests/StaticPluginNavigationPolicyTests.swift
@@ -8,11 +8,17 @@
  * (at your option) any later version.
  */
 
+import SwiftUI
+import WebKit
 import XCTest
 
 @testable import Atoll
 
 final class StaticPluginNavigationPolicyTests: XCTestCase {
+    private struct IgnoringExternalOpener: StaticPluginExternalOpening {
+        func open(_ url: URL) {}
+    }
+
     private let rootURL = URL(fileURLWithPath: "/tmp/Tools.atollplugin", isDirectory: true)
     private let allowedURL = URL(string: "https://geojson.io/")!
 
@@ -81,16 +87,66 @@ final class StaticPluginNavigationPolicyTests: XCTestCase {
     func testContentRulesBlockHTTPAndWebSocketLoads() throws {
         let data = try XCTUnwrap(StaticPluginWebView.networkBlockingRules.data(using: .utf8))
         let rules = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [[String: Any]])
+        let filters = rules.compactMap {
+            ($0["trigger"] as? [String: Any])?["url-filter"] as? String
+        }
+        let actions = rules.compactMap {
+            ($0["action"] as? [String: Any])?["type"] as? String
+        }
 
         XCTAssertEqual(rules.count, 2)
-        XCTAssertTrue(StaticPluginWebView.networkBlockingRules.contains("^https?://"))
-        XCTAssertTrue(StaticPluginWebView.networkBlockingRules.contains("^wss?://"))
+        XCTAssertEqual(Set(filters), ["^https?://.*", "^wss?://.*"])
+        XCTAssertEqual(actions, ["block", "block"])
+    }
+
+    func testSuccessfulNavigationClearsPreviousLoadingError() throws {
+        var loadingError: String? = "Previous load failed"
+        let coordinator = StaticPluginWebRepresentable.Coordinator(
+            plugin: try makePlugin(),
+            loadingError: Binding(
+                get: { loadingError },
+                set: { loadingError = $0 }
+            ),
+            externalOpener: IgnoringExternalOpener()
+        )
+
+        coordinator.webView(WKWebView(), didFinish: nil)
+
+        XCTAssertNil(loadingError)
     }
 
     private func makePolicy() -> StaticPluginNavigationPolicy {
         StaticPluginNavigationPolicy(
             pluginRoot: rootURL,
             allowedExternalURLs: [allowedURL]
+        )
+    }
+
+    private func makePlugin() throws -> InstalledStaticPlugin {
+        let manifest = try JSONDecoder().decode(
+            StaticPluginManifest.self,
+            from: Data(
+                """
+                {
+                  "schemaVersion": 1,
+                  "id": "com.example.tools",
+                  "name": "Tools",
+                  "version": "1.0.0",
+                  "entrypoint": "index.html",
+                  "tab": {
+                    "title": "Tools",
+                    "icon": "wrench.and.screwdriver"
+                  },
+                  "allowedExternalURLs": []
+                }
+                """.utf8
+            )
+        )
+        return InstalledStaticPlugin(
+            manifest: manifest,
+            rootURL: rootURL,
+            entrypointURL: rootURL.appendingPathComponent("index.html"),
+            allowedExternalURLs: []
         )
     }
 }

--- a/DynamicIslandTests/StaticPluginNavigationPolicyTests.swift
+++ b/DynamicIslandTests/StaticPluginNavigationPolicyTests.swift
@@ -47,6 +47,13 @@ final class StaticPluginNavigationPolicyTests: XCTestCase {
         )
     }
 
+    func testAllowlistedUserClickWithoutTargetFrameOpensExternally() {
+        XCTAssertEqual(
+            makePolicy().decision(for: allowedURL, userActivated: true, mainFrame: nil),
+            .openExternally(allowedURL)
+        )
+    }
+
     func testScriptedAndPopupNavigationAreCancelled() {
         let policy = makePolicy()
 

--- a/DynamicIslandTests/StaticPluginNavigationPolicyTests.swift
+++ b/DynamicIslandTests/StaticPluginNavigationPolicyTests.swift
@@ -1,0 +1,89 @@
+/*
+ * Atoll (DynamicIsland)
+ * Copyright (C) 2024-2026 Atoll Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+import XCTest
+
+@testable import Atoll
+
+final class StaticPluginNavigationPolicyTests: XCTestCase {
+    private let rootURL = URL(fileURLWithPath: "/tmp/Tools.atollplugin", isDirectory: true)
+    private let allowedURL = URL(string: "https://geojson.io/")!
+
+    func testLocalFileInsidePluginRootIsAllowed() {
+        let policy = makePolicy()
+
+        XCTAssertEqual(
+            policy.decision(
+                for: rootURL.appendingPathComponent("assets/app.js"),
+                userActivated: false,
+                mainFrame: true
+            ),
+            .allow
+        )
+    }
+
+    func testLocalFileOutsidePluginRootIsCancelled() {
+        XCTAssertEqual(
+            makePolicy().decision(
+                for: URL(fileURLWithPath: "/tmp/private.txt"),
+                userActivated: true,
+                mainFrame: true
+            ),
+            .cancel
+        )
+    }
+
+    func testExactAllowlistedUserClickOpensExternally() {
+        XCTAssertEqual(
+            makePolicy().decision(for: allowedURL, userActivated: true, mainFrame: true),
+            .openExternally(allowedURL)
+        )
+    }
+
+    func testScriptedAndPopupNavigationAreCancelled() {
+        let policy = makePolicy()
+
+        XCTAssertEqual(policy.decision(for: allowedURL, userActivated: false, mainFrame: true), .cancel)
+        XCTAssertEqual(policy.decision(for: allowedURL, userActivated: true, mainFrame: false), .cancel)
+    }
+
+    func testUndeclaredAndNonHTTPURLsAreCancelled() {
+        let policy = makePolicy()
+
+        XCTAssertEqual(
+            policy.decision(for: URL(string: "https://example.com/")!, userActivated: true, mainFrame: true),
+            .cancel
+        )
+        XCTAssertEqual(
+            policy.decision(for: URL(string: "https://geojson.io/?changed=true")!, userActivated: true, mainFrame: true),
+            .cancel
+        )
+        XCTAssertEqual(
+            policy.decision(for: URL(string: "mailto:test@example.com")!, userActivated: true, mainFrame: true),
+            .cancel
+        )
+    }
+
+    func testContentRulesBlockHTTPAndWebSocketLoads() throws {
+        let data = try XCTUnwrap(StaticPluginWebView.networkBlockingRules.data(using: .utf8))
+        let rules = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [[String: Any]])
+
+        XCTAssertEqual(rules.count, 2)
+        XCTAssertTrue(StaticPluginWebView.networkBlockingRules.contains("^https?://"))
+        XCTAssertTrue(StaticPluginWebView.networkBlockingRules.contains("^wss?://"))
+    }
+
+    private func makePolicy() -> StaticPluginNavigationPolicy {
+        StaticPluginNavigationPolicy(
+            pluginRoot: rootURL,
+            allowedExternalURLs: [allowedURL]
+        )
+    }
+}

--- a/DynamicIslandTests/StaticPluginPackageValidatorTests.swift
+++ b/DynamicIslandTests/StaticPluginPackageValidatorTests.swift
@@ -114,6 +114,37 @@ final class StaticPluginPackageValidatorTests: XCTestCase {
 }
 
 final class StaticPluginLayoutTests: XCTestCase {
+    func testResolvesSelectedStaticPluginSizeForWindowSizing() throws {
+        let plugin = try makePlugin(id: "com.example.tools", preferredHeight: 460)
+
+        XCTAssertEqual(
+            StaticPluginLayout.resolvedSize(
+                baseSize: CGSize(width: 640, height: 200),
+                isStaticPluginView: true,
+                selectedPluginID: plugin.id,
+                enabledPlugins: [plugin],
+                visibleScreenHeight: 900,
+                fallbackMaximumHeight: 332
+            ),
+            CGSize(width: 640, height: 460)
+        )
+    }
+
+    func testDoesNotResolveSizeOutsideStaticPluginView() throws {
+        let plugin = try makePlugin(id: "com.example.tools", preferredHeight: 460)
+
+        XCTAssertNil(
+            StaticPluginLayout.resolvedSize(
+                baseSize: CGSize(width: 640, height: 200),
+                isStaticPluginView: false,
+                selectedPluginID: plugin.id,
+                enabledPlugins: [plugin],
+                visibleScreenHeight: 900,
+                fallbackMaximumHeight: 332
+            )
+        )
+    }
+
     func testUsesRequestedHeightWhenItFitsScreen() {
         XCTAssertEqual(
             StaticPluginLayout.resolvedHeight(
@@ -159,6 +190,34 @@ final class StaticPluginLayoutTests: XCTestCase {
                 fallbackMaximumHeight: 332
             ),
             332
+        )
+    }
+
+    private func makePlugin(id: String, preferredHeight: Double) throws -> InstalledStaticPlugin {
+        let manifestData = Data(
+            """
+            {
+              "schemaVersion": 1,
+              "id": "\(id)",
+              "name": "Tools",
+              "version": "1.0.0",
+              "entrypoint": "index.html",
+              "tab": {
+                "title": "Tools",
+                "icon": "wrench.and.screwdriver",
+                "preferredHeight": \(preferredHeight)
+              },
+              "allowedExternalURLs": []
+            }
+            """.utf8
+        )
+        let manifest = try JSONDecoder().decode(StaticPluginManifest.self, from: manifestData)
+        let rootURL = URL(fileURLWithPath: "/tmp/\(id).atollplugin", isDirectory: true)
+        return InstalledStaticPlugin(
+            manifest: manifest,
+            rootURL: rootURL,
+            entrypointURL: rootURL.appendingPathComponent("index.html"),
+            allowedExternalURLs: []
         )
     }
 }

--- a/DynamicIslandTests/StaticPluginPackageValidatorTests.swift
+++ b/DynamicIslandTests/StaticPluginPackageValidatorTests.swift
@@ -33,12 +33,16 @@ final class StaticPluginPackageValidatorTests: XCTestCase {
         XCTAssertEqual(plugin.id, "com.example.tools")
         XCTAssertEqual(plugin.entrypointURL.lastPathComponent, "index.html")
         XCTAssertEqual(plugin.allowedExternalURLs, [URL(string: "https://geojson.io/")!])
+        XCTAssertEqual(plugin.allowedExternalURLPrefixes, ["https://uri.amap.com/marker?"])
     }
 
-    func testMissingExternalURLListDefaultsToEmpty() throws {
-        let plugin = try validator.validate(packageURL: makePackage(allowedURLs: nil))
+    func testMissingExternalURLListsDefaultToEmpty() throws {
+        let plugin = try validator.validate(
+            packageURL: makePackage(allowedURLs: nil, allowedURLPrefixes: nil)
+        )
 
         XCTAssertTrue(plugin.allowedExternalURLs.isEmpty)
+        XCTAssertTrue(plugin.allowedExternalURLPrefixes.isEmpty)
     }
 
     func testUnsupportedSchemaIsRejected() throws {
@@ -85,6 +89,16 @@ final class StaticPluginPackageValidatorTests: XCTestCase {
         }
     }
 
+    func testExternalURLPrefixWithoutQueryDelimiterIsRejected() throws {
+        assertThrows(.invalidExternalURLPrefix("https://uri.amap.com/marker")) {
+            _ = try validator.validate(
+                packageURL: makePackage(
+                    allowedURLPrefixes: ["https://uri.amap.com/marker"]
+                )
+            )
+        }
+    }
+
     func testEmptyDisplayValueIsRejected() throws {
         assertThrows(.emptyDisplayValue("name")) {
             _ = try validator.validate(packageURL: makePackage(name: "  "))
@@ -114,7 +128,8 @@ final class StaticPluginPackageValidatorTests: XCTestCase {
         version: String = "1.0.0",
         schemaVersion: Int = 1,
         entrypoint: String = "index.html",
-        allowedURLs: [String]? = ["https://geojson.io/"]
+        allowedURLs: [String]? = ["https://geojson.io/"],
+        allowedURLPrefixes: [String]? = ["https://uri.amap.com/marker?"]
     ) throws -> URL {
         let packageURL = rootURL.appendingPathComponent("Tools.atollplugin", isDirectory: true)
         try FileManager.default.createDirectory(at: packageURL, withIntermediateDirectories: true)
@@ -133,6 +148,9 @@ final class StaticPluginPackageValidatorTests: XCTestCase {
         ]
         if let allowedURLs {
             manifest["allowedExternalURLs"] = allowedURLs
+        }
+        if let allowedURLPrefixes {
+            manifest["allowedExternalURLPrefixes"] = allowedURLPrefixes
         }
 
         let manifestData = try JSONSerialization.data(withJSONObject: manifest, options: [.prettyPrinted])
@@ -236,7 +254,8 @@ final class StaticPluginLayoutTests: XCTestCase {
                 "icon": "wrench.and.screwdriver",
                 "preferredHeight": \(preferredHeight)
               },
-              "allowedExternalURLs": []
+              "allowedExternalURLs": [],
+              "allowedExternalURLPrefixes": []
             }
             """.utf8
         )
@@ -246,7 +265,8 @@ final class StaticPluginLayoutTests: XCTestCase {
             manifest: manifest,
             rootURL: rootURL,
             entrypointURL: rootURL.appendingPathComponent("index.html"),
-            allowedExternalURLs: []
+            allowedExternalURLs: [],
+            allowedExternalURLPrefixes: []
         )
     }
 }

--- a/DynamicIslandTests/StaticPluginPackageValidatorTests.swift
+++ b/DynamicIslandTests/StaticPluginPackageValidatorTests.swift
@@ -1,0 +1,114 @@
+/*
+ * Atoll (DynamicIsland)
+ * Copyright (C) 2024-2026 Atoll Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+import XCTest
+
+@testable import Atoll
+
+final class StaticPluginPackageValidatorTests: XCTestCase {
+    private var rootURL: URL!
+    private let validator = StaticPluginPackageValidator()
+
+    override func setUpWithError() throws {
+        rootURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: rootURL, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(at: rootURL)
+        rootURL = nil
+    }
+
+    func testValidPackageProducesPlugin() throws {
+        let plugin = try validator.validate(packageURL: makePackage())
+
+        XCTAssertEqual(plugin.id, "com.example.tools")
+        XCTAssertEqual(plugin.entrypointURL.lastPathComponent, "index.html")
+        XCTAssertEqual(plugin.allowedExternalURLs, [URL(string: "https://geojson.io/")!])
+    }
+
+    func testMissingExternalURLListDefaultsToEmpty() throws {
+        let plugin = try validator.validate(packageURL: makePackage(allowedURLs: nil))
+
+        XCTAssertTrue(plugin.allowedExternalURLs.isEmpty)
+    }
+
+    func testUnsupportedSchemaIsRejected() throws {
+        XCTAssertThrowsError(try validator.validate(packageURL: makePackage(schemaVersion: 2)))
+    }
+
+    func testUnsafeIdentifierIsRejected() throws {
+        XCTAssertThrowsError(try validator.validate(packageURL: makePackage(id: "../escape")))
+        XCTAssertThrowsError(try validator.validate(packageURL: makePackage(id: "工具.example")))
+    }
+
+    func testTraversalEntrypointIsRejected() throws {
+        try Data("outside".utf8).write(to: rootURL.appendingPathComponent("outside.html"))
+
+        XCTAssertThrowsError(try validator.validate(packageURL: makePackage(entrypoint: "../outside.html")))
+    }
+
+    func testPackageContainingSymlinkIsRejected() throws {
+        let outsideURL = rootURL.appendingPathComponent("outside.html")
+        try Data("outside".utf8).write(to: outsideURL)
+        let packageURL = try makePackage()
+        try FileManager.default.createSymbolicLink(
+            at: packageURL.appendingPathComponent("escaped.html"),
+            withDestinationURL: outsideURL
+        )
+
+        XCTAssertThrowsError(try validator.validate(packageURL: packageURL))
+    }
+
+    func testNonHTTPExternalURLIsRejected() throws {
+        XCTAssertThrowsError(
+            try validator.validate(packageURL: makePackage(allowedURLs: ["file:///tmp/private"]))
+        )
+    }
+
+    func testEmptyDisplayValueIsRejected() throws {
+        XCTAssertThrowsError(try validator.validate(packageURL: makePackage(name: "  ")))
+    }
+
+    @discardableResult
+    private func makePackage(
+        id: String = "com.example.tools",
+        name: String = "Tools",
+        version: String = "1.0.0",
+        schemaVersion: Int = 1,
+        entrypoint: String = "index.html",
+        allowedURLs: [String]? = ["https://geojson.io/"]
+    ) throws -> URL {
+        let packageURL = rootURL.appendingPathComponent("Tools.atollplugin", isDirectory: true)
+        try FileManager.default.createDirectory(at: packageURL, withIntermediateDirectories: true)
+
+        var manifest: [String: Any] = [
+            "schemaVersion": schemaVersion,
+            "id": id,
+            "name": name,
+            "version": version,
+            "entrypoint": entrypoint,
+            "tab": [
+                "title": "Tools",
+                "icon": "wrench.and.screwdriver",
+                "preferredHeight": 360
+            ]
+        ]
+        if let allowedURLs {
+            manifest["allowedExternalURLs"] = allowedURLs
+        }
+
+        let manifestData = try JSONSerialization.data(withJSONObject: manifest, options: [.prettyPrinted])
+        try manifestData.write(to: packageURL.appendingPathComponent("manifest.json"))
+        try Data("<html></html>".utf8).write(to: packageURL.appendingPathComponent("index.html"))
+        return packageURL
+    }
+}

--- a/DynamicIslandTests/StaticPluginPackageValidatorTests.swift
+++ b/DynamicIslandTests/StaticPluginPackageValidatorTests.swift
@@ -42,18 +42,25 @@ final class StaticPluginPackageValidatorTests: XCTestCase {
     }
 
     func testUnsupportedSchemaIsRejected() throws {
-        XCTAssertThrowsError(try validator.validate(packageURL: makePackage(schemaVersion: 2)))
+        assertThrows(.unsupportedSchema(2)) {
+            _ = try validator.validate(packageURL: makePackage(schemaVersion: 2))
+        }
     }
 
     func testUnsafeIdentifierIsRejected() throws {
-        XCTAssertThrowsError(try validator.validate(packageURL: makePackage(id: "../escape")))
-        XCTAssertThrowsError(try validator.validate(packageURL: makePackage(id: "工具.example")))
+        for id in ["../escape", "工具.example"] {
+            assertThrows(.invalidIdentifier) {
+                _ = try validator.validate(packageURL: makePackage(id: id))
+            }
+        }
     }
 
     func testTraversalEntrypointIsRejected() throws {
         try Data("outside".utf8).write(to: rootURL.appendingPathComponent("outside.html"))
 
-        XCTAssertThrowsError(try validator.validate(packageURL: makePackage(entrypoint: "../outside.html")))
+        assertThrows(.unsafeEntrypoint) {
+            _ = try validator.validate(packageURL: makePackage(entrypoint: "../outside.html"))
+        }
     }
 
     func testPackageContainingSymlinkIsRejected() throws {
@@ -65,17 +72,39 @@ final class StaticPluginPackageValidatorTests: XCTestCase {
             withDestinationURL: outsideURL
         )
 
-        XCTAssertThrowsError(try validator.validate(packageURL: packageURL))
+        assertThrows(.symbolicLink("escaped.html")) {
+            _ = try validator.validate(packageURL: packageURL)
+        }
     }
 
     func testNonHTTPExternalURLIsRejected() throws {
-        XCTAssertThrowsError(
-            try validator.validate(packageURL: makePackage(allowedURLs: ["file:///tmp/private"]))
-        )
+        assertThrows(.invalidExternalURL("file:///tmp/private")) {
+            _ = try validator.validate(
+                packageURL: makePackage(allowedURLs: ["file:///tmp/private"])
+            )
+        }
     }
 
     func testEmptyDisplayValueIsRejected() throws {
-        XCTAssertThrowsError(try validator.validate(packageURL: makePackage(name: "  ")))
+        assertThrows(.emptyDisplayValue("name")) {
+            _ = try validator.validate(packageURL: makePackage(name: "  "))
+        }
+    }
+
+    private func assertThrows(
+        _ expectedError: StaticPluginValidationError,
+        file: StaticString = #filePath,
+        line: UInt = #line,
+        operation: () throws -> Void
+    ) {
+        XCTAssertThrowsError(try operation(), file: file, line: line) { error in
+            XCTAssertEqual(
+                error as? StaticPluginValidationError,
+                expectedError,
+                file: file,
+                line: line
+            )
+        }
     }
 
     @discardableResult

--- a/DynamicIslandTests/StaticPluginPackageValidatorTests.swift
+++ b/DynamicIslandTests/StaticPluginPackageValidatorTests.swift
@@ -112,3 +112,53 @@ final class StaticPluginPackageValidatorTests: XCTestCase {
         return packageURL
     }
 }
+
+final class StaticPluginLayoutTests: XCTestCase {
+    func testUsesRequestedHeightWhenItFitsScreen() {
+        XCTAssertEqual(
+            StaticPluginLayout.resolvedHeight(
+                preferredHeight: 460,
+                baseHeight: 200,
+                visibleScreenHeight: 900,
+                fallbackMaximumHeight: 332
+            ),
+            460
+        )
+    }
+
+    func testNeverShrinksBelowBaseHeight() {
+        XCTAssertEqual(
+            StaticPluginLayout.resolvedHeight(
+                preferredHeight: 100,
+                baseHeight: 200,
+                visibleScreenHeight: 900,
+                fallbackMaximumHeight: 332
+            ),
+            200
+        )
+    }
+
+    func testClampsToSeventyPercentOfVisibleScreen() {
+        XCTAssertEqual(
+            StaticPluginLayout.resolvedHeight(
+                preferredHeight: 800,
+                baseHeight: 200,
+                visibleScreenHeight: 600,
+                fallbackMaximumHeight: 332
+            ),
+            420
+        )
+    }
+
+    func testUsesExistingFallbackWithoutScreenHeight() {
+        XCTAssertEqual(
+            StaticPluginLayout.resolvedHeight(
+                preferredHeight: 460,
+                baseHeight: 200,
+                visibleScreenHeight: nil,
+                fallbackMaximumHeight: 332
+            ),
+            332
+        )
+    }
+}

--- a/tests/test_static_plugin_window_sizing.py
+++ b/tests/test_static_plugin_window_sizing.py
@@ -19,6 +19,40 @@ class StaticPluginWindowSizingTests(unittest.TestCase):
                     f"{relative_path} does not use the shared static-plugin window size",
                 )
 
+    def test_content_view_keeps_selected_plugin_lookup_for_rendering(self):
+        source = (REPOSITORY_ROOT / "DynamicIsland/ContentView.swift").read_text()
+        self.assertTrue(
+            "private func currentStaticPlugin()" in source,
+            "ContentView lost the selected-plugin lookup used by its render switch",
+        )
+
+    def test_runtime_sizing_uses_each_window_screen(self):
+        for relative_path in (
+            "DynamicIsland/ContentView.swift",
+            "DynamicIsland/models/DynamicIslandViewModel.swift",
+        ):
+            with self.subTest(path=relative_path):
+                source = (REPOSITORY_ROOT / relative_path).read_text()
+                self.assertTrue(
+                    "visibleScreenHeight: currentScreenVisibleHeight" in source,
+                    f"{relative_path} does not use its view model's screen height",
+                )
+
+        app_source = (REPOSITORY_ROOT / "DynamicIsland/DynamicIslandApp.swift").read_text()
+        self.assertTrue(
+            "private func staticPluginAdjustedSize(_ size: CGSize, for screen: NSScreen)"
+            in app_source,
+            "AppDelegate has no per-window static-plugin sizing helper",
+        )
+        self.assertTrue(
+            "visibleScreenHeight: screen.visibleFrame.height" in app_source,
+            "AppDelegate does not clamp against each window screen",
+        )
+        self.assertTrue(
+            "staticPluginAdjustedSize(size, for: screen)" in app_source,
+            "AppDelegate does not apply per-window static-plugin sizing",
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_static_plugin_window_sizing.py
+++ b/tests/test_static_plugin_window_sizing.py
@@ -1,0 +1,24 @@
+import unittest
+from pathlib import Path
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+
+
+class StaticPluginWindowSizingTests(unittest.TestCase):
+    def test_all_runtime_sizing_paths_use_shared_plugin_size(self):
+        for relative_path in (
+            "DynamicIsland/ContentView.swift",
+            "DynamicIsland/models/DynamicIslandViewModel.swift",
+            "DynamicIsland/DynamicIslandApp.swift",
+        ):
+            with self.subTest(path=relative_path):
+                source = (REPOSITORY_ROOT / relative_path).read_text()
+                self.assertTrue(
+                    "StaticPluginLayout.resolvedSize(" in source,
+                    f"{relative_path} does not use the shared static-plugin window size",
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_static_plugin_window_sizing.py
+++ b/tests/test_static_plugin_window_sizing.py
@@ -26,6 +26,19 @@ class StaticPluginWindowSizingTests(unittest.TestCase):
             "ContentView lost the selected-plugin lookup used by its render switch",
         )
 
+    def test_plugin_reload_recreates_web_view_and_resizes_window(self):
+        content_source = (REPOSITORY_ROOT / "DynamicIsland/ContentView.swift").read_text()
+        self.assertTrue(
+            "staticPluginManager.reloadRevision" in content_source,
+            "ContentView does not key plugin rendering by the reload revision",
+        )
+
+        app_source = (REPOSITORY_ROOT / "DynamicIsland/DynamicIslandApp.swift").read_text()
+        self.assertTrue(
+            "StaticPluginManager.shared.$reloadRevision" in app_source,
+            "AppDelegate does not observe plugin reloads for window resizing",
+        )
+
     def test_runtime_sizing_uses_each_window_screen(self):
         for relative_path in (
             "DynamicIsland/ContentView.swift",


### PR DESCRIPTION
## Summary

- import validated `.atollplugin` directories from Settings

- install, enable, disable, remove, and confirm same-ID replacement

- render enabled plugins as notch tabs in a non-persistent WKWebView

- resize the host window for each plugin requested height, capped at 70% of that window screen visible height

- block plugin network access and only open exact allowlisted, user-clicked URLs in the system browser

## Validation

- full Debug build succeeds locally with Xcode 26.3

- 32 focused static-plugin XCTest cases pass locally

- 11 Python regression tests pass locally

- requested 460 pt height and tab switching manually verified locally

- fork CI passes on macOS 15 and macOS 26 for commit `5035960a`

Fork CI evidence: https://github.com/Sq-List/Atoll/actions/runs/32962849485

Closes #780\n<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for installing local `.atollplugin` packages as isolated tabs.
  * Added controls to enable, disable, replace, and remove installed plugins.
  * Added replacement confirmation, package validation, and discovery error reporting.
  * Plugins can display local web content with controlled external-link access.
  * Added plugin-specific sizing, tab selection, icons, and navigation handling.
  * Plugin sizing now adapts to the selected display.
* **Bug Fixes**
  * Invalid, disabled, or removed plugins are automatically cleared from selection.
  * Failed or invalid replacements preserve the existing installed plugin.
  * Restricted plugin content from accessing unauthorized network resources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->