### PR TITLE
fix: keep Lock Screen Glass in one place

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Lyrics on the side**: Added ability to show lyrics of the current song when calendar is disabled (#741)
 
 ### Changed
-- **Lock screen glass has one home**: the Lock Screen Glass section is now only on the Lock Screen tab. Appearance carried a second copy of the same material and glass-mode pickers, with its own variant sliders whose caption admitted they mirrored the other tab — two places to change one setting, and neither obviously the real one.
+- **Lock screen glass has one home**: the Lock Screen Glass section is now only on the Lock Screen tab. Appearance carried a second copy of the same material and glass-mode pickers, with its own variant sliders whose caption admitted they mirrored the other tab — two places to change one setting, and neither obviously the real one. The live glass preview that only existed on the Appearance copy moved over with it, so nothing is lost in the move.
 
 - Lock screen live activity timings now follow the selected icons: the fingerprint remains visible through its scan, while the open lock gets its own brief confirmation beat before the island contracts. (#774)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Lyrics on the side**: Added ability to show lyrics of the current song when calendar is disabled (#741)
 
 ### Changed
+- **Lock screen glass has one home**: the Lock Screen Glass section is now only on the Lock Screen tab. Appearance carried a second copy of the same material and glass-mode pickers, with its own variant sliders whose caption admitted they mirrored the other tab — two places to change one setting, and neither obviously the real one.
+
 - Lock screen live activity timings now follow the selected icons: the fingerprint remains visible through its scan, while the open lock gets its own brief confirmation beat before the island contracts. (#774)
 
 - The LIVE indicator shown in place of a progress bar on streams now follows Apple's treatment: two thin rules meeting the word in the middle, softening as they run away from it. It was a 10pt capsule with a fill, a centre shade, a stroke and three blend modes. Shadowed text was dropped over the top of all that. The result read as a progress bar someone had written on, and a stream has no progress to draw. The notch, the lock screen player and the floating window all draw the same component, so all three change together.

--- a/DynamicIsland/components/Settings/SettingsView.swift
+++ b/DynamicIsland/components/Settings/SettingsView.swift
@@ -5634,7 +5634,10 @@ struct LockScreenSettings: View {
                         value: musicVariantBinding,
                         currentValue: lockScreenMusicLiquidGlassVariant.rawValue,
                         isEnabled: enableLockScreenMediaWidget,
-                        highlight: highlightID("Music panel variant")
+                        highlight: highlightID("Music panel variant"),
+                        preview: AnyView(
+                            LockScreenGlassVariantPreviewCell(variant: $lockScreenMusicLiquidGlassVariant)
+                        )
                     )
                 } else if lockScreenGlassStyle == .frosted {
                     Defaults.Toggle(key: .lockScreenPanelUsesBlur) {

--- a/DynamicIsland/components/Settings/SettingsView.swift
+++ b/DynamicIsland/components/Settings/SettingsView.swift
@@ -4669,13 +4669,9 @@ struct Appearance: View {
     @Default(.enableMinimalisticUI) var enableMinimalisticUI
     @Default(.lockScreenGlassCustomizationMode) private var lockScreenGlassCustomizationMode
     @Default(.lockScreenGlassStyle) private var lockScreenGlassStyle
-    @Default(.lockScreenMusicLiquidGlassVariant) private var lockScreenMusicLiquidGlassVariant
-    @Default(.lockScreenTimerLiquidGlassVariant) private var lockScreenTimerLiquidGlassVariant
     @Default(.lockScreenTimerGlassStyle) private var lockScreenTimerGlassStyle
     @Default(.lockScreenTimerGlassCustomizationMode) private var lockScreenTimerGlassCustomizationMode
     @Default(.lockScreenTimerWidgetUsesBlur) private var timerGlassModeIsGlass
-    @Default(.enableLockScreenMediaWidget) private var enableLockScreenMediaWidget
-    @Default(.enableLockScreenTimerWidget) private var enableLockScreenTimerWidget
     @Default(.externalDisplayStyle) private var externalDisplayStyle
     @State private var selectedListVisualizer: CustomVisualizer? = nil
 
@@ -4707,29 +4703,7 @@ struct Appearance: View {
         SettingsTab.appearance.highlightID(for: title)
     }
 
-    private var liquidVariantRange: ClosedRange<Double> {
-        Double(LiquidGlassVariant.supportedRange.lowerBound)...Double(LiquidGlassVariant.supportedRange.upperBound)
-    }
 
-    private var appearanceMusicVariantBinding: Binding<Double> {
-        Binding(
-            get: { Double(lockScreenMusicLiquidGlassVariant.rawValue) },
-            set: { newValue in
-                let raw = Int(newValue.rounded())
-                lockScreenMusicLiquidGlassVariant = LiquidGlassVariant.clamped(raw)
-            }
-        )
-    }
-
-    private var appearanceTimerVariantBinding: Binding<Double> {
-        Binding(
-            get: { Double(lockScreenTimerLiquidGlassVariant.rawValue) },
-            set: { newValue in
-                let raw = Int(newValue.rounded())
-                lockScreenTimerLiquidGlassVariant = LiquidGlassVariant.clamped(raw)
-            }
-        )
-    }
 
     private var timerSurfaceBinding: Binding<LockScreenTimerSurfaceMode> {
         Binding(
@@ -4784,83 +4758,6 @@ struct Appearance: View {
             }
 
             notchWidthControls()
-
-            Section {
-                if #available(macOS 26.0, *) {
-                    Picker("Material", selection: $lockScreenGlassStyle) {
-                        ForEach(LockScreenGlassStyle.allCases) { style in
-                            Text(style.localizedName).tag(style)
-                        }
-                    }
-                    .settingsHighlight(id: highlightID("Lock screen material"))
-                } else {
-                    Picker("Material", selection: $lockScreenGlassStyle) {
-                        ForEach(LockScreenGlassStyle.allCases) { style in
-                            Text(style.localizedName).tag(style)
-                        }
-                    }
-                    .disabled(true)
-                    .settingsHighlight(id: highlightID("Lock screen material"))
-                    Text("Liquid Glass requires macOS 26 or later.")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                }
-
-                if lockScreenGlassStyle == .liquid {
-                    Picker("Lock screen glass mode", selection: $lockScreenGlassCustomizationMode) {
-                        ForEach(LockScreenGlassCustomizationMode.allCases) { mode in
-                            Text(mode.localizedName).tag(mode)
-                        }
-                    }
-                    .pickerStyle(.segmented)
-                    .settingsHighlight(id: highlightID("Lock screen glass mode"))
-
-                    if lockScreenGlassCustomizationMode == .customLiquid {
-                        Text("Pick per-widget liquid-glass variants below. Changes mirror the Lock Screen tab.")
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-
-                        VStack(alignment: .leading, spacing: 6) {
-                            HStack {
-                                Text("Music panel variant")
-                                Spacer()
-                                Text("v\(lockScreenMusicLiquidGlassVariant.rawValue)")
-                                    .font(.caption)
-                                    .foregroundStyle(.secondary)
-                            }
-                            Slider(value: appearanceMusicVariantBinding, in: liquidVariantRange, step: 1)
-
-                            LockScreenGlassVariantPreviewCell(variant: $lockScreenMusicLiquidGlassVariant)
-                                .padding(.top, 6)
-                        }
-                        .settingsHighlight(id: highlightID("Music panel variant (appearance)"))
-                        .disabled(!enableLockScreenMediaWidget)
-                        .opacity(enableLockScreenMediaWidget ? 1 : 0.4)
-
-                        VStack(alignment: .leading, spacing: 6) {
-                            HStack {
-                                Text("Timer widget variant")
-                                Spacer()
-                                Text("v\(lockScreenTimerLiquidGlassVariant.rawValue)")
-                                    .font(.caption)
-                                    .foregroundStyle(.secondary)
-                            }
-                            Slider(value: appearanceTimerVariantBinding, in: liquidVariantRange, step: 1)
-                        }
-                        .settingsHighlight(id: highlightID("Timer widget variant (appearance)"))
-                        .disabled(!enableLockScreenTimerWidget)
-                        .opacity(enableLockScreenTimerWidget ? 1 : 0.4)
-                    }
-                } else {
-                    Text("Custom Liquid settings require the Liquid Glass material.")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                }
-            } header: {
-                Text("Lock Screen Glass")
-            } footer: {
-                Text("Configure lock screen materials from the Appearance tab. Custom Liquid unlocks variant sliders for both widgets whenever Liquid Glass is selected.")
-            }
 
             Section {
                 Defaults.Toggle(key: .coloredSpectrogram) {


### PR DESCRIPTION
Settings had two **Lock Screen Glass** sections — one on Appearance, one on Lock Screen — driving the same defaults.

The Appearance copy had the same `Material` picker, the same glass-mode picker, and variant sliders for the music panel and timer widget. Those sliders already exist on the Lock Screen tab; the Appearance copy's own caption said so ("Changes mirror the Lock Screen tab"), and its footer told you to "Configure lock screen materials from the Appearance tab" — which is the tab you were already on.

So the duplicate is gone and the Lock Screen tab keeps it, on the grounds that it is where the widgets being described are configured. Also removes the four bindings and the variant range in `Appearance` that only fed the removed section.

No defaults changed and no keys renamed, so nobody's existing configuration moves — only where you go to change it. Settings search had no entries pointing at the removed rows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Moved the live glass preview from the duplicate **Appearance** settings to the **Lock Screen** tab.
  - Consolidated Lock Screen glass controls in one location for a clearer settings experience.
  - Added a liquid-glass preview to the lock-screen music variant slider.
  - Removed duplicate lock-screen music, timer, and glass controls from **Appearance**.
  - Timer-specific glass settings remain available in the timer settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->