### PR TITLE
Support content-only extension tabs and scoped scroll suppression

### DIFF
--- a/DynamicIsland/components/Extensions/ExtensionLiveActivityViews.swift
+++ b/DynamicIsland/components/Extensions/ExtensionLiveActivityViews.swift
@@ -183,6 +183,9 @@ private func logExtensionDiagnostics(_ message: String) {
 struct ExtensionNotchExperienceTabView: View {
     let payload: ExtensionNotchExperiencePayload
 
+    @EnvironmentObject private var vm: DynamicIslandViewModel
+    @State private var suppressionToken = UUID()
+
     @Default(.enableExtensionNotchInteractiveWebViews) private var interactiveWebViewsEnabled
 
     private var descriptor: AtollNotchExperienceDescriptor { payload.descriptor }
@@ -195,32 +198,18 @@ struct ExtensionNotchExperienceTabView: View {
     var body: some View {
         Group {
             if let tabConfiguration {
-                ScrollView(.vertical, showsIndicators: false) {
-                    VStack(alignment: .leading, spacing: 18) {
-                        header(for: tabConfiguration)
-                        ForEach(Array(tabConfiguration.sections.enumerated()), id: \.offset) { index, section in
-                            ExtensionNotchSectionView(
-                                section: section,
-                                accent: accentColor,
-                                allowWebInteraction: allowInteractiveWebViews
-                            )
-                            .accessibilityIdentifier("extension-notch-section-\(payload.descriptor.id)-\(index)")
+                if tabConfiguration.contentLayout == .contentOnly {
+                    contentStack(for: tabConfiguration, spacing: 0, clipsWebContent: false)
+                        .frame(maxHeight: .infinity, alignment: .topLeading)
+                } else {
+                    ScrollView(.vertical, showsIndicators: false) {
+                        VStack(alignment: .leading, spacing: 18) {
+                            header(for: tabConfiguration)
+                            contentStack(for: tabConfiguration, spacing: 18, clipsWebContent: true)
                         }
-                        if let webDescriptor = tabConfiguration.webContent {
-                            ExtensionWebContentView(descriptor: webDescriptor, allowInteraction: allowInteractiveWebViews)
-                                .frame(height: webDescriptor.preferredHeight)
-                                .frame(maxWidth: webDescriptor.maximumContentWidth ?? .infinity)
-                                .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
-                        }
-                        if let footnote = tabConfiguration.footnote {
-                            Text(footnote)
-                                .font(.system(size: 11, weight: .regular))
-                                .foregroundStyle(Color.white.opacity(0.65))
-                                .lineLimit(2)
-                        }
+                        .padding(.vertical, 14)
+                        .padding(.horizontal, 16)
                     }
-                    .padding(.vertical, 14)
-                    .padding(.horizontal, 16)
                 }
             } else {
                 Text("Extension tab unavailable")
@@ -232,6 +221,60 @@ struct ExtensionNotchExperienceTabView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(tabBackground)
         .clipShape(RoundedRectangle(cornerRadius: 22, style: .continuous))
+        .onHover { hovering in
+            vm.setScrollGestureSuppression(hovering, token: suppressionToken)
+        }
+        .onDisappear {
+            vm.setScrollGestureSuppression(false, token: suppressionToken)
+        }
+        .onChange(of: vm.notchState) { _, state in
+            if state == .closed {
+                vm.setScrollGestureSuppression(false, token: suppressionToken)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func contentStack(
+        for configuration: AtollNotchExperienceDescriptor.TabConfiguration,
+        spacing: CGFloat,
+        clipsWebContent: Bool
+    ) -> some View {
+        VStack(alignment: .leading, spacing: spacing) {
+            ForEach(Array(configuration.sections.enumerated()), id: \.offset) { index, section in
+                ExtensionNotchSectionView(
+                    section: section,
+                    accent: accentColor,
+                    allowWebInteraction: allowInteractiveWebViews
+                )
+                .accessibilityIdentifier("extension-notch-section-\(payload.descriptor.id)-\(index)")
+            }
+            if let webDescriptor = configuration.webContent {
+                Group {
+                    if clipsWebContent {
+                        ExtensionWebContentView(
+                            descriptor: webDescriptor,
+                            allowInteraction: allowInteractiveWebViews
+                        )
+                        .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+                    } else {
+                        ExtensionWebContentView(
+                            descriptor: webDescriptor,
+                            allowInteraction: allowInteractiveWebViews
+                        )
+                    }
+                }
+                .frame(height: webDescriptor.preferredHeight)
+                .frame(maxWidth: webDescriptor.maximumContentWidth ?? .infinity)
+            }
+            if let footnote = configuration.footnote {
+                Text(footnote)
+                    .font(.system(size: 11, weight: .regular))
+                    .foregroundStyle(Color.white.opacity(0.65))
+                    .lineLimit(2)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 
     @ViewBuilder

--- a/docs/extension-content-layout.md
+++ b/docs/extension-content-layout.md
@@ -1,0 +1,34 @@
+# Extension content layout and scrolling
+
+This proposal depends on the optional `TabConfiguration.contentLayout` API in
+AtollExtensionKit (branch `tibetgao:feature/notch-content-layout`). Update the
+resolved SDK revision after that API merges; the production dependency must
+continue to point to the official SDK.
+
+An absent layout or `.standard` preserves the native title, icon, padding and
+outer scroll view. `.contentOnly` removes that wrapper and lets the extension
+own its scrollable content. Tab selector branding, permissions, height limits
+and outer rounded clipping remain in place. Neither path changes closed-notch
+sizing or physical screen safe areas.
+
+Both layouts acquire a scroll-suppression token while the pointer is inside the
+extension content, matching Terminal. Tokens are released on pointer exit,
+view disappearance and notch close. Layout choice is not used as a gesture
+permission, and no process-wide preference is changed.
+
+## Manual acceptance checks
+
+- Present an existing descriptor without `contentLayout`: header and padding
+  must match the unmodified host.
+- Present a `.contentOnly` dashboard: no duplicate title or wrapper padding;
+  selector title/icon remain visible.
+- Scroll a long standard section and a web-backed content-only dashboard:
+  content scrolls without the outer blur/close animation, including at edges.
+- Move outside the content, switch to Home and verify close gestures resume.
+- Close/reopen the notch, switch extension tabs, dismiss an extension and revoke
+  web interaction; verify no stale suppression remains and permissions hold.
+- Check built-in and external displays with a long title and large preferred
+  height; physical notch exclusion and host height limits must not change.
+
+SDK compatibility tests are provided in the companion SDK PR. Full host build
+and visual acceptance remain required before this dependent PR is merge-ready.


### PR DESCRIPTION
Self-contained extension dashboards currently receive a duplicate native title header, and scrolling their content also drives the outer notch close/blur gesture.

This change honors optional `contentLayout: .contentOnly` while preserving legacy header/padding when absent. It reuses Terminal's `setScrollGestureSuppression` token API on hover for extension content, releasing the token on pointer exit, disappearance and notch close. Gesture handling is independent of layout mode; no global preferences or closed-notch geometry are changed.

Depends on https://github.com/Ebullioscopic/AtollExtensionKit/pull/18. The official SDK dependency is intentionally retained; its resolved revision must be updated after the SDK API merges.

Validation: Swift frontend syntax parse and git diff checks passed. SDK compatibility tests passed (5 tests). Full host build and visual acceptance are NOT yet complete; this is a dependent draft, not merge-ready. The manual regression checklist is included in docs/extension-content-layout.md. UI screenshots/recording will be added after the dependent build is verified.

Targeting main according to CONTRIBUTING.md; happy to retarget to dev if preferred.