### PR TITLE
fix: keep live activities off the frontmost app's menus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The separate-tab clipboard now uses the same card grid (two columns) with drag-out and per-item delete, replacing the single-column list (#698).
 
 ### Fixed
+- **Live activities step around the menu bar**: a live activity draws into the strip of menu bar beside the notch, which is where the frontmost app's own menus live, so a timer or download could sit on top of them — the Help menu especially, being the one nearest the notch. macOS offers no way to tell it that part of that strip is spoken for, so Atoll measures where the menus actually end and slides the activity clear, moving back once there is room again (#793).
 - **The custom OSD no longer sticks on screen**: switching away from Custom OSD while one of its windows was visible left the overlay there for good. Nothing watched the setting, and the only thing that would ever have hidden that window was its own two-second timer, which the switch outran. Turning the OSD off -- or turning off volume, brightness or keyboard backlight individually -- now dismisses what is on screen.
 - Restored the notch's curved top corners in both standard and Minimalistic music UI while retaining the top-edge anti-gap fill, and synchronized the lock and fingerprint indicators through one shared scan state. (#782)
 - The lock screen Dynamic Island now completes one clean unlock contraction instead of disappearing early or showing a second island that closes immediately afterward. (#774)

--- a/DynamicIsland.xcodeproj/project.pbxproj
+++ b/DynamicIsland.xcodeproj/project.pbxproj
@@ -39,6 +39,7 @@
 		A70F1A012F90000100F1A001 /* FingerprintScan.json in Resources */ = {isa = PBXBuildFile; fileRef = A70F1A022F90000100F1A001 /* FingerprintScan.json */; };
 		B1C2D3E4F5A60718293A4B01 /* MediaKeyTapRetryPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1C2D3E4F5A60718293A4B02 /* MediaKeyTapRetryPolicyTests.swift */; };
 		B4777BB9FE29243B253B8306 /* SpotifyLibraryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFA269966BB987D4A1B411A2 /* SpotifyLibraryTests.swift */; };
+		738C4EBB63E3449B923997D0 /* MenuBarClearanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EB37667F763422E97DEEB49 /* MenuBarClearanceTests.swift */; };
 		B5E314BBF3AF4E6D8E90B25B /* LRCParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D82568218362418EA59B2CDC /* LRCParserTests.swift */; };
 		C0DECAFE1234567890ABCDEF /* FlyoutFrameCalculatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DEFACE1234567890ABCDEF /* FlyoutFrameCalculatorTests.swift */; };
 		D1A2B3C4D5E6F70819AB2C4D /* SystemHUDPlacementTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1A2B3C4D5E6F70819AB2C4E /* SystemHUDPlacementTests.swift */; };
@@ -103,6 +104,7 @@
 		D82568218362418EA59B2CDC /* LRCParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LRCParserTests.swift; sourceTree = "<group>"; };
 		DAA671E7B1B26733F02166C5 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		DFA269966BB987D4A1B411A2 /* SpotifyLibraryTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SpotifyLibraryTests.swift; sourceTree = "<group>"; };
+		2EB37667F763422E97DEEB49 /* MenuBarClearanceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MenuBarClearanceTests.swift"; sourceTree = "<group>"; };
 		E1F2A3B4C5D6E7F8A9B0C1D2 /* JSONLUsageParserTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = JSONLUsageParserTests.swift; sourceTree = "<group>"; };
 		B1C2D3E4F5061728394A5B6D /* PartialDownloadTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PartialDownloadTests.swift; sourceTree = "<group>"; };
 		F2E3D4C5B6A7E8F9A0B1C2D3 /* Contents/Helpers/NowPlayingTestClient */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "compiled.mach-o.executable"; path = Contents/Helpers/NowPlayingTestClient; sourceTree = "<group>"; };
