### PR TITLE
fix: use M5 CPU temperature sensor keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The separate-tab clipboard now uses the same card grid (two columns) with drag-out and per-item delete, replacing the single-column list (#698).
 
 ### Fixed
+- Fixed CPU temperature reporting on M5-series Macs by using the M5 SMC sensor keys instead of the M4 key set (#585).
 - **The custom OSD no longer sticks on screen**: switching away from Custom OSD while one of its windows was visible left the overlay there for good. Nothing watched the setting, and the only thing that would ever have hidden that window was its own two-second timer, which the switch outran. Turning the OSD off -- or turning off volume, brightness or keyboard backlight individually -- now dismisses what is on screen.
 - Restored the notch's curved top corners in both standard and Minimalistic music UI while retaining the top-edge anti-gap fill, and synchronized the lock and fingerprint indicators through one shared scan state. (#782)
 - The lock screen Dynamic Island now completes one clean unlock contraction instead of disappearing early or showing a second island that closes immediately afterward. (#774)

--- a/DynamicIsland/utils/CPUSensorCollector.swift
+++ b/DynamicIsland/utils/CPUSensorCollector.swift
@@ -247,7 +247,7 @@ final class CPUSensorCollector {
         case .m4, .m4Pro, .m4Max, .m4Ultra:
             return ["Te05", "Te09", "Te0H", "Te0S", "Tp01", "Tp05", "Tp09", "Tp0D", "Tp0V", "Tp0Y", "Tp0b", "Tp0e"]
         case .m5, .m5Pro, .m5Max, .m5Ultra:
-            return ["Te05", "Te09", "Te0H", "Te0S", "Tp01", "Tp05", "Tp09", "Tp0D", "Tp0V", "Tp0Y", "Tp0b", "Tp0e"]
+            return ["Tp00", "Tp04", "Tp08", "Tp0C", "Tp0G", "Tp0K", "Tp0O", "Tp0R", "Tp0U", "Tp0X", "Tp0a", "Tp0d", "Tp0g", "Tp0j", "Tp0m", "Tp0p", "Tp0u", "Tp0y"]
         default:
             return ["TC0P", "TC0E", "TC0F", "TC0H", "TC0D"]
         }


### PR DESCRIPTION
## Summary

- Replace the M4 temperature fallback keys used for M5 platforms with the
  M5 CPU core sensor keys.
- Restore CPU temperature reporting on M5-series Macs.

## Root cause

M5 platform detection was added, but its temperature fallback list reused
the M4 SMC keys. Those keys do not provide CPU temperature readings on M5.

Fixes #585.

## Testing

- Verified the new keys return plausible CPU temperatures on a MacBook Air
  M5 (Mac17,3).
- `python3 -m unittest tests.test_privacy_configuration tests.test_timer_lifecycle`
- `git diff --check`

A full local Xcode build was unavailable because this machine only has the
Command Line Tools installed; the repository CI builds on macOS 15 and 26.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved CPU temperature reporting on M5-series Macs by using the correct M5 SMC sensor keys.
  - Expanded fallback sensor coverage for M5, M5 Pro, M5 Max, and M5 Ultra models.

- **Documentation**
  - Added the fix to the upcoming release changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->