@@ -207,6 +209,7 @@
 				2137D0F9431A495AA62ACE96 /* NowPlayingPayloadTests.swift */,
 				8DC2ACF06B40405DB1A8F99E /* MarqueeTextMeasurementTests.swift */,
 				DFA269966BB987D4A1B411A2 /* SpotifyLibraryTests.swift */,
+				2EB37667F763422E97DEEB49 /* MenuBarClearanceTests.swift */,
 				A1B2C3D40000000000000002 /* LyricsMetadataTests.swift */,
 				A1B2C3D4E5F60718293A4B5D /* ExtensionRPCServerTests.swift */,
 				D1A2B3C4D5E6F70819AB2C4E /* SystemHUDPlacementTests.swift */,
@@ -487,6 +490,7 @@
 				9A7D1A012F90000200A71001 /* AudioTapTests.swift in Sources */,
 				A4B5C6D7E8F90123456789AB /* AppleMusicControllerTests.swift in Sources */,
 				B4777BB9FE29243B253B8306 /* SpotifyLibraryTests.swift in Sources */,
+				738C4EBB63E3449B923997D0 /* MenuBarClearanceTests.swift in Sources */,
 				A1B2C3D40000000000000001 /* LyricsMetadataTests.swift in Sources */,
 				A1B2C3D4E5F60718293A4B5C /* ExtensionRPCServerTests.swift in Sources */,
 				D1A2B3C4D5E6F70819AB2C4D /* SystemHUDPlacementTests.swift in Sources */,

--- a/DynamicIsland/ContentView.swift
+++ b/DynamicIsland/ContentView.swift
@@ -2084,8 +2084,11 @@ struct ContentView: View {
         let activationWidth = vm.closedNotchSize.width + horizontalPadding * 2
         let activationHeight = max(vm.closedNotchSize.height + zeroHeightHoverPadding, 14)
 
+        // Follows the rendered content: when a live activity has stepped aside
+         // from the menus, activating at the old centre would arm the notch where
+         // nothing is drawn and refuse the pointer where it is.
         let activationRect = CGRect(
-            x: screen.frame.midX - activationWidth / 2,
+            x: screen.frame.midX - activationWidth / 2 + menuBarClearanceOffset,
             y: screen.frame.maxY - activationHeight,
             width: activationWidth,
             height: activationHeight
@@ -2359,7 +2362,8 @@ struct ContentView: View {
         )
         let height = max(closedHeight, recordingSize?.height ?? 0) + 6
         let width = max(closedWidth, recordingSize?.width ?? 0) + 24
-        let minX = screen.frame.midX - width / 2
+        // Same shift the content is drawn with, so the hit area stays under it.
+        let minX = screen.frame.midX - width / 2 + menuBarClearanceOffset
         let minY = screen.frame.maxY - height
 
         return location.x >= minX && location.x <= minX + width

--- a/DynamicIsland/ContentView.swift
+++ b/DynamicIsland/ContentView.swift
@@ -49,6 +49,11 @@ struct ContentView: View {
     @ObservedObject var privacyManager = PrivacyIndicatorManager.shared
     @ObservedObject var doNotDisturbManager = DoNotDisturbManager.shared
     @ObservedObject var lockScreenManager = LockScreenManager.shared
+    @ObservedObject private var menuBarLayout = MenuBarLayout.shared
+    /// Width of the closed-notch content, measured so its left edge can be
+    /// compared against the frontmost app's menus. Only the *size* is read --
+    /// the offset that follows does not change it, so there is no feedback.
+    @State private var closedContentWidth: CGFloat = 0
     @ObservedObject var capsLockManager = CapsLockManager.shared
     @ObservedObject var extensionLiveActivityManager = ExtensionLiveActivityManager.shared
     @ObservedObject var extensionNotchExperienceManager = ExtensionNotchExperienceManager.shared
@@ -962,9 +967,49 @@ struct ContentView: View {
                     enqueueMusicControlWindowSync(forceRefresh: true)
                 }
             }
+            .onAppear {
+                if vm.notchState == .closed { menuBarLayout.startTracking() }
+            }
+            .onChange(of: vm.notchState) { _, state in
+                // An open notch covers the menu bar wholesale and is the user's
+                // own doing, so there is nothing to step around while it is up.
+                if state == .closed {
+                    menuBarLayout.startTracking()
+                } else {
+                    menuBarLayout.stopTracking()
+                }
+            }
             .onDisappear {
                 performViewTeardown()
             }
+    }
+
+    /// How far right the closed-notch content has to move so it stops covering
+    /// the frontmost app's menus.
+    ///
+    /// A live activity's left wing draws into the strip of menu bar beside the
+    /// notch, which is where the app's own menus live. macOS lays those out
+    /// against `NSScreen.auxiliaryTopLeftArea` and there is no way to tell it
+    /// some of that strip is spoken for -- both auxiliary areas are read-only.
+    /// So the content moves instead of the menus.
+    ///
+    /// Zero unless something is actually being covered: no live activity, an
+    /// open notch, no accessibility permission, or menus that end before the
+    /// content begins all leave the notch centred where it belongs.
+    private var menuBarClearanceOffset: CGFloat {
+        guard vm.notchState == .closed,
+              !vm.hideOnClosed,
+              closedContentWidth > 0,
+              let menusRightEdge = menuBarLayout.appMenusRightEdge,
+              let screenFrame = getScreenFrame(currentScreenName)
+        else { return 0 }
+
+        return MenuBarLayout.clearanceOffset(
+            contentWidth: closedContentWidth,
+            screenFrame: screenFrame,
+            menusRightEdge: menusRightEdge,
+            gap: MenuBarLayout.clearanceGap
+        )
     }
 
     @ViewBuilder
@@ -1175,6 +1220,15 @@ struct ContentView: View {
                   view
                       .fixedSize()
               }
+              .background {
+                  GeometryReader { geo in
+                      Color.clear
+                          .onAppear { closedContentWidth = geo.size.width }
+                          .onChange(of: geo.size.width) { _, width in closedContentWidth = width }
+                  }
+              }
+              .offset(x: menuBarClearanceOffset)
+              .animation(.smooth(duration: 0.25), value: menuBarClearanceOffset)
               .zIndex(2)
               
               ZStack {
@@ -2043,6 +2097,7 @@ struct ContentView: View {
     /// Cancels every long-lived task / event monitor this view owns. Called from
     /// `.onDisappear` and from `vm.onViewTeardown` on window close. Idempotent.
     private func performViewTeardown() {
+        menuBarLayout.stopTracking()
         hoverTask?.cancel()
         stopHoverClickMonitor()
         removeStickyTerminalClickMonitor()

--- a/DynamicIsland/managers/MenuBarLayout.swift
+++ b/DynamicIsland/managers/MenuBarLayout.swift
@@ -130,18 +130,31 @@ final class MenuBarLayout: ObservableObject {
         }
     }
 
+    /// Longest the whole scan may take. A menu bar with many items could
+    /// otherwise reach minutes at the per-element timeout, and until it returns
+    /// no further measurement is taken.
+    nonisolated private static let scanDeadline: TimeInterval = 1
+
+    /// Per-element messaging timeout. `AXUIElementSetMessagingTimeout` applies
+    /// only to the element it is called on -- it does not carry to the children
+    /// that element hands back -- so every element messaged here is given its
+    /// own, or a hung app would still block on the ones that inherited nothing.
+    nonisolated private static let elementTimeout: Float = 0.25
+
     /// The right edge of the last menu, or `nil` if the menu bar cannot be read.
     nonisolated private static func menusRightEdge(pid: pid_t) -> CGFloat? {
+        let startedAt = Date()
         let app = AXUIElementCreateApplication(pid)
         // A hung app must not hold this up; the measurement is an optimisation,
         // never something worth waiting on.
-        AXUIElementSetMessagingTimeout(app, 0.25)
+        AXUIElementSetMessagingTimeout(app, elementTimeout)
 
         var menuBarValue: CFTypeRef?
         guard AXUIElementCopyAttributeValue(app, kAXMenuBarAttribute as CFString, &menuBarValue) == .success,
               CFGetTypeID(menuBarValue) == AXUIElementGetTypeID()
         else { return nil }
         let menuBar = unsafeBitCast(menuBarValue, to: AXUIElement.self)
+        AXUIElementSetMessagingTimeout(menuBar, elementTimeout)
 
         var childrenValue: CFTypeRef?
         guard AXUIElementCopyAttributeValue(menuBar, kAXChildrenAttribute as CFString, &childrenValue) == .success,
@@ -150,6 +163,12 @@ final class MenuBarLayout: ObservableObject {
 
         var rightEdge: CGFloat?
         for item in items {
+            // Whatever has been measured so far is still usable; a scan that has
+            // run long is one where the app is not answering, and waiting out
+            // every remaining item only delays the next attempt.
+            guard Date().timeIntervalSince(startedAt) < scanDeadline else { break }
+            AXUIElementSetMessagingTimeout(item, elementTimeout)
+
             var positionValue: CFTypeRef?
             var sizeValue: CFTypeRef?
             guard AXUIElementCopyAttributeValue(item, kAXPositionAttribute as CFString, &positionValue) == .success,

--- a/DynamicIsland/managers/MenuBarLayout.swift
+++ b/DynamicIsland/managers/MenuBarLayout.swift
@@ -1,0 +1,169 @@
+//
+//  MenuBarLayout.swift
+//  DynamicIsland
+//
+//  Where the frontmost app's menus end, so a live activity can stay out of
+//  their way.
+//
+
+import AppKit
+import ApplicationServices
+import Combine
+
+/// Tracks the right edge of the frontmost application's menu bar items.
+///
+/// A live activity draws into the strip of menu bar to the left of the notch,
+/// which is the same strip the app's own menus occupy. macOS lays those menus
+/// out inside `NSScreen.auxiliaryTopLeftArea` and offers no way to tell it that
+/// something else is using part of that space -- both auxiliary areas are
+/// read-only and derived from the display hardware. So rather than reserving
+/// room, Atoll measures what is already there and moves aside.
+///
+/// The measurement is the accessibility API's view of the menu bar, which is
+/// how the geometry is available at all: every menu reports its own position
+/// and size.
+@MainActor
+final class MenuBarLayout: ObservableObject {
+    static let shared = MenuBarLayout()
+
+    /// Right edge of the last menu of the frontmost app, in screen coordinates.
+    /// `nil` when it cannot be known -- no accessibility permission, an app that
+    /// exposes no menu bar, or a process that did not answer in time. Callers
+    /// treat that as "no constraint" rather than guessing.
+    @Published private(set) var appMenusRightEdge: CGFloat?
+
+    /// Menus change with the frontmost app, and within an app as its windows
+    /// change, so a slow poll backs up the activation notice. It runs only
+    /// while something actually needs the measurement.
+    private static let pollInterval: TimeInterval = 3
+
+    private var observer: NSObjectProtocol?
+    private var pollTimer: Timer?
+    private var trackers = 0
+    private var inFlight = false
+
+    private init() {}
+
+    /// How far right content of `contentWidth`, centred in `screenFrame`, has to
+    /// move so its left edge clears menus ending at `menusRightEdge`.
+    ///
+    /// Zero when nothing is covered. Capped at the room remaining on the right,
+    /// because a shift that pushes the content off the far edge has traded one
+    /// covered thing for another.
+    nonisolated static func clearanceOffset(
+        contentWidth: CGFloat,
+        screenFrame: CGRect,
+        menusRightEdge: CGFloat,
+        gap: CGFloat
+    ) -> CGFloat {
+        guard contentWidth > 0 else { return 0 }
+        let contentLeftEdge = screenFrame.midX - contentWidth / 2
+        let overlap = (menusRightEdge + gap) - contentLeftEdge
+        guard overlap > 0 else { return 0 }
+        let rightHeadroom = max(0, screenFrame.maxX - (contentLeftEdge + contentWidth))
+        return min(overlap, rightHeadroom)
+    }
+
+    /// Breathing room between the last menu and the notch content, so they do
+    /// not end up flush against each other.
+    nonisolated static let clearanceGap: CGFloat = 8
+
+    /// Begin measuring. Balanced by `stopTracking()`; nested calls are counted,
+    /// so several live activities can ask at once without one's disappearance
+    /// stopping the others.
+    func startTracking() {
+        trackers += 1
+        guard trackers == 1 else { return }
+
+        observer = NSWorkspace.shared.notificationCenter.addObserver(
+            forName: NSWorkspace.didActivateApplicationNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            MainActor.assumeIsolated { self?.refresh() }
+        }
+
+        let timer = Timer(timeInterval: Self.pollInterval, repeats: true) { [weak self] _ in
+            Task { @MainActor in self?.refresh() }
+        }
+        RunLoop.main.add(timer, forMode: .common)
+        pollTimer = timer
+
+        refresh()
+    }
+
+    func stopTracking() {
+        guard trackers > 0 else { return }
+        trackers -= 1
+        guard trackers == 0 else { return }
+
+        if let observer {
+            NSWorkspace.shared.notificationCenter.removeObserver(observer)
+            self.observer = nil
+        }
+        pollTimer?.invalidate()
+        pollTimer = nil
+        appMenusRightEdge = nil
+    }
+
+    func refresh() {
+        guard !inFlight else { return }
+        guard AXIsProcessTrusted() else {
+            appMenusRightEdge = nil
+            return
+        }
+        guard let pid = NSWorkspace.shared.frontmostApplication?.processIdentifier else {
+            appMenusRightEdge = nil
+            return
+        }
+
+        // Off the main actor: these are cross-process calls, and an app that has
+        // stopped answering would otherwise take the notch's UI down with it.
+        inFlight = true
+        Task.detached(priority: .utility) {
+            let edge = Self.menusRightEdge(pid: pid)
+            await MainActor.run {
+                self.inFlight = false
+                guard self.trackers > 0 else { return }
+                if self.appMenusRightEdge != edge { self.appMenusRightEdge = edge }
+            }
+        }
+    }
+
+    /// The right edge of the last menu, or `nil` if the menu bar cannot be read.
+    nonisolated private static func menusRightEdge(pid: pid_t) -> CGFloat? {
+        let app = AXUIElementCreateApplication(pid)
+        // A hung app must not hold this up; the measurement is an optimisation,
+        // never something worth waiting on.
+        AXUIElementSetMessagingTimeout(app, 0.25)
+
+        var menuBarValue: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(app, kAXMenuBarAttribute as CFString, &menuBarValue) == .success,
+              CFGetTypeID(menuBarValue) == AXUIElementGetTypeID()
+        else { return nil }
+        let menuBar = unsafeBitCast(menuBarValue, to: AXUIElement.self)
+
+        var childrenValue: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(menuBar, kAXChildrenAttribute as CFString, &childrenValue) == .success,
+              let items = childrenValue as? [AXUIElement], !items.isEmpty
+        else { return nil }
+
+        var rightEdge: CGFloat?
+        for item in items {
+            var positionValue: CFTypeRef?
+            var sizeValue: CFTypeRef?
+            guard AXUIElementCopyAttributeValue(item, kAXPositionAttribute as CFString, &positionValue) == .success,
+                  AXUIElementCopyAttributeValue(item, kAXSizeAttribute as CFString, &sizeValue) == .success
+            else { continue }
+
+            var origin = CGPoint.zero
+            var size = CGSize.zero
+            guard AXValueGetValue(positionValue as! AXValue, .cgPoint, &origin),
+                  AXValueGetValue(sizeValue as! AXValue, .cgSize, &size)
+            else { continue }
+
+            rightEdge = max(rightEdge ?? 0, origin.x + size.width)
+        }
+        return rightEdge
+    }
+}

--- a/DynamicIslandTests/MenuBarClearanceTests.swift
+++ b/DynamicIslandTests/MenuBarClearanceTests.swift
@@ -1,0 +1,73 @@
+import XCTest
+@testable import Atoll
+
+/// The screen these use is a 14" MacBook Pro: 1710pt wide, notch 185pt wide and
+/// centred, so the menu bar's left strip runs 0...762.5.
+final class MenuBarClearanceTests: XCTestCase {
+    private let screen = CGRect(x: 0, y: 0, width: 1710, height: 1107)
+    private let gap: CGFloat = 8
+
+    private func offset(contentWidth: CGFloat, menusEnd: CGFloat, screen: CGRect? = nil) -> CGFloat {
+        MenuBarLayout.clearanceOffset(
+            contentWidth: contentWidth,
+            screenFrame: screen ?? self.screen,
+            menusRightEdge: menusEnd,
+            gap: gap
+        )
+    }
+
+    func testShortMenusLeaveTheNotchCentred() {
+        // 300pt of content is centred at 855, so it begins at 705. Menus that
+        // end at 606 -- Zen's, measured -- are nowhere near it.
+        XCTAssertEqual(offset(contentWidth: 300, menusEnd: 606), 0)
+    }
+
+    func testMenusReachingTheContentPushItRight() {
+        // Content begins at 705; menus ending at 720 overlap it by 15, plus the
+        // 8pt gap.
+        XCTAssertEqual(offset(contentWidth: 300, menusEnd: 720), 23)
+    }
+
+    func testTheGapAloneIsEnoughToMove() {
+        // Menus end exactly where the content begins: no overlap, but they would
+        // be flush, so the content still steps aside by the gap.
+        XCTAssertEqual(offset(contentWidth: 300, menusEnd: 705), 8)
+    }
+
+    func testMenusEndingJustShortOfTheGapDoNotMove() {
+        XCTAssertEqual(offset(contentWidth: 300, menusEnd: 697), 0)
+    }
+
+    func testAWiderActivityIsCoveredSooner() {
+        // 500pt of content begins at 605, so the same menus that cleared a
+        // 300pt activity now overlap it.
+        XCTAssertEqual(offset(contentWidth: 500, menusEnd: 606), 9)
+        XCTAssertEqual(offset(contentWidth: 300, menusEnd: 606), 0)
+    }
+
+    func testTheShiftStopsAtTheScreenEdge() {
+        // Content this wide has only 105pt of room on the right, so a demand for
+        // more than that is capped rather than pushing it off screen.
+        let wide: CGFloat = 1500
+        let headroom = screen.maxX - (screen.midX - wide / 2 + wide)
+        XCTAssertEqual(offset(contentWidth: wide, menusEnd: 1000), headroom)
+        XCTAssertEqual(headroom, 105)
+    }
+
+    func testContentFillingTheScreenNeverMoves() {
+        XCTAssertEqual(offset(contentWidth: 1710, menusEnd: 900), 0)
+    }
+
+    func testNoContentMeansNoShift() {
+        XCTAssertEqual(offset(contentWidth: 0, menusEnd: 900), 0)
+    }
+
+    func testAnExternalDisplayIsMeasuredOnItsOwnGeometry() {
+        // A screen that does not start at x=0 -- the arithmetic is in global
+        // coordinates, so a second display must not be treated as if it did.
+        let external = CGRect(x: 1710, y: 0, width: 2560, height: 1440)
+        // Centre is 2990, so 300pt of content begins at 2840.
+        XCTAssertEqual(offset(contentWidth: 300, menusEnd: 2850, screen: external), 18)
+        XCTAssertEqual(offset(contentWidth: 300, menusEnd: 2000, screen: external), 0)
+    }
+}


### PR DESCRIPTION
Closes #793.

A live activity draws into the strip of menu bar beside the notch. That is the same strip the frontmost app's menus occupy, so a running timer sits on top of them — the Help menu especially, being the one nearest the notch. The reporter's screenshots show exactly that, and there was no way out short of turning live activities off in settings and back on again, which they rightly point out is too many steps to click one button.

They asked for a gesture to hide the HUD. This does it without them having to do anything.

### There is no way to reserve the space

Worth writing down, because it is the obvious first idea and it does not work. macOS lays app menus out inside `NSScreen.auxiliaryTopLeftArea`, and status items inside `auxiliaryTopRightArea`. On a 14" MacBook Pro those read:

```
auxiliaryTopLeftArea :  (0.0, 1073.5, 762.5, 33.5)
auxiliaryTopRightArea: (947.5, 1073.5, 762.5, 33.5)
=> notch x-range: 762.5 … 947.5  (185pt wide)
```

Both are get-only, and `safeAreaInsets` is derived from the display hardware. There is no setter, no entitlement, and no `NSApplication` option that widens the notch as far as menu bar layout is concerned. `NSStatusItem` is the only supported way to reserve menu bar room and it reserves on the *right*, which is the wrong side of this problem.

### So measure instead of reserving

The accessibility API reports each menu's own position and size, which gives the exact edge to clear:

```
Apple  x=  10.0  right=  44.0
...
Window x= 488.0  right= 558.0
Help   x= 557.0  right= 606.0
=> app menus end at x = 606.0
```

`MenuBarLayout` tracks that edge, and the closed-notch content slides right by however much it overlaps, plus a small gap. What that works out to in practice, for a few activity widths:

| menus end at | w=250 | w=300 | w=360 | w=420 | w=500 |
|---|---|---|---|---|---|
| 606 (Zen) | 0 | 0 | 0 | 0 | 9 |
| 700 | 0 | 3 | 33 | 63 | 103 |
| 740 | 18 | 43 | 73 | 103 | 143 |

Which is the shape you want: an app with few menus never moves the notch at all, and the shift grows only as far as the collision actually demands. It returns to centre as soon as the frontmost app allows, so the notch is off-centre only while something would otherwise be hidden.

### Care taken

- **The shift is capped at the room remaining on the right.** A shift that pushed the activity off the far edge would trade one covered thing for another.
- **The measurement runs off the main actor, with `AXUIElementSetMessagingTimeout`.** It is a cross-process call, and an app that has stopped answering must not take the notch's UI down with it. This is an optimisation, never something worth waiting on.
- **A missing accessibility permission means no constraint, not a broken HUD.** Same for an app that exposes no menu bar, or one that does not answer in time — all read as "nothing known", and the notch stays centred exactly as it does today.
- **Tracking is reference-counted** so several displays can ask at once, and it only runs while the notch is closed. An open notch covers the menu bar wholesale and is the user's own doing, so there is nothing to step around.
- The offset is only ever an `.offset`, so it never changes the measured width — no layout feedback.

### Testing

The arithmetic is pulled out into `MenuBarLayout.clearanceOffset(contentWidth:screenFrame:menusRightEdge:gap:)` and covered by 9 tests: short menus leaving the notch centred, menus reaching the content, the gap alone being enough to move, a wider activity being covered sooner, the shift being capped at the screen edge, content filling the screen, zero width, and an external display whose frame does not start at x=0 — the arithmetic is in global coordinates, and a second display must not be treated as if it were the first.

134/134 pass. Verified the accessibility read against a live menu bar (the figures above are real output, not invented).

What I have **not** been able to verify is the reporter's own case, since it needs a menu-heavy app in a language where the menus run long enough to reach the notch. The geometry says it will, but someone who can reproduce #793 confirming it would be worth having.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added support for M5 CPU temperature sensors.
  * Live activities now automatically move clear of frontmost app menu bar items beside the notch.
  * Activities smoothly return to their normal position when space is available.
  * Improved behavior across built-in and external displays.
  * Pointer activation areas remain aligned when activities shift.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